### PR TITLE
feat: Windows 兼容内置 PortableGit + Python + Node

### DIFF
--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -10,6 +10,7 @@ import logging
 import os
 import platform
 import re
+import sys
 import time
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -18,6 +19,7 @@ from pydantic import Field, model_validator
 
 from .base import Tool, ToolResult
 from .pptx_safety import detect_pptx_self_check_bypass
+from .runtime import bundled_win_bash
 from .safety import (
     ask_user_confirmation,
     backup_file,
@@ -282,6 +284,47 @@ class BashTool(Tool):
         """
         self.is_windows = platform.system() == "Windows"
         self.shell_name = "PowerShell" if self.is_windows else "bash"
+        # Win-only: prefer the PortableGit ``bash.exe`` shipped inside the
+        # frozen runtime when available so the LLM can use bash syntax + the
+        # unix coreutils that the skills assume. Falls back to PowerShell
+        # when the bundle is absent (dev installs / older runtimes).
+        # Mac/Linux behavior unchanged.
+        self._bundled_win_bash: str | None = None
+        self._bundled_win_path_dirs: list[str] = []
+        if self.is_windows:
+            bundled = bundled_win_bash()
+            if bundled is not None:
+                self._bundled_win_bash = str(bundled)
+                self.shell_name = "bash"
+                # bash.exe lives at <PortableGit>/usr/bin/bash.exe. We launch
+                # bash without ``--login`` to avoid MSYS profile slow-start,
+                # which means /etc/profile never runs and coreutils dirs are
+                # absent from PATH. Prepend the three PortableGit search dirs
+                # explicitly so the LLM's `find`/`grep`/`sed`/`git` resolve.
+                portable_git_root = bundled.parent.parent.parent
+                self._bundled_win_path_dirs = [
+                    str(portable_git_root / "usr" / "bin"),
+                    str(portable_git_root / "mingw64" / "bin"),
+                    str(portable_git_root / "cmd"),
+                ]
+                # Some Electron launchers (and the restart-electron-foreground
+                # PowerShell helper) strip the Win system dirs from the env
+                # they hand to box-agent-acp, which leaves `powershell.exe`,
+                # `cmd.exe`, `where`, etc. unreachable from the LLM's bash.
+                # Append them defensively after the PortableGit dirs so the
+                # bundled coreutils still take precedence.
+                sys_root = os.environ.get("SystemRoot") or r"C:\Windows"
+                self._bundled_win_path_dirs.extend([
+                    os.path.join(sys_root, "system32"),
+                    sys_root,
+                    os.path.join(sys_root, "system32", "Wbem"),
+                    os.path.join(sys_root, "system32", "WindowsPowerShell", "v1.0"),
+                ])
+            log.info(
+                "bash_tool/init shell=%s bundled_bash=%s frozen=%s path_dirs=%s",
+                self.shell_name, self._bundled_win_bash,
+                getattr(sys, "frozen", False), self._bundled_win_path_dirs,
+            )
         # Unix: resolve login shell so subprocess inherits user's PATH.
         # Only trust known POSIX-compatible shells; fall back to /bin/bash
         # for fish, csh, and other non-POSIX shells whose syntax is
@@ -318,8 +361,45 @@ class BashTool(Tool):
         """
         stderr = asyncio.subprocess.STDOUT if merge_stderr else asyncio.subprocess.PIPE
         if self.is_windows:
+            # Win-only: detach stdin so the child shell does not inherit the
+            # ACP stdin pipe (parent box-agent-acp has stdio piped to Electron).
+            # Without this, MSYS bash.exe / powershell.exe may keep the handle
+            # alive even after the command finishes, leading to hangs.
+            if self._bundled_win_bash is not None:
+                # Copy env so we can prepend PortableGit search dirs without
+                # mutating the cached ``_subprocess_env``. Fall back to the
+                # process env when no custom env was prepared.
+                spawn_env = (
+                    dict(self._subprocess_env)
+                    if self._subprocess_env is not None
+                    else os.environ.copy()
+                )
+                if self._bundled_win_path_dirs:
+                    existing_path = spawn_env.get("PATH", "")
+                    path_parts = list(self._bundled_win_path_dirs)
+                    if existing_path:
+                        path_parts.append(existing_path)
+                    spawn_env["PATH"] = os.pathsep.join(path_parts)
+                log.info(
+                    "bash/spawn shell=bundled_bash cmd=%r cwd=%s merge_stderr=%s path_head=%s",
+                    command[:500], self.workspace_dir, merge_stderr,
+                    spawn_env.get("PATH", "")[:200],
+                )
+                return await asyncio.create_subprocess_exec(
+                    self._bundled_win_bash, "-c", command,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=stderr,
+                    cwd=self.workspace_dir,
+                    env=spawn_env,
+                )
+            log.info(
+                "bash/spawn shell=powershell cmd=%r cwd=%s merge_stderr=%s",
+                command[:500], self.workspace_dir, merge_stderr,
+            )
             return await asyncio.create_subprocess_exec(
                 "powershell.exe", "-NoProfile", "-Command", command,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=stderr,
                 cwd=self.workspace_dir,
@@ -384,7 +464,12 @@ Examples:
   - npm test
   - python3 -m http.server 8080 (with run_in_background=true)""",
         }
-        return shell_examples["Windows"] if self.is_windows else shell_examples["Unix"]
+        # When the bundled Git-for-Windows bash is active on Win, the shell is
+        # POSIX bash with coreutils — use the Unix description so the LLM
+        # picks bash syntax (`&&`, `$()`, `grep`, `sed`) instead of PowerShell.
+        if self.is_windows and self._bundled_win_bash is None:
+            return shell_examples["Windows"]
+        return shell_examples["Unix"]
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -91,17 +91,20 @@ class SandboxEnvironment:
         self._ready = False
         self._bundled_override = False
 
-        # Dev/Windows override: point at an already-prepared interpreter
+        # Windows-only override: point at an already-prepared interpreter
         # (e.g. the bundled python.exe in officev3/build-resources) so we
         # skip venv creation and pip install entirely. Mirrors the
         # BOX_AGENT_BUNDLED_BASH / BOX_AGENT_NODE_RUNTIME_ROOT pattern.
-        override = os.environ.get("BOX_AGENT_BUNDLED_PYTHON")
-        if override:
-            override_path = Path(override)
-            if override_path.exists():
-                self.python_path = override_path
-                self._bundled_override = True
-                self._ready = True
+        # Gated to win32 so a stray env var on macOS/Linux cannot bypass
+        # the normal sandbox venv initialization.
+        if sys.platform == "win32":
+            override = os.environ.get("BOX_AGENT_BUNDLED_PYTHON")
+            if override:
+                override_path = Path(override)
+                if override_path.exists():
+                    self.python_path = override_path
+                    self._bundled_override = True
+                    self._ready = True
 
     @property
     def is_created(self) -> bool:

--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -8,6 +8,7 @@ environment, so user-installed packages don't pollute the tool's dependencies.
 
 import asyncio
 import json
+import os
 import platform
 import re
 import subprocess
@@ -82,8 +83,25 @@ class SandboxEnvironment:
     def __init__(self, base_dir: Path | None = None):
         self.base_dir = base_dir or SANDBOX_BASE_DIR
         self.venv_dir = self.base_dir / "venv"
-        self.python_path = self.venv_dir / "bin" / "python"
+        # Windows venv lays out python under Scripts/, Unix under bin/.
+        if sys.platform == "win32":
+            self.python_path = self.venv_dir / "Scripts" / "python.exe"
+        else:
+            self.python_path = self.venv_dir / "bin" / "python"
         self._ready = False
+        self._bundled_override = False
+
+        # Dev/Windows override: point at an already-prepared interpreter
+        # (e.g. the bundled python.exe in officev3/build-resources) so we
+        # skip venv creation and pip install entirely. Mirrors the
+        # BOX_AGENT_BUNDLED_BASH / BOX_AGENT_NODE_RUNTIME_ROOT pattern.
+        override = os.environ.get("BOX_AGENT_BUNDLED_PYTHON")
+        if override:
+            override_path = Path(override)
+            if override_path.exists():
+                self.python_path = override_path
+                self._bundled_override = True
+                self._ready = True
 
     @property
     def is_created(self) -> bool:
@@ -847,6 +865,12 @@ class JupyterSandboxTool(Tool):
         self, session_id: str, workspace: Path, env: SandboxEnvironment
     ) -> "JupyterKernelSession | InProcessKernelSession":
         """Create the appropriate kernel session for the current environment."""
+        # Windows compatibility: PyInstaller frozen Win exe's in-process
+        # ipykernel hangs (start_kernel never returns). When a bundled
+        # standalone python is available via BOX_AGENT_BUNDLED_PYTHON, route
+        # the kernel through a subprocess instead. macOS unaffected.
+        if sys.platform == "win32" and env._bundled_override:
+            return JupyterKernelSession(session_id, workspace, env)
         if IS_FROZEN:
             return InProcessKernelSession(session_id, workspace)
         return JupyterKernelSession(session_id, workspace, env)

--- a/box_agent/tools/runtime.py
+++ b/box_agent/tools/runtime.py
@@ -144,6 +144,21 @@ def _build_python_runtime(
         )
 
     if getattr(sys, "frozen", False):
+        # Win-only: a bundled portable Python is shipped under
+        # ``<runtime_root>/runtime/python/`` so shell skills (`$BOX_AGENT_PYTHON`)
+        # have a real interpreter. Mac/Linux frozen behavior unchanged.
+        if sys.platform == "win32":
+            bundled_python = bundled_win_python()
+            if bundled_python is not None:
+                path = str(bundled_python)
+                return SkillRuntime(
+                    kind="python",
+                    status="available",
+                    provider="box_agent",
+                    executable_path=path,
+                    env_vars={"BOX_AGENT_PYTHON": path, "BOX_AGENT_PYTHON3": path},
+                    notes=("Bundled Windows portable Python.",),
+                )
         return SkillRuntime(
             kind="python",
             status="unavailable",
@@ -261,6 +276,106 @@ class NodeRuntimeManager:
                 shutil.rmtree(temp_dir)
 
         missing = [name for name, path in (("node", node), ("npm", npm), ("npx", npx)) if not _is_executable_file(str(path))]
+        if missing:
+            raise NodeRuntimeInstallError(f"Installed Node runtime is incomplete: missing {', '.join(missing)}")
+
+        self._write_manifest(
+            version=version,
+            platform_id=target,
+            node=node,
+            npm=npm,
+            npx=npx,
+            node_modules=self.node_modules_dir,
+        )
+        return self.discover()
+
+    def install_win(
+        self,
+        *,
+        version: str = DEFAULT_NODE_VERSION,
+        platform_id: str | None = None,
+        downloader: Any | None = None,
+        base_url: str = NODE_DIST_BASE_URL,
+    ) -> SkillRuntime:
+        """Install the pinned official Node.js Windows runtime.
+
+        Mirrors :meth:`install_macos` but for ``win-x64``/``win-arm64``: pulls
+        the official Node ``.zip`` archive plus ``SHASUMS256.txt``, verifies
+        SHA-256, extracts into ``versions/``, then atomically writes
+        ``manifest.json``.
+        """
+        target = platform_id or _detect_node_win_platform()
+        if target not in {"win-x64", "win-arm64"}:
+            raise NodeRuntimeInstallError(f"Unsupported Windows Node platform: {target}")
+        if not version.startswith("v"):
+            raise NodeRuntimeInstallError("Node version must include the leading 'v'.")
+
+        archive_name = f"node-{version}-{target}.zip"
+        version_dir = self.versions_dir / archive_name.removesuffix(".zip")
+        node = version_dir / "node.exe"
+        npm = version_dir / "npm.cmd"
+        npx = version_dir / "npx.cmd"
+
+        if all(_path_exists(path) for path in (node, npm, npx)):
+            self._write_manifest(
+                version=version,
+                platform_id=target,
+                node=node,
+                npm=npm,
+                npx=npx,
+                node_modules=self.node_modules_dir,
+            )
+            return self.discover()
+
+        self.downloads_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = self.downloads_dir / archive_name
+        shasums_path = self.downloads_dir / f"SHASUMS256-{version}.txt"
+        version_url = f"{base_url.rstrip('/')}/{version}"
+        fetch = downloader or _download_url
+        fetch(f"{version_url}/{archive_name}", archive_path)
+        fetch(f"{version_url}/SHASUMS256.txt", shasums_path)
+
+        expected = _checksum_for_archive(shasums_path.read_text(encoding="utf-8"), archive_name)
+        actual = _sha256_file(archive_path)
+        if actual != expected:
+            raise NodeRuntimeInstallError(
+                f"Checksum mismatch for {archive_name}: expected {expected}, got {actual}"
+            )
+
+        temp_dir = self.versions_dir / f".{version_dir.name}.tmp"
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            _safe_extract_zip(archive_path, temp_dir)
+            extracted = temp_dir / version_dir.name
+            if not extracted.is_dir():
+                raise NodeRuntimeInstallError(f"Node archive did not contain {version_dir.name}")
+            if version_dir.exists():
+                shutil.rmtree(version_dir)
+            version_dir.parent.mkdir(parents=True, exist_ok=True)
+            # ``Path.rename`` is a raw MoveFileEx on Win and trips WinError 5
+            # if Defender / Search Indexer briefly holds a handle on the freshly
+            # extracted node.exe. ``shutil.move`` falls back to copy+delete and
+            # is more tolerant; retry once after a short pause as a final
+            # safety net.
+            try:
+                shutil.move(str(extracted), str(version_dir))
+            except PermissionError:
+                import time
+                time.sleep(2)
+                shutil.move(str(extracted), str(version_dir))
+        except Exception as exc:
+            if version_dir.exists() and not all(_path_exists(path) for path in (node, npm, npx)):
+                shutil.rmtree(version_dir)
+            if isinstance(exc, NodeRuntimeInstallError):
+                raise
+            raise NodeRuntimeInstallError(f"Failed to extract Node runtime archive: {exc}") from exc
+        finally:
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+
+        missing = [name for name, path in (("node.exe", node), ("npm.cmd", npm), ("npx.cmd", npx)) if not _path_exists(path)]
         if missing:
             raise NodeRuntimeInstallError(f"Installed Node runtime is incomplete: missing {', '.join(missing)}")
 
@@ -440,12 +555,67 @@ def _is_executable_file(path: str) -> bool:
 
 
 def _bundled_node_runtime_root() -> Path | None:
+    # Dev override: when ``BOX_AGENT_NODE_RUNTIME_ROOT`` is set and points at
+    # a directory containing ``manifest.json``, use it. Lets dev (non-frozen)
+    # runs reuse the Node runtime that the Electron host's
+    # managedNodeDependencies.ts already extracted under
+    # ``officev3/build-resources/box-agent-runtime/runtimes/node`` instead of
+    # requiring a separate PyInstaller bundle.
+    override = os.environ.get("BOX_AGENT_NODE_RUNTIME_ROOT")
+    if override:
+        override_path = Path(override)
+        if (override_path / "manifest.json").exists():
+            return override_path
     if not getattr(sys, "frozen", False):
         return None
     candidate = Path(sys.executable).resolve().parent.parent / "runtimes" / "node"
     if (candidate / "manifest.json").exists():
         return candidate
     return None
+
+
+def _bundled_runtime_root() -> Path | None:
+    """Return the PyInstaller frozen runtime root directory, or None if not frozen.
+
+    Layout assumed: ``<root>/bin/box-agent-acp(.exe)`` so root is the parent
+    of the directory containing ``sys.executable``. Win-only bundled tools
+    (PortableGit / portable Python) live under ``<root>/runtime/``.
+    """
+    if not getattr(sys, "frozen", False):
+        return None
+    return Path(sys.executable).resolve().parent.parent
+
+
+def bundled_win_bash() -> Path | None:
+    """Locate the Windows-bundled PortableGit ``bash.exe`` if present.
+
+    Dev override: when ``BOX_AGENT_BUNDLED_BASH`` is set and points at an
+    existing ``bash.exe``, use it. Lets dev (non-frozen) runs exercise the
+    bundled-bash code path without rebuilding the PyInstaller bundle.
+    """
+    if sys.platform != "win32":
+        return None
+    override = os.environ.get("BOX_AGENT_BUNDLED_BASH")
+    if override:
+        override_path = Path(override)
+        if override_path.is_file():
+            return override_path
+    root = _bundled_runtime_root()
+    if root is None:
+        return None
+    candidate = root / "runtime" / "PortableGit" / "usr" / "bin" / "bash.exe"
+    return candidate if candidate.is_file() else None
+
+
+def bundled_win_python() -> Path | None:
+    """Locate the Windows-bundled portable ``python.exe`` if present."""
+    if sys.platform != "win32":
+        return None
+    root = _bundled_runtime_root()
+    if root is None:
+        return None
+    candidate = root / "runtime" / "python" / "python.exe"
+    return candidate if candidate.is_file() else None
 
 
 def _is_bundled_node_runtime_root(root: Path) -> bool:
@@ -460,6 +630,21 @@ def _is_bundled_node_runtime_root(root: Path) -> bool:
 
 class NodeRuntimeInstallError(RuntimeError):
     """Node runtime installation failed without changing the active runtime."""
+
+
+def _detect_node_win_platform() -> str:
+    if sys.platform != "win32":
+        raise NodeRuntimeInstallError(f"Node Win install requires Windows, got {sys.platform}.")
+    machine = platform.machine().lower()
+    if machine in {"amd64", "x86_64"}:
+        return "win-x64"
+    if machine in {"arm64", "aarch64"}:
+        return "win-arm64"
+    raise NodeRuntimeInstallError(f"Unsupported Windows CPU architecture for Node runtime: {machine}")
+
+
+def _path_exists(path: Path) -> bool:
+    return path.is_file()
 
 
 def _detect_node_macos_platform() -> str:
@@ -517,3 +702,17 @@ def _safe_extract_tar(archive_path: Path, dest: Path) -> None:
                 except ValueError as exc:
                     raise NodeRuntimeInstallError(f"Unsafe link in Node archive: {member.name}") from exc
         tar.extractall(dest)
+
+
+def _safe_extract_zip(archive_path: Path, dest: Path) -> None:
+    import zipfile
+
+    dest_resolved = dest.resolve()
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        for member in zf.namelist():
+            target = (dest / member).resolve()
+            try:
+                target.relative_to(dest_resolved)
+            except ValueError as exc:
+                raise NodeRuntimeInstallError(f"Unsafe path in Node archive: {member}") from exc
+        zf.extractall(dest)

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import urllib.request
 from pathlib import Path
 
 # Make `python scripts/build_runtime.py` work from a source checkout even when
@@ -29,6 +30,25 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from box_agent.tools.runtime import DEFAULT_NODE_VERSION, NodeRuntimeManager
+
+# ── Win-only bundled tool versions ────────────────────────────
+# bash + coreutils. PortableGit ships as a 7-Zip self-extracting .exe.
+PORTABLE_GIT_VERSION = "2.46.0"
+PORTABLE_GIT_TAG = "v2.46.0.windows.1"
+PORTABLE_GIT_URL = (
+    f"https://github.com/git-for-windows/git/releases/download/"
+    f"{PORTABLE_GIT_TAG}/PortableGit-{PORTABLE_GIT_VERSION}-64-bit.7z.exe"
+)
+# Standalone CPython distribution with full stdlib + venv + ensurepip.
+# install_only build is what we need.
+PYTHON_STANDALONE_VERSION = "3.12.6"
+PYTHON_STANDALONE_RELEASE = "20240909"
+PYTHON_STANDALONE_URL = (
+    f"https://github.com/indygreg/python-build-standalone/releases/download/"
+    f"{PYTHON_STANDALONE_RELEASE}/cpython-{PYTHON_STANDALONE_VERSION}+"
+    f"{PYTHON_STANDALONE_RELEASE}-x86_64-pc-windows-msvc-install_only.tar.gz"
+)
+BUILD_TOOLS_CACHE = Path.home() / ".cache" / "box-agent-build-tools"
 
 # ── Platform detection ───────────────────────────────────────
 
@@ -262,6 +282,8 @@ def build_runtime(version: str, output_dir: Path) -> Path:
 
     if plat == "darwin" and arch in {"arm64", "x64"}:
         _install_bundled_node_runtime(runtime_dir, plat=plat, arch=arch)
+    elif plat == "win32" and arch == "x64":
+        _install_bundled_win_runtimes(runtime_dir)
     else:
         print(f"\nSkipping bundled Node runtime for unsupported platform: {plat}-{arch}")
 
@@ -299,6 +321,196 @@ def _install_bundled_node_runtime(runtime_dir: Path, *, plat: str, arch: str) ->
     shutil.rmtree(node_root / "downloads", ignore_errors=True)
     _relativize_node_manifest(node_root)
     print(f"Bundled Node runtime: {node_root}")
+
+
+def _install_bundled_win_runtimes(runtime_dir: Path) -> None:
+    """Bundle PortableGit (bash/coreutils) + standalone Python + Node into the Win runtime.
+
+    box-agent on Windows can't rely on system bash/python/node — Mac users have
+    them by default, Win users almost never. This drops self-contained copies
+    into the runtime tar so the artifact is install-and-go.
+    """
+    print("\n[win] Installing bundled PortableGit + Python + Node runtimes...")
+    BUILD_TOOLS_CACHE.mkdir(parents=True, exist_ok=True)
+
+    _install_portable_git_win(runtime_dir)
+    _install_portable_python_win(runtime_dir)
+
+    node_root = runtime_dir / "runtimes" / "node"
+    print(f"\n[win] Installing bundled Node.js runtime {DEFAULT_NODE_VERSION} for win-x64...")
+    manager = NodeRuntimeManager(root=node_root)
+    manager.install_win(version=DEFAULT_NODE_VERSION, platform_id="win-x64")
+    shutil.rmtree(node_root / "downloads", ignore_errors=True)
+    _relativize_node_manifest(node_root)
+    print(f"[win] Bundled Node runtime: {node_root}")
+
+
+def _install_portable_git_win(runtime_dir: Path) -> None:
+    """Download and extract PortableGit 7-Zip SFX into ``runtime/PortableGit/``."""
+    target = runtime_dir / "runtime" / "PortableGit"
+    bash_exe = target / "usr" / "bin" / "bash.exe"
+    if bash_exe.is_file():
+        print(f"[win] PortableGit already present: {target}")
+        return
+
+    override = os.environ.get("BOX_AGENT_BUILD_PORTABLE_GIT")
+    if override:
+        archive = Path(override)
+        if not archive.is_file():
+            raise RuntimeError(f"BOX_AGENT_BUILD_PORTABLE_GIT not found: {archive}")
+        print(f"[win] Using PortableGit override: {archive}")
+    else:
+        archive = BUILD_TOOLS_CACHE / f"PortableGit-{PORTABLE_GIT_VERSION}-64-bit.7z.exe"
+        if not archive.is_file():
+            print(f"[win] Downloading PortableGit -> {archive}")
+            _download_to(PORTABLE_GIT_URL, archive)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
+
+    # PortableGit-*.7z.exe is a 7-Zip self-extracting archive. The supported
+    # extraction flags are: -y (assume yes), -o<dir> (output directory).
+    print(f"[win] Extracting PortableGit -> {target}")
+    result = subprocess.run(
+        [str(archive), "-y", f"-o{target}"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"PortableGit extraction failed (exit {result.returncode}): "
+            f"{result.stderr.decode(errors='replace')[:500]}"
+        )
+
+    if not bash_exe.is_file():
+        raise RuntimeError(f"PortableGit extracted but bash.exe missing: {bash_exe}")
+    print(f"[win] PortableGit ready: {bash_exe}")
+
+
+def _install_portable_python_win(runtime_dir: Path) -> None:
+    """Download and extract python-build-standalone install_only into ``runtime/python/``."""
+    target = runtime_dir / "runtime" / "python"
+    python_exe = target / "python.exe"
+    if python_exe.is_file():
+        print(f"[win] Portable Python already present: {target}")
+        return
+
+    override = os.environ.get("BOX_AGENT_BUILD_PORTABLE_PYTHON")
+    if override:
+        archive = Path(override)
+        if not archive.is_file():
+            raise RuntimeError(f"BOX_AGENT_BUILD_PORTABLE_PYTHON not found: {archive}")
+        print(f"[win] Using portable Python override: {archive}")
+    else:
+        archive = (
+            BUILD_TOOLS_CACHE
+            / f"cpython-{PYTHON_STANDALONE_VERSION}-{PYTHON_STANDALONE_RELEASE}-win-x64-install_only.tar.gz"
+        )
+        if not archive.is_file():
+            print(f"[win] Downloading python-build-standalone -> {archive}")
+            _download_to(PYTHON_STANDALONE_URL, archive)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        shutil.rmtree(target)
+
+    # install_only tar.gz layout: ``python/python.exe + python/Lib/...``.
+    print(f"[win] Extracting portable Python -> {target}")
+    extract_root = target.parent / ".python-extract"
+    if extract_root.exists():
+        shutil.rmtree(extract_root)
+    extract_root.mkdir(parents=True)
+    try:
+        with tarfile.open(archive, "r:gz") as tar:
+            tar.extractall(extract_root)
+        inner = extract_root / "python"
+        if not inner.is_dir():
+            raise RuntimeError(f"Portable Python archive missing 'python/' dir: {archive}")
+        # Win: ``Path.rename`` (MoveFileEx) trips ``WinError 5`` when
+        # Defender/Search Indexer briefly holds the freshly extracted
+        # ``python.exe``. ``shutil.move`` falls back to copy+delete and is
+        # more tolerant; retry once after a short pause as final safety net.
+        try:
+            shutil.move(str(inner), str(target))
+        except PermissionError:
+            import time
+            time.sleep(2)
+            shutil.move(str(inner), str(target))
+    finally:
+        if extract_root.exists():
+            shutil.rmtree(extract_root, ignore_errors=True)
+
+    if not python_exe.is_file():
+        raise RuntimeError(f"Portable Python extracted but python.exe missing: {python_exe}")
+    print(f"[win] Portable Python ready: {python_exe}")
+
+    _install_sandbox_packages_win(python_exe)
+
+
+# Pre-installed into the bundled Python's site-packages so that the frozen
+# Win build's ``execute_code`` (InProcessKernelSession) can ``import pandas``
+# etc. without spawning pip at first run. Mirrors
+# ``box_agent.tools.jupyter_tool.SANDBOX_DEFAULT_PACKAGES`` + ``ipykernel``.
+_SANDBOX_BUNDLED_PACKAGES = (
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "openpyxl",
+    "scikit-learn",
+    "ipykernel",
+)
+
+
+def _install_sandbox_packages_win(python_exe: Path) -> None:
+    """Pre-install sandbox data-science packages into the bundled portable Python."""
+    print(f"\n[win] Pre-installing sandbox packages into bundled Python: {', '.join(_SANDBOX_BUNDLED_PACKAGES)}")
+    print(f"[win] (this can take several minutes the first time)")
+    # Strip parent-process venv markers so the bundled python doesn't try to
+    # load pip/site-packages from the build venv (.venv-build / uv cpython)
+    # — those copies are ABI-incompatible with python-build-standalone and
+    # trip ``AttributeError: class must define a '_type_' attribute`` in
+    # ctypes when imported.
+    clean_env = {
+        k: v for k, v in os.environ.items()
+        if k not in {
+            "PYTHONPATH",
+            "PYTHONHOME",
+            "VIRTUAL_ENV",
+            "__PYVENV_LAUNCHER__",
+            "PYTHONNOUSERSITE",
+            "PYTHONUSERBASE",
+        }
+    }
+    clean_env["PYTHONNOUSERSITE"] = "1"
+    result = subprocess.run(
+        [
+            str(python_exe), "-I", "-m", "pip", "install",
+            "--no-warn-script-location",
+            "--disable-pip-version-check",
+            *_SANDBOX_BUNDLED_PACKAGES,
+        ],
+        capture_output=True,
+        env=clean_env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Pre-install of sandbox packages failed (exit {result.returncode}): "
+            f"{result.stderr.decode(errors='replace')[:1000]}"
+        )
+    print("[win] Sandbox packages ready in bundled Python.")
+
+
+def _download_to(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    try:
+        with urllib.request.urlopen(url, timeout=300) as response, tmp.open("wb") as f:
+            shutil.copyfileobj(response, f)
+        os.replace(tmp, dest)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
 
 
 def _relativize_node_manifest(node_root: Path) -> None:

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -14,6 +14,7 @@ Requires:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -39,6 +40,11 @@ PORTABLE_GIT_URL = (
     f"https://github.com/git-for-windows/git/releases/download/"
     f"{PORTABLE_GIT_TAG}/PortableGit-{PORTABLE_GIT_VERSION}-64-bit.7z.exe"
 )
+# Pinned SHA-256 of the upstream PortableGit self-extractor. Mismatch implies
+# CDN tampering / MITM proxy / cache corruption; refuse to execute the .exe.
+# Source: https://github.com/git-for-windows/git/releases/tag/v2.46.0.windows.1
+PORTABLE_GIT_SHA256 = "dedae83f4d0851bcbf473c516701e2da6a5d7c574d694d5eceec46d1307132ea"
+
 # Standalone CPython distribution with full stdlib + venv + ensurepip.
 # install_only build is what we need.
 PYTHON_STANDALONE_VERSION = "3.12.6"
@@ -47,6 +53,12 @@ PYTHON_STANDALONE_URL = (
     f"https://github.com/indygreg/python-build-standalone/releases/download/"
     f"{PYTHON_STANDALONE_RELEASE}/cpython-{PYTHON_STANDALONE_VERSION}+"
     f"{PYTHON_STANDALONE_RELEASE}-x86_64-pc-windows-msvc-install_only.tar.gz"
+)
+# Pinned SHA-256 of the upstream python-build-standalone archive. Source:
+# https://github.com/astral-sh/python-build-standalone/releases/download/
+#   20240909/cpython-3.12.6+20240909-x86_64-pc-windows-msvc-install_only.tar.gz.sha256
+PYTHON_STANDALONE_SHA256 = (
+    "6280ce84c87ebaca2c4b42040bad48e7efbfd1b3f323579378ecf043e9fb023d"
 )
 BUILD_TOOLS_CACHE = Path.home() / ".cache" / "box-agent-build-tools"
 
@@ -365,6 +377,12 @@ def _install_portable_git_win(runtime_dir: Path) -> None:
             print(f"[win] Downloading PortableGit -> {archive}")
             _download_to(PORTABLE_GIT_URL, archive)
 
+    # PortableGit is a self-extracting .exe — about to be executed below.
+    # Verify SHA-256 before invoking the binary, otherwise a tampered
+    # download / poisoned cache entry would execute arbitrary code on the
+    # build host.
+    _verify_sha256(archive, PORTABLE_GIT_SHA256, label="PortableGit")
+
     target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists():
         shutil.rmtree(target)
@@ -410,6 +428,11 @@ def _install_portable_python_win(runtime_dir: Path) -> None:
         if not archive.is_file():
             print(f"[win] Downloading python-build-standalone -> {archive}")
             _download_to(PYTHON_STANDALONE_URL, archive)
+
+    # The extracted interpreter is invoked later to pre-install sandbox
+    # packages, so a tampered archive becomes code execution on the build
+    # host. Verify the pinned SHA-256 before touching the contents.
+    _verify_sha256(archive, PYTHON_STANDALONE_SHA256, label="python-build-standalone")
 
     target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists():
@@ -511,6 +534,28 @@ def _download_to(url: str, dest: Path) -> None:
     finally:
         if tmp.exists():
             tmp.unlink()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_sha256(archive: Path, expected: str, *, label: str) -> None:
+    """Abort the build if ``archive`` does not match the pinned SHA-256.
+
+    Guards against CDN tampering / MITM proxies / corrupted cache entries.
+    Matches the integrity check already done on the Node download path.
+    """
+    actual = _sha256_file(archive)
+    if actual.lower() != expected.lower():
+        raise RuntimeError(
+            f"{label} SHA-256 mismatch for {archive}: "
+            f"expected {expected}, got {actual}"
+        )
 
 
 def _relativize_node_manifest(node_root: Path) -> None:

--- a/scripts/build_win_runtime.py
+++ b/scripts/build_win_runtime.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Windows-only BoxAgent runtime builder with two stages.
+
+Stages:
+    bin/              ← PyInstaller-frozen BoxAgent (changes when source changes)
+    runtime/          ← PortableGit (bash) + python-build-standalone (python)
+    runtimes/         ← Node
+
+`--exe-only` rebuilds **bin/ only**, leaving runtime/ and runtimes/ untouched.
+Use this when you change BoxAgent Python source but don't touch bash/node/python.
+
+Usage:
+    # Full build (PyInstaller + bash + python + node + tar.gz)
+    python scripts/build_win_runtime.py --version 0.8.40
+
+    # Rebuild only the BoxAgent exe; keep existing runtime/ and runtimes/
+    python scripts/build_win_runtime.py --version 0.8.40 --exe-only
+
+    # Drop new bin/ straight onto the dev install (no tar)
+    python scripts/build_win_runtime.py --exe-only --no-tar \\
+        --install-to D:\\qilin2\\officev3\\build-resources\\box-agent-runtime
+
+Output (default):
+    dist/runtime/box-agent-runtime/                 (assembled tree)
+    dist/runtime/box-agent-runtime-v{ver}-win32-x64.tar.gz
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# Reuse existing helpers from build_runtime.py so we don't drift.
+from scripts.build_runtime import (  # type: ignore
+    BUILD_TOOLS_CACHE,
+    PYTHON_STANDALONE_VERSION,
+    _install_portable_git_win,
+    _install_portable_python_win,
+    _install_sandbox_packages_win,
+    _relativize_node_manifest,
+)
+from box_agent.tools.runtime import DEFAULT_NODE_VERSION, NodeRuntimeManager
+
+
+def _read_version_from_package() -> str:
+    """Pull version from box_agent/__init__.py or pyproject — fallback to 'dev'."""
+    init_file = PROJECT_ROOT / "box_agent" / "__init__.py"
+    if init_file.is_file():
+        for line in init_file.read_text(encoding="utf-8").splitlines():
+            if line.strip().startswith("__version__"):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return "dev"
+
+
+def _ensure_win() -> None:
+    if sys.platform != "win32":
+        print(f"This script only runs on Windows (got: {sys.platform})", file=sys.stderr)
+        sys.exit(2)
+
+
+def _run_pyinstaller(bin_dir: Path) -> None:
+    """Run PyInstaller and copy the output into ``bin_dir``."""
+    print("\n[win] Installing runtime extras...")
+    extras_cmd_pip = [sys.executable, "-m", "pip", "install", "--quiet",
+                      f"{PROJECT_ROOT}[runtime]"]
+    uv_bin = shutil.which("uv")
+    if uv_bin:
+        extras = subprocess.run(
+            [uv_bin, "pip", "install", "--quiet", f"{PROJECT_ROOT}[runtime]"],
+            cwd=str(PROJECT_ROOT),
+        )
+        if extras.returncode != 0:
+            subprocess.run(extras_cmd_pip, cwd=str(PROJECT_ROOT))
+    else:
+        subprocess.run(extras_cmd_pip, cwd=str(PROJECT_ROOT))
+
+    work_dir = bin_dir.parent.parent / "pyinstaller_work"
+    dist_dir = bin_dir.parent.parent / "pyinstaller_out"
+    spec_dir = bin_dir.parent.parent
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+
+    entry_point = PROJECT_ROOT / "box_agent" / "acp" / "runtime_entry.py"
+
+    datas = [
+        (str(PROJECT_ROOT / "box_agent" / "config"), "box_agent/config"),
+        (str(PROJECT_ROOT / "box_agent" / "skills"), "box_agent/skills"),
+    ]
+    datas_args: list[str] = []
+    for src, dst in datas:
+        if Path(src).exists():
+            datas_args.extend(["--add-data", f"{src}{os.pathsep}{dst}"])
+
+    hidden_imports = [
+        "box_agent", "box_agent.acp", "box_agent.acp.debug_logger",
+        "box_agent.agent", "box_agent.cli", "box_agent.config", "box_agent.core",
+        "box_agent.events", "box_agent.llm", "box_agent.llm.anthropic_client",
+        "box_agent.llm.openai_client", "box_agent.llm.llm_wrapper",
+        "box_agent.logger", "box_agent.retry", "box_agent.schema",
+        "box_agent.tools", "box_agent.tools.bash_tool", "box_agent.tools.file_tools",
+        "box_agent.tools.jupyter_tool", "box_agent.tools.mcp_loader",
+        "box_agent.tools.skill_tool", "box_agent.utils",
+        "tiktoken", "tiktoken_ext", "tiktoken_ext.openai_public",
+        "httpx", "httpcore", "anthropic", "openai", "pydantic", "yaml", "mcp", "acp",
+        "jupyter_client", "jupyter_client.provisioning",
+        "jupyter_client.provisioning.local_provisioner",
+        "ipykernel", "ipykernel.inprocess", "ipykernel.inprocess.manager",
+        "ipykernel_launcher", "jupyter_core",
+        "debugpy", "debugpy._vendored",
+        "pandas", "numpy", "matplotlib", "matplotlib.backends",
+        "matplotlib.backends.backend_agg",
+        "seaborn", "openpyxl", "xlrd", "sklearn", "sklearn.cluster",
+        "sklearn.linear_model", "sklearn.preprocessing",
+        "docx", "pypdf", "pdfplumber", "reportlab",
+        "reportlab.pdfgen", "reportlab.lib", "pptx",
+        "pip", "pip._internal", "pip._internal.cli", "pip._internal.cli.main",
+    ]
+    hidden_args: list[str] = []
+    for imp in hidden_imports:
+        hidden_args.extend(["--hidden-import", imp])
+
+    cmd = [
+        sys.executable, "-m", "PyInstaller",
+        "--noconfirm", "--clean",
+        "--name", "box-agent-acp",
+        "--distpath", str(dist_dir),
+        "--workpath", str(work_dir),
+        "--specpath", str(spec_dir),
+        *datas_args, *hidden_args,
+        "--collect-all", "tiktoken",
+        "--collect-all", "tiktoken_ext",
+        "--collect-all", "jupyter_client",
+        "--collect-all", "ipykernel",
+        "--collect-all", "jupyter_core",
+        "--collect-all", "debugpy",
+        "--collect-all", "matplotlib",
+        "--collect-submodules", "pandas",
+        "--collect-submodules", "seaborn",
+        "--collect-submodules", "openpyxl",
+        "--collect-submodules", "sklearn",
+        "--collect-submodules", "pip",
+        str(entry_point),
+    ]
+
+    print("\n[win] Running PyInstaller...")
+    result = subprocess.run(cmd, cwd=str(PROJECT_ROOT))
+    if result.returncode != 0:
+        print("PyInstaller failed!", file=sys.stderr)
+        sys.exit(1)
+
+    pyinstaller_output = dist_dir / "box-agent-acp"
+    if not pyinstaller_output.exists():
+        print(f"Expected output not found: {pyinstaller_output}", file=sys.stderr)
+        sys.exit(1)
+
+    if bin_dir.exists():
+        shutil.rmtree(bin_dir)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for item in pyinstaller_output.iterdir():
+        dest = bin_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest)
+        else:
+            shutil.copy2(item, dest)
+
+    entry_bin = bin_dir / "box-agent-acp.exe"
+    if entry_bin.exists():
+        entry_bin.chmod(0o755)
+
+    shutil.rmtree(dist_dir, ignore_errors=True)
+    shutil.rmtree(work_dir, ignore_errors=True)
+    for spec in spec_dir.glob("*.spec"):
+        spec.unlink(missing_ok=True)
+
+    print(f"[win] BoxAgent exe -> {bin_dir}")
+
+
+def _install_node_win(runtime_dir: Path) -> None:
+    node_root = runtime_dir / "runtimes" / "node"
+    if (node_root / "versions").exists() and any((node_root / "versions").iterdir()):
+        print(f"[win] Node runtime already present: {node_root}")
+        return
+    print(f"\n[win] Installing bundled Node.js {DEFAULT_NODE_VERSION} for win-x64...")
+    manager = NodeRuntimeManager(root=node_root)
+    manager.install_win(version=DEFAULT_NODE_VERSION, platform_id="win-x64")
+    shutil.rmtree(node_root / "downloads", ignore_errors=True)
+    _relativize_node_manifest(node_root)
+    print(f"[win] Node runtime ready: {node_root}")
+
+
+def _write_manifest(runtime_dir: Path, version: str) -> None:
+    manifest = {
+        "name": "box-agent",
+        "version": version,
+        "platform": "win32",
+        "arch": "x64",
+        "entry": "bin/box-agent-acp.exe",
+        "mode": "standalone",
+    }
+    (runtime_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    (runtime_dir / "VERSION").write_text(version + "\n", encoding="utf-8")
+
+
+def _create_tar(output_dir: Path, runtime_dir: Path, version: str) -> Path:
+    archive_name = f"box-agent-runtime-v{version}-win32-x64.tar.gz"
+    archive_path = output_dir / archive_name
+    print(f"\n[win] Creating archive: {archive_path}")
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(runtime_dir, arcname="box-agent-runtime")
+    size_mb = archive_path.stat().st_size / (1024 * 1024)
+    print(f"[win] Archive created: {archive_path} ({size_mb:.1f} MB)")
+    return archive_path
+
+
+def _install_to(runtime_dir: Path, target: Path, exe_only: bool) -> None:
+    """Copy assembled runtime tree to an existing officev3 install location."""
+    target = target.resolve()
+    if exe_only:
+        src_bin = runtime_dir / "bin"
+        dst_bin = target / "bin"
+        if dst_bin.exists():
+            shutil.rmtree(dst_bin)
+        shutil.copytree(src_bin, dst_bin)
+        # Refresh manifest + VERSION too so consumers see new version
+        for fname in ("manifest.json", "VERSION"):
+            src_f = runtime_dir / fname
+            if src_f.is_file():
+                shutil.copy2(src_f, target / fname)
+        print(f"[win] Installed bin/ -> {target}")
+    else:
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(runtime_dir, target)
+        print(f"[win] Installed full runtime tree -> {target}")
+
+
+def main() -> None:
+    _ensure_win()
+
+    parser = argparse.ArgumentParser(description="Windows-only BoxAgent runtime builder")
+    parser.add_argument("--version", default=None,
+                        help="Version string (default: read from box_agent/__init__.py)")
+    parser.add_argument("--output", default="dist/runtime",
+                        help="Output directory (default: dist/runtime)")
+    parser.add_argument("--exe-only", action="store_true",
+                        help="Only rebuild bin/ (PyInstaller). Keep existing runtime/ and runtimes/.")
+    parser.add_argument("--no-tar", action="store_true",
+                        help="Skip the tar.gz archive step (faster dev iteration).")
+    parser.add_argument("--install-to", default=None,
+                        help="After build, copy artifacts to this path "
+                             "(e.g. officev3 build-resources/box-agent-runtime).")
+    args = parser.parse_args()
+
+    version = args.version or _read_version_from_package()
+    output_dir = Path(args.output).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    runtime_dir = output_dir / "box-agent-runtime"
+    BUILD_TOOLS_CACHE.mkdir(parents=True, exist_ok=True)
+
+    print(f"Building box-agent-runtime v{version} for win32-x64")
+    print(f"Output: {runtime_dir}")
+    print(f"Mode: {'exe-only' if args.exe_only else 'full'}")
+
+    if args.exe_only:
+        if not runtime_dir.exists():
+            print(
+                f"\nERROR: --exe-only requires an existing runtime at:\n  {runtime_dir}\n"
+                "Run a full build first (drop --exe-only) to bootstrap "
+                "runtime/ and runtimes/.",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        # Wipe only bin/
+        bin_dir = runtime_dir / "bin"
+        if bin_dir.exists():
+            shutil.rmtree(bin_dir)
+        _run_pyinstaller(bin_dir)
+        # Manifest version bump so consumers see the new exe
+        _write_manifest(runtime_dir, version)
+    else:
+        # Full clean build
+        if runtime_dir.exists():
+            shutil.rmtree(runtime_dir)
+        runtime_dir.mkdir(parents=True)
+        bin_dir = runtime_dir / "bin"
+        bin_dir.mkdir()
+        _run_pyinstaller(bin_dir)
+        _write_manifest(runtime_dir, version)
+        # bash + python + sandbox packages + node
+        _install_portable_git_win(runtime_dir)
+        _install_portable_python_win(runtime_dir)
+        python_exe = runtime_dir / "runtime" / "python" / "python.exe"
+        if python_exe.is_file():
+            _install_sandbox_packages_win(python_exe)
+        _install_node_win(runtime_dir)
+
+    print(f"\n[win] Runtime tree assembled: {runtime_dir}")
+
+    if not args.no_tar:
+        _create_tar(output_dir, runtime_dir, version)
+    else:
+        print("[win] --no-tar set, skipping archive step")
+
+    if args.install_to:
+        _install_to(runtime_dir, Path(args.install_to), args.exe_only)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 改动

- **bash_tool**：检测到内置 PortableGit `bash.exe` 时优先使用，将 coreutils
  前置到 PATH；将子进程 stdin 设为 DEVNULL，避免句柄继承导致的卡死
- **jupyter_tool**：检测到 `BOX_AGENT_BUNDLED_PYTHON` 时，kernel 走子进程
  而非进程内（绕开 PyInstaller 冻结环境下 ipykernel 卡死）；Win venv 使用
  `Scripts/python.exe` 布局
- **runtime**：新增 `bundled_win_bash` / `bundled_win_python` 定位函数；
  新增 `NodeRuntimeManager.install_win`（zip 下载 + SHA-256 校验）；
  新增 `BOX_AGENT_NODE_RUNTIME_ROOT` 开发期 override
- **build_runtime**：Windows 构建时下载并解压 PortableGit 2.46.0 +
  python-build-standalone 3.12.6 + 锁定版本的 Node 进 `runtime/`
- **build_win_runtime**：Windows 专用两阶段构建器，支持 `--exe-only`
  增量模式（只重打 PyInstaller `bin/`，复用既有 `runtime/` 和 `runtimes/`）

## 兼容性

macOS 行为**完全不变**：所有新增逻辑都用 `sys.platform == "win32"` 或
`plat == "win32"` 严格门控。darwin 构建路径字节级一致。