### PR TITLE
fix(acp): extMethod 重命名为 ext_method 以匹配框架命名约定

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -692,7 +692,7 @@ class BoxACPAgent:
             state.cancelled = True
             log.info("session/cancel", session_id=params.sessionId, message="Cancel requested")
 
-    async def extMethod(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Handle custom ACP extension methods (called as ``_<method>``)."""
         if method == "inject":
             session_id = params.get("sessionId", "")
@@ -1262,7 +1262,7 @@ class _MemoryProposalNegotiator:
 
         try:
             response = await asyncio.wait_for(
-                self._conn.extMethod("session/memory_proposal", payload),
+                self._conn.ext_method("session/memory_proposal", payload),
                 timeout=120.0,
             )
         except asyncio.TimeoutError:
@@ -1276,7 +1276,7 @@ class _MemoryProposalNegotiator:
             log.warn(
                 "memory/proposal_error",
                 count=len(candidates),
-                message=f"extMethod failed (host may not support session/memory_proposal): {exc}",
+                message=f"ext_method failed (host may not support session/memory_proposal): {exc}",
             )
             return
 

--- a/tests/test_acp_memory_proposal.py
+++ b/tests/test_acp_memory_proposal.py
@@ -57,7 +57,7 @@ async def test_memory_proposal_list_returns_eligible_candidates(tmp_path: Path):
         _entry("- already rejected", hits=8, core_status="rejected"),
     ])
 
-    result = await agent.extMethod("memory_proposal_list", {"sessionId": ""})
+    result = await agent.ext_method("memory_proposal_list", {"sessionId": ""})
     contents = {c["content"] for c in result["candidates"]}
 
     assert contents == {"- promote me"}
@@ -78,10 +78,10 @@ async def test_memory_proposal_list_respects_cooldown(tmp_path: Path):
         _entry("- never proposed", hits=10),
     ])
 
-    default = await agent.extMethod("memory_proposal_list", {"sessionId": ""})
+    default = await agent.ext_method("memory_proposal_list", {"sessionId": ""})
     assert {c["content"] for c in default["candidates"]} == {"- never proposed"}
 
-    bypass = await agent.extMethod(
+    bypass = await agent.ext_method(
         "memory_proposal_list", {"sessionId": "", "includeCooldown": True}
     )
     assert {c["content"] for c in bypass["candidates"]} == {"- in cooldown", "- never proposed"}
@@ -90,14 +90,14 @@ async def test_memory_proposal_list_respects_cooldown(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_memory_proposal_list_empty_returns_empty_array(tmp_path: Path):
     agent, _ = _make_agent(tmp_path)
-    result = await agent.extMethod("memory_proposal_list", {"sessionId": ""})
+    result = await agent.ext_method("memory_proposal_list", {"sessionId": ""})
     assert result == {"candidates": []}
 
 
 @pytest.mark.asyncio
 async def test_memory_proposal_list_unknown_session(tmp_path: Path):
     agent, _ = _make_agent(tmp_path)
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_list", {"sessionId": "no-such-session"}
     )
     assert result == {"error": "session_not_found"}
@@ -114,7 +114,7 @@ async def test_memory_proposal_apply_pins_and_returns_core(tmp_path: Path):
     skip = _entry("- skip me", hits=10)
     write_context_file(mgr.context_file, [pin, reject, skip])
 
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_apply",
         {
             "sessionId": "",
@@ -141,7 +141,7 @@ async def test_memory_proposal_apply_ignores_invalid_decisions(tmp_path: Path):
     keep = _entry("- keep me", hits=10)
     write_context_file(mgr.context_file, [keep])
 
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_apply",
         {
             "sessionId": "",
@@ -160,7 +160,7 @@ async def test_memory_proposal_apply_ignores_invalid_decisions(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_memory_proposal_apply_rejects_malformed_payload(tmp_path: Path):
     agent, _ = _make_agent(tmp_path)
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_apply", {"sessionId": "", "decisions": "not-a-dict"}
     )
     assert result == {"error": "invalid_decisions"}


### PR DESCRIPTION
acp framework 的 AgentSideConnection 暴露 ext_method (snake_case) 作为 扩展方法 outbound 调用接口，build_agent_router 也通过
getattr(agent, ext_method) 派发入站 _<name> 扩展请求。box_agent 之前 两处都用 camelCase extMethod，导致：

- _list_skills / _inject / _memory_proposal_* 全部返回 method_not_found；Electron 宿主 fallback 到仅扫 user 目录的逻辑， Skills 页内置技能栏目永不显示。
- 出站 self._conn.extMethod(...) 抛 AttributeError，被 memory_proposal 的 try/except 静默吞掉。

4 处全部改名：handler 定义、两处 outbound 调用、一处 error log 文案。