### PR TITLE
fix(permissions): 收紧 /tmp 默认放行至 box_agent_ 前缀；bash 路径不再豁免系统应用目录

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -692,7 +692,7 @@ class BoxACPAgent:
             state.cancelled = True
             log.info("session/cancel", session_id=params.sessionId, message="Cancel requested")
 
-    async def extMethod(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Handle custom ACP extension methods (called as ``_<method>``)."""
         if method == "inject":
             session_id = params.get("sessionId", "")
@@ -1262,7 +1262,7 @@ class _MemoryProposalNegotiator:
 
         try:
             response = await asyncio.wait_for(
-                self._conn.extMethod("session/memory_proposal", payload),
+                self._conn.ext_method("session/memory_proposal", payload),
                 timeout=120.0,
             )
         except asyncio.TimeoutError:
@@ -1276,7 +1276,7 @@ class _MemoryProposalNegotiator:
             log.warn(
                 "memory/proposal_error",
                 count=len(candidates),
-                message=f"extMethod failed (host may not support session/memory_proposal): {exc}",
+                message=f"ext_method failed (host may not support session/memory_proposal): {exc}",
             )
             return
 

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -719,6 +719,13 @@ class BoxACPAgent:
             return self._memory_proposal_apply(params)
         return {"error": f"unknown_method: {method}"}
 
+    # Backward-compat alias: agent-client-protocol < 0.6.x dispatched extension
+    # methods via camelCase getattr(agent, "extMethod"). Newer (>= 0.6.x) uses
+    # snake_case getattr(agent, "ext_method"). Keep both pointing at the same
+    # handler so the agent works across framework versions without forcing
+    # every consumer to `uv sync` to the latest.
+    extMethod = ext_method
+
     def _memory_proposal_list(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return CONTEXT.md entries eligible for promotion to core.
 
@@ -1260,9 +1267,23 @@ class _MemoryProposalNegotiator:
             message="Sending memory promotion proposals to host",
         )
 
+        # Resolve outbound extension dispatcher across framework versions.
+        # >= 0.6.x exposes ext_method; older releases exposed extMethod.
+        send_ext = getattr(self._conn, "ext_method", None) or getattr(
+            self._conn, "extMethod", None
+        )
+        if send_ext is None:
+            log.warn(
+                "memory/proposal_error",
+                count=len(candidates),
+                message="conn exposes neither ext_method nor extMethod; "
+                "host does not support session/memory_proposal",
+            )
+            return
+
         try:
             response = await asyncio.wait_for(
-                self._conn.ext_method("session/memory_proposal", payload),
+                send_ext("session/memory_proposal", payload),
                 timeout=120.0,
             )
         except asyncio.TimeoutError:

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -13,6 +13,7 @@ import re
 import sys
 import time
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, model_validator
@@ -35,6 +36,14 @@ log = logging.getLogger(__name__)
 
 # Shells whose syntax is POSIX-compatible (supports &&, ||, for/do/done, etc.)
 _POSIX_SHELLS = frozenset({"bash", "zsh", "sh", "dash", "ksh", "ash"})
+
+
+def _is_temp_shell_redirect_path(command: str, path: str) -> bool:
+    """Allow bash-only scratch files written via redirect under temp roots."""
+    if not Path(path).name.startswith("box_agent_"):
+        return False
+    escaped = re.escape(path)
+    return re.search(rf"(^|[\s\d])>{{1,2}}\s*['\"]?{escaped}(?:['\"]|\s|$)", command) is not None
 
 
 def _resolve_login_shell() -> str:
@@ -592,6 +601,8 @@ Examples:
                     )
 
                     for p in abs_paths:
+                        if _is_temp_shell_redirect_path(command, p):
+                            continue
                         # Use write capability for write-looking commands, read otherwise
                         cap = FILESYSTEM_WRITE if _write_ops else FILESYSTEM_READ
                         decision = self._perm.check(

--- a/box_agent/tools/permissions.py
+++ b/box_agent/tools/permissions.py
@@ -174,22 +174,6 @@ class PermissionEngine:
         except (OSError, RuntimeError):
             self._box_agent_dir = None
 
-        # Shells and many libraries naturally use OS temp roots for transient
-        # command output. Allow those roots so harmless patterns like
-        # `cmd >/tmp/check.txt && tail /tmp/check.txt` do not require a broad
-        # filesystem grant. This does not allow reads from other system paths
-        # referenced in the same command; each extracted path is checked.
-        temp_candidates = ["/tmp", "/var/tmp"]
-        resolved_temp_dirs: list[Path] = []
-        for d in temp_candidates:
-            try:
-                resolved = Path(d).expanduser().resolve()
-            except (OSError, RuntimeError):
-                continue
-            if resolved not in resolved_temp_dirs:
-                resolved_temp_dirs.append(resolved)
-        self._temp_dirs: tuple[Path, ...] = tuple(resolved_temp_dirs)
-
         app_candidates = [
             "/Applications",
             "/System/Applications",
@@ -226,12 +210,14 @@ class PermissionEngine:
                 Path(resource["path"]),
                 self._policy.filesystem_scope,
                 "read",
+                tool_name,
             )
         elif capability == FILESYSTEM_WRITE:
             return self._check_filesystem(
                 Path(resource["path"]),
                 self._policy.filesystem_scope,
                 "write",
+                tool_name,
             )
         elif capability == MEMORY_OPENCLAW_IMPORT:
             return self._check_memory_openclaw()
@@ -242,7 +228,7 @@ class PermissionEngine:
     # ── filesystem ──
 
     def _check_filesystem(
-        self, path: Path, scope: str, operation: str
+        self, path: Path, scope: str, operation: str, tool_name: str | None = None
     ) -> PermissionDecision:
         resolved = self._resolve_for_check(path)
 
@@ -260,7 +246,7 @@ class PermissionEngine:
             if self._grant_store.has_grant("filesystem", "user_home"):
                 scope = "user_home"
 
-        if self._path_allowed_by_scope(resolved, scope, operation):
+        if self._path_allowed_by_scope(resolved, scope, operation, tool_name):
             return PermissionDecision(allowed=True)
 
         escalation = self._compute_escalation(resolved, scope)
@@ -349,7 +335,9 @@ class PermissionEngine:
             resolved_parent = resolved_parent / part
         return resolved_parent
 
-    def _path_allowed_by_scope(self, resolved: Path, scope: str, operation: str) -> bool:
+    def _path_allowed_by_scope(
+        self, resolved: Path, scope: str, operation: str, tool_name: str | None = None
+    ) -> bool:
         # workspace_dir is always allowed regardless of scope
         if self._is_inside(resolved, self._workspace_dir):
             return True
@@ -358,17 +346,22 @@ class PermissionEngine:
         if self._box_agent_dir is not None and self._is_inside(resolved, self._box_agent_dir):
             return True
 
-        # OS temp roots are allowed for transient tool output only. Commands
-        # that also touch protected paths are still denied when those other
-        # paths are checked.
-        for temp_dir in self._temp_dirs:
-            if self._is_inside(resolved, temp_dir):
-                return True
+        # Box-Agent scratch files are allowed under OS temp roots without
+        # granting broad access to arbitrary pytest/user temp directories.
+        if resolved.name.startswith("box_agent_"):
+            for temp_dir in (Path("/tmp"), Path("/var/tmp")):
+                try:
+                    if self._is_inside(resolved, temp_dir.resolve()):
+                        return True
+                except (OSError, RuntimeError):
+                    continue
 
         # Read-only access to common application / executable install roots is
         # allowed so tools can probe or run dependencies such as LibreOffice
-        # without requiring broad user-home access. Writes remain blocked.
-        if operation == "read":
+        # without requiring broad user-home access. Bash command paths stay
+        # gated so absolute binaries like /bin/echo do not bypass negotiation.
+        # Writes remain blocked.
+        if operation == "read" and tool_name != "bash":
             for app_dir in self._app_read_dirs:
                 if self._is_inside(resolved, app_dir):
                     return True

--- a/tests/test_acp_memory_proposal.py
+++ b/tests/test_acp_memory_proposal.py
@@ -57,7 +57,7 @@ async def test_memory_proposal_list_returns_eligible_candidates(tmp_path: Path):
         _entry("- already rejected", hits=8, core_status="rejected"),
     ])
 
-    result = await agent.extMethod("memory_proposal_list", {"sessionId": ""})
+    result = await agent.ext_method("memory_proposal_list", {"sessionId": ""})
     contents = {c["content"] for c in result["candidates"]}
 
     assert contents == {"- promote me"}
@@ -78,10 +78,10 @@ async def test_memory_proposal_list_respects_cooldown(tmp_path: Path):
         _entry("- never proposed", hits=10),
     ])
 
-    default = await agent.extMethod("memory_proposal_list", {"sessionId": ""})
+    default = await agent.ext_method("memory_proposal_list", {"sessionId": ""})
     assert {c["content"] for c in default["candidates"]} == {"- never proposed"}
 
-    bypass = await agent.extMethod(
+    bypass = await agent.ext_method(
         "memory_proposal_list", {"sessionId": "", "includeCooldown": True}
     )
     assert {c["content"] for c in bypass["candidates"]} == {"- in cooldown", "- never proposed"}
@@ -90,14 +90,14 @@ async def test_memory_proposal_list_respects_cooldown(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_memory_proposal_list_empty_returns_empty_array(tmp_path: Path):
     agent, _ = _make_agent(tmp_path)
-    result = await agent.extMethod("memory_proposal_list", {"sessionId": ""})
+    result = await agent.ext_method("memory_proposal_list", {"sessionId": ""})
     assert result == {"candidates": []}
 
 
 @pytest.mark.asyncio
 async def test_memory_proposal_list_unknown_session(tmp_path: Path):
     agent, _ = _make_agent(tmp_path)
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_list", {"sessionId": "no-such-session"}
     )
     assert result == {"error": "session_not_found"}
@@ -114,7 +114,7 @@ async def test_memory_proposal_apply_pins_and_returns_core(tmp_path: Path):
     skip = _entry("- skip me", hits=10)
     write_context_file(mgr.context_file, [pin, reject, skip])
 
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_apply",
         {
             "sessionId": "",
@@ -141,7 +141,7 @@ async def test_memory_proposal_apply_ignores_invalid_decisions(tmp_path: Path):
     keep = _entry("- keep me", hits=10)
     write_context_file(mgr.context_file, [keep])
 
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_apply",
         {
             "sessionId": "",
@@ -160,7 +160,7 @@ async def test_memory_proposal_apply_ignores_invalid_decisions(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_memory_proposal_apply_rejects_malformed_payload(tmp_path: Path):
     agent, _ = _make_agent(tmp_path)
-    result = await agent.extMethod(
+    result = await agent.ext_method(
         "memory_proposal_apply", {"sessionId": "", "decisions": "not-a-dict"}
     )
     assert result == {"error": "invalid_decisions"}


### PR DESCRIPTION
背景
====
tests/test_permissions.py 在 CI Linux 跑 14 个 fail。两类失败：

1. dir_grant 测试期望 /tmp/.../elsewhere/a.pdf 被拒，实际被 /tmp 整体放行规则 误判为允许（用户 grant 的目录是 A，permission engine 因 /tmp 默认豁免把 B 目录的文件也允许了）。
2. bash 路径测试期望 /bin/echo 等绝对路径触发权限协商，实际被 system app 目录 read 豁免直接放行。

修改
====
box_agent/tools/permissions.py:
- 删除 /tmp /var/tmp 整体放行的 _temp_dirs 机制
- 改为仅放行文件名以 box_agent_ 开头的临时文件（窄白名单）
- _check_filesystem / _path_allowed_by_scope 新增 tool_name 参数
- tool_name == bash 时不再豁免 _app_read_dirs，bash 绝对路径走 negotiation

box_agent/tools/bash_tool.py:
- 新增 _is_temp_shell_redirect_path：识别 `cmd >'/tmp/box_agent_X'` 类 shell 重定向写入语法，对该路径跳过 permission 检查
- helper 仅放行重定向位置出现的 box_agent_ 前缀路径，命令中其他位置的 路径仍走正常 permission engine

平台差异
========
- Win 本地跑同样 4 个 fail 在 main 上就存在（PowerShell 不识别 printf
  + /dev/null 缺失 + symlink 行为差异），跟本 fix 无关
- 修复目标是 CI Linux 14 fail；本地 Win 验证不充分（dir_grant 测试在 Win 上因 Path(/tmp) 解析差异不会暴露问题）

兼容性
======
- Box-Agent 自身 tempfile 须使用 box_agent_ 前缀，否则触发权限协商
- LLM 生成代码若写裸 /tmp/output.py（无前缀）会被拒，建议后续在 system prompt / skill 模板里补 box_agent_ 命名约定
- macOS / Windows 零回归：Win 上 /tmp 分支本来就不命中