### PR TITLE
feat(obsidian): 支持 Obsidian 原生 CLI 工具

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -631,6 +631,7 @@ class BoxACPAgent:
                 permission_engine=perm_engine,
                 skill_runtime_context=skill_runtime_context,
                 use_output_dir=artifact_mode != "project",
+                env_context=env_context,
             )
         agent = Agent(
             llm_client=self._llm,

--- a/box_agent/acp/env_context.py
+++ b/box_agent/acp/env_context.py
@@ -35,7 +35,7 @@ from pydantic import BaseModel, ConfigDict, Field
 logger = logging.getLogger(__name__)
 
 _KNOWN_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
-    {"cli", "platform", "browser_tools", "image_service", "memory_configured", "runtimes"}
+    {"cli", "platform", "browser_tools", "image_service", "memory_configured", "runtimes", "obsidian"}
 )
 
 _MAX_PATH_LEN = 512
@@ -128,6 +128,17 @@ def _sanitize_provider(raw: Any) -> str | None:
     return raw
 
 
+def _sanitize_label(raw: Any, *, max_len: int = _MAX_NAME_LEN) -> str | None:
+    if raw is None or not isinstance(raw, str):
+        return None
+    raw = raw.strip()
+    if not raw or len(raw) > max_len:
+        return None
+    if _has_unsafe_chars(raw):
+        return None
+    return raw
+
+
 def _sanitize_runtimes(raw: Any) -> dict[str, dict[str, Any]]:
     if not isinstance(raw, dict):
         return {}
@@ -163,6 +174,31 @@ def _sanitize_runtimes(raw: Any) -> dict[str, dict[str, Any]]:
 
         if runtime:
             cleaned[kind] = runtime
+    return cleaned
+
+
+def _sanitize_obsidian(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+
+    cleaned: dict[str, Any] = {}
+    for field_name in ("enabled", "cli_available", "app_running"):
+        value = raw.get(field_name)
+        if isinstance(value, bool):
+            cleaned[field_name] = value
+
+    vault_name = _sanitize_label(raw.get("vault_name"))
+    if vault_name is not None:
+        cleaned["vault_name"] = vault_name
+
+    for field_name in ("vault_path", "cli_path", "app_path"):
+        value = raw.get(field_name)
+        if value is None:
+            continue
+        path = _sanitize_path(f"obsidian.{field_name}", value)
+        if path is not None:
+            cleaned[field_name] = path
+
     return cleaned
 
 
@@ -208,6 +244,20 @@ class HostRuntime(BaseModel):
     provider: str | None = None
 
 
+class ObsidianState(BaseModel):
+    """Sanitized host-provided Obsidian integration metadata."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool | None = None
+    vault_path: str | None = None
+    vault_name: str | None = None
+    cli_path: str | None = None
+    app_path: str | None = None
+    cli_available: bool | None = None
+    app_running: bool | None = None
+
+
 class EnvContext(BaseModel):
     """Parsed view of ``session/new._meta.env_context``.
 
@@ -225,6 +275,7 @@ class EnvContext(BaseModel):
     image_service: ImageServiceState | None = None
     memory_configured: bool | None = None
     runtimes: dict[str, HostRuntime] = Field(default_factory=dict)
+    obsidian: ObsidianState | None = None
     extras: dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
@@ -252,6 +303,8 @@ class EnvContext(BaseModel):
             known["platform"] = _sanitize_platform(known["platform"])
         if "runtimes" in known:
             known["runtimes"] = _sanitize_runtimes(known["runtimes"])
+        if "obsidian" in known:
+            known["obsidian"] = _sanitize_obsidian(known["obsidian"])
 
         try:
             ctx = cls.model_validate(known)
@@ -269,6 +322,7 @@ class EnvContext(BaseModel):
             or self.browser_tools is not None
             or self.image_service is not None
             or self.memory_configured is not None
+            or self.obsidian is not None
         )
 
 
@@ -315,6 +369,35 @@ def _format_image_service(state: ImageServiceState) -> list[str]:
     return [f"- 生图服务状态：{label}"]
 
 
+def _format_obsidian(state: ObsidianState) -> list[str]:
+    parts: list[str] = []
+    if state.enabled is not None:
+        parts.append(f"enabled={str(state.enabled).lower()}")
+    if state.cli_available is not None:
+        parts.append(f"cli_available={str(state.cli_available).lower()}")
+    if state.app_running is not None:
+        parts.append(f"app_running={str(state.app_running).lower()}")
+
+    lines: list[str] = []
+    if parts:
+        lines.append(f"- Obsidian 状态：{', '.join(parts)}")
+    if state.vault_name:
+        lines.append(f"  - Vault：{state.vault_name}")
+    if state.vault_path:
+        lines.append(f"  - Vault 路径：`{state.vault_path}`")
+    if state.cli_path:
+        lines.append(f"  - Obsidian CLI：`{state.cli_path}`")
+    if state.app_path:
+        lines.append(f"  - Obsidian App：`{state.app_path}`")
+    if state.enabled is True:
+        lines.append(
+            "- Obsidian 写入/打开策略：当用户要求导出、写入、保存或追加到 Obsidian 时，"
+            "必须优先使用 `obsidian_create_note`、`obsidian_update_note` 或 `obsidian_daily_note`；"
+            "不要用 bash 直接调用 `obsidian create/append/prepend/open/daily`。"
+        )
+    return lines
+
+
 def build_env_context_prompt(ctx: EnvContext | None) -> str:
     """Render ``EnvContext`` into a markdown checklist for the system prompt.
 
@@ -333,6 +416,8 @@ def build_env_context_prompt(ctx: EnvContext | None) -> str:
         lines.extend(_format_browser_tools(ctx.browser_tools))
     if ctx.image_service is not None:
         lines.extend(_format_image_service(ctx.image_service))
+    if ctx.obsidian is not None:
+        lines.extend(_format_obsidian(ctx.obsidian))
     if ctx.memory_configured is not None:
         state = "已完成" if ctx.memory_configured else "未完成"
         lines.append(f"- 个人记忆配置：{state}")

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -597,6 +597,69 @@ def cmd_config(edit: bool = False):
         subprocess.run([editor, str(config_path)])
 
 
+def build_cli_env_context():
+    """Build host-style environment facts for standalone CLI sessions."""
+    from box_agent.acp.env_context import EnvContext
+    from box_agent.tools.obsidian_tool import load_obsidian_config
+
+    obsidian_config = load_obsidian_config()
+    if not obsidian_config:
+        return None
+    return EnvContext.from_meta(
+        {
+            "platform": platform.system().lower(),
+            "obsidian": obsidian_config,
+        }
+    )
+
+
+def _resolve_obsidian_cli(cli_path: str | None) -> str | None:
+    candidate = (cli_path or "").strip() or "obsidian"
+    if "/" in candidate or "\\" in candidate:
+        candidate = str(Path(candidate).expanduser())
+    return shutil.which(candidate)
+
+
+def _doctor_obsidian_status_line() -> str:
+    from box_agent.tools.obsidian_tool import load_obsidian_config, obsidian_config_path
+
+    config_path = obsidian_config_path()
+    config = load_obsidian_config()
+    if not config and not config_path.exists():
+        return "  ⚠️  Obsidian — not configured (officev3 will create obsidian.json after Vault binding)"
+    if config.get("enabled") is False:
+        return "  ⚠️  Obsidian — disabled (bind a Vault in officev3 Settings → Connect Data Sources)"
+
+    problems: list[str] = []
+    vault_path = config.get("vault_path")
+    vault: Path | None = None
+    if isinstance(vault_path, str) and vault_path.strip():
+        vault = Path(vault_path).expanduser()
+        if not vault.exists() or not vault.is_dir():
+            problems.append(f"Vault missing or not a directory: {vault}")
+        elif not (vault / ".obsidian").is_dir():
+            problems.append(f"Vault missing .obsidian: {vault}")
+    else:
+        problems.append("Vault not configured")
+
+    cli_path = config.get("cli_path") if isinstance(config.get("cli_path"), str) else None
+    resolved_cli = _resolve_obsidian_cli(cli_path)
+    if not resolved_cli:
+        problems.append(f"CLI not found: {(cli_path or 'obsidian').strip() or 'obsidian'}")
+
+    if problems:
+        return f"  ❌ Obsidian — {'; '.join(problems)}"
+
+    vault_label = config.get("vault_name") if isinstance(config.get("vault_name"), str) else None
+    if not vault_label and vault is not None:
+        vault_label = vault.name
+    return f"  ✅ Obsidian — Vault: {vault_label or 'configured'}; CLI: {resolved_cli}"
+
+
+def _doctor_check_obsidian() -> None:
+    print(_doctor_obsidian_status_line())
+
+
 async def cmd_doctor():
     """Check environment health: config, API, sandbox, MCP."""
     print(f"{Colors.BOLD}Box Agent Doctor{Colors.RESET}\n")
@@ -672,6 +735,10 @@ async def cmd_doctor():
 
     # 5. Browser runtime (Playwright)
     _doctor_check_browser()
+
+    # 6. Obsidian host configuration. This is diagnostic only; never starts
+    # Obsidian or runs write/open CLI commands.
+    _doctor_check_obsidian()
 
     print()
 
@@ -1077,7 +1144,8 @@ async def run_agent(workspace_dir: Path, task: str = None, sandbox_mode: bool = 
             policy = CapabilityPolicy(session_workspace_root=str(workspace_dir))
         perm_engine = PermissionEngine(policy, workspace_dir, grant_store=grant_store)
 
-    skill_runtime_context = build_skill_runtime_context(sandbox_mode=sandbox_mode)
+    cli_env_context = build_cli_env_context()
+    skill_runtime_context = build_skill_runtime_context(sandbox_mode=sandbox_mode, env_context=cli_env_context)
 
     add_workspace_tools(
         tools, config, workspace_dir,
@@ -1087,6 +1155,7 @@ async def run_agent(workspace_dir: Path, task: str = None, sandbox_mode: bool = 
         llm=llm_client,
         permission_engine=perm_engine,
         skill_runtime_context=skill_runtime_context,
+        env_context=cli_env_context,
     )
 
     if not allow_full_access:
@@ -1127,6 +1196,14 @@ async def run_agent(workspace_dir: Path, task: str = None, sandbox_mode: bool = 
         system_prompt = system_prompt.replace("{SANDBOX_INFO}", "")
 
     system_prompt = f"{system_prompt.rstrip()}\n\n{build_skill_runtime_prompt(skill_runtime_context)}"
+
+    if cli_env_context is not None:
+        from box_agent.acp.env_context import build_env_context_prompt
+
+        env_prompt = build_env_context_prompt(cli_env_context)
+        if env_prompt:
+            system_prompt = f"{system_prompt.rstrip()}\n\n{env_prompt}"
+            print(f"{Colors.GREEN}✅ Loaded CLI environment context{Colors.RESET}")
 
     # 6.6 Inject Memory context
     if memory_mgr:

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -60,6 +60,10 @@
       "path": "scheduled-task/SKILL.md"
     },
     {
+      "name": "obsidian",
+      "path": "obsidian/SKILL.md"
+    },
+    {
       "name": "skill-architect",
       "path": "skill-architect/SKILL.md"
     },

--- a/box_agent/skills/obsidian/SKILL.md
+++ b/box_agent/skills/obsidian/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: obsidian
+description: Use this skill whenever the user asks to create, export, save, append, prepend, open, or write Markdown notes in Obsidian. It explains when to call the native obsidian_* tools backed by the official Obsidian CLI, and how to avoid unsafe direct bash CLI writes.
+keywords: [obsidian, vault, note, daily note, todo, markdown, 导出 Obsidian, 写入 Obsidian, 保存到 Obsidian, 追加到 Obsidian, 笔记, 日记]
+---
+
+# Obsidian 笔记助手
+
+当用户明确要求把内容写入、导出、保存、追加或打开到 Obsidian 时，使用本 skill，并优先调用 Box-Agent 的原生 `obsidian_*` 工具。
+
+## 何时使用
+
+出现这些信号就进入本流程：
+
+- “导出到 Obsidian”
+- “保存到 Obsidian”
+- “写入 Obsidian”
+- “追加到某篇 Obsidian 笔记”
+- “生成今天的 todo 到 Obsidian”
+- “打开 / 更新 / 覆盖 Obsidian 笔记”
+
+## 工具选择
+
+- 新建普通笔记：调用 `obsidian_create_note`。
+- 追加、前置或覆盖已有笔记：调用 `obsidian_update_note`。
+- 今天的 Daily Note / todo / 日记：调用 `obsidian_daily_note`。
+
+## 路径规则
+
+- `path` 必须是 Vault 相对路径，例如 `Projects/AI 周报.md`。
+- 不要传绝对路径。
+- 不要使用 `..`。
+- 写入目标必须是 `.md` 文件。
+
+## Bash 边界
+
+可以用 bash 做诊断：
+
+```bash
+obsidian version
+obsidian help
+which obsidian
+```
+
+不要用 bash 直接执行写入或打开类命令，例如：
+
+```bash
+obsidian create ...
+obsidian append ...
+obsidian prepend ...
+obsidian open ...
+obsidian daily ...
+```
+
+这些操作必须走 `obsidian_*` 原生工具，因为工具会处理 Vault 配置、路径校验、权限确认、CLI 参数转义和失败提示。
+
+## 示例
+
+用户：“帮我生成今天的 todo 项到 Obsidian。”
+
+做法：整理 todo 内容后调用：
+
+```text
+obsidian_daily_note(action="append", content="<Markdown todo>", open_after=true)
+```
+
+用户：“把这份报告导出为 Obsidian 笔记。”
+
+做法：调用：
+
+```text
+obsidian_create_note(title="报告标题", content="<Markdown report>", open_after=true)
+```

--- a/box_agent/tools/__init__.py
+++ b/box_agent/tools/__init__.py
@@ -3,6 +3,7 @@
 from .base import Tool, ToolResult
 from .bash_tool import BashTool
 from .file_tools import EditTool, ReadTool, WriteTool
+from .obsidian_tool import ObsidianCreateNoteTool, ObsidianDailyNoteTool, ObsidianUpdateNoteTool
 from .plan_tool import PlanReadTool, PlanStore, PlanWriteTool
 from .setup import add_workspace_tools, initialize_base_tools
 from .todo_tool import TodoReadTool, TodoStore, TodoWriteTool
@@ -15,6 +16,9 @@ __all__ = [
     "WriteTool",
     "EditTool",
     "BashTool",
+    "ObsidianCreateNoteTool",
+    "ObsidianUpdateNoteTool",
+    "ObsidianDailyNoteTool",
     "PlanStore",
     "PlanWriteTool",
     "PlanReadTool",

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -10,6 +10,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import sys
 import time
 import uuid
@@ -49,6 +50,22 @@ _LARK_CLI_ENV_ASSIGNMENT_RE = re.compile(
     r"^(?:export\s+|set\s+)BOX_AGENT_LARK_CLI\s*=",
     re.IGNORECASE,
 )
+_OBSIDIAN_COMMAND_SEPARATOR_RE = re.compile(r"&&|\|\||[;\n|]")
+_OBSIDIAN_CLI_NAMES = frozenset({"obsidian", "obsidian.exe", "obsidian.cmd"})
+_OBSIDIAN_WRITE_COMMANDS = frozenset({
+    "create",
+    "append",
+    "prepend",
+    "open",
+    "daily",
+    "daily:read",
+    "daily:append",
+    "daily:prepend",
+    "delete",
+    "move",
+    "rename",
+    "property:set",
+})
 _SAFETY_SCOPE = "safety"
 _DANGEROUS_COMMAND_SCOPE = "dangerous_command"
 
@@ -104,6 +121,50 @@ def _detect_lark_user_mode_violation(command: str) -> str | None:
 
         if not _LARK_USER_FLAG_RE.search(part):
             return "lark-cli business commands must pass `--as user` in officev3 local-agent sessions."
+    return None
+
+
+def _detect_obsidian_cli_violation(command: str) -> str | None:
+    """Reject direct Obsidian writes/opens that should go through native tools."""
+    for raw_part in _OBSIDIAN_COMMAND_SEPARATOR_RE.split(command):
+        part = raw_part.strip()
+        if not part:
+            continue
+        try:
+            tokens = shlex.split(part, posix=platform.system() != "Windows")
+        except ValueError:
+            continue
+        if not tokens:
+            continue
+
+        # Diagnostics are allowed through bash.
+        if len(tokens) >= 2 and tokens[0] in {"which", "where"} and os.path.basename(tokens[1]).lower() in _OBSIDIAN_CLI_NAMES:
+            continue
+
+        exe_index = None
+        for index, token in enumerate(tokens):
+            if token in {"env", "command"}:
+                continue
+            if "=" in token and not token.startswith("-"):
+                continue
+            base = os.path.basename(token).lower()
+            if base in _OBSIDIAN_CLI_NAMES or token in {"$BOX_AGENT_OBSIDIAN_CLI", "${BOX_AGENT_OBSIDIAN_CLI}", "%BOX_AGENT_OBSIDIAN_CLI%"}:
+                exe_index = index
+            break
+        if exe_index is None:
+            continue
+
+        args = tokens[exe_index + 1 :]
+        if not args:
+            continue
+        first = args[0].lower()
+        if first in {"help", "--help", "-h", "version", "--version", "-v"}:
+            continue
+        if first in _OBSIDIAN_WRITE_COMMANDS:
+            return (
+                "Obsidian 写入、打开或修改命令必须通过原生工具执行；"
+                "请改用 `obsidian_create_note`、`obsidian_update_note` 或 `obsidian_daily_note`。"
+            )
     return None
 
 
@@ -624,6 +685,16 @@ Examples:
                     error=f"Blocked: {lark_identity_error}\nCommand: {command}",
                     stdout="",
                     stderr=f"Blocked: {lark_identity_error}",
+                    exit_code=1,
+                )
+
+            obsidian_cli_error = _detect_obsidian_cli_violation(command)
+            if obsidian_cli_error:
+                return BashOutputResult(
+                    success=False,
+                    error=f"Blocked: {obsidian_cli_error}\nCommand: {command}",
+                    stdout="",
+                    stderr=f"Blocked: {obsidian_cli_error}",
                     exit_code=1,
                 )
 

--- a/box_agent/tools/obsidian_tool.py
+++ b/box_agent/tools/obsidian_tool.py
@@ -1,0 +1,400 @@
+"""Obsidian CLI tools for writing notes through the official desktop CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import re
+from pathlib import Path
+from typing import Any
+
+from .base import Tool, ToolResult
+
+OBSIDIAN_PERMISSION_SCOPE = "external_app"
+OBSIDIAN_LAUNCH_SCOPE = "obsidian_launch"
+OBSIDIAN_CONFIG_ENV = "BOX_AGENT_OBSIDIAN_CONFIG"
+OBSIDIAN_CLI_ENV = "BOX_AGENT_OBSIDIAN_CLI"
+OBSIDIAN_APP_ENV = "BOX_AGENT_OBSIDIAN_APP"
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".box-agent" / "config" / "obsidian.json"
+_DEFAULT_CLI_NAME = "obsidian"
+_NOTE_TITLE_RE = re.compile(r"[^A-Za-z0-9\u4e00-\u9fff._ -]+")
+
+
+def _launch_permission_request(reason: str) -> dict[str, Any]:
+    return {
+        "type": "permission_request",
+        "scope": OBSIDIAN_PERMISSION_SCOPE,
+        "requested_scope": OBSIDIAN_LAUNCH_SCOPE,
+        "path": "",
+        "reason": reason,
+        "temporary_supported": True,
+        "persistent_supported": False,
+        "persistent_label": "",
+    }
+
+
+def _clean_optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _config_from_env_context(env_context: Any) -> dict[str, Any]:
+    if env_context is None:
+        return {}
+    obsidian = getattr(env_context, "obsidian", None)
+    if obsidian is None and isinstance(env_context, dict):
+        obsidian = env_context.get("obsidian")
+    if obsidian is None:
+        return {}
+    if isinstance(obsidian, dict):
+        return dict(obsidian)
+    return {
+        "enabled": getattr(obsidian, "enabled", None),
+        "vault_path": getattr(obsidian, "vault_path", None),
+        "vault_name": getattr(obsidian, "vault_name", None),
+        "cli_path": getattr(obsidian, "cli_path", None),
+        "app_path": getattr(obsidian, "app_path", None),
+        "cli_available": getattr(obsidian, "cli_available", None),
+        "app_running": getattr(obsidian, "app_running", None),
+    }
+
+
+def load_obsidian_config(env_context: Any = None) -> dict[str, Any]:
+    config_path = Path(os.environ.get(OBSIDIAN_CONFIG_ENV, str(_DEFAULT_CONFIG_PATH))).expanduser()
+    file_config = _read_json(config_path)
+    host_config = _config_from_env_context(env_context)
+    merged = {**file_config, **{k: v for k, v in host_config.items() if v is not None}}
+
+    cli_override = _clean_optional_str(os.environ.get(OBSIDIAN_CLI_ENV))
+    app_override = _clean_optional_str(os.environ.get(OBSIDIAN_APP_ENV))
+    if cli_override:
+        merged["cli_path"] = cli_override
+    if app_override:
+        merged["app_path"] = app_override
+    return merged
+
+
+def _validate_config(config: dict[str, Any]) -> tuple[bool, str]:
+    if config.get("enabled") is False:
+        return False, "Obsidian 尚未启用。请先在 officev3 的 设置-连接数据源 中绑定 Vault。"
+
+    vault_path = _clean_optional_str(config.get("vault_path"))
+    if not vault_path:
+        return False, "未找到 Obsidian Vault 配置。请先在 officev3 的 设置-连接数据源 中绑定 Vault。"
+    vault = Path(vault_path).expanduser()
+    if not vault.exists() or not vault.is_dir():
+        return False, f"Obsidian Vault 不存在或不是目录：{vault}"
+    if not (vault / ".obsidian").is_dir():
+        return False, f"所配置目录不是有效 Obsidian Vault（缺少 .obsidian）：{vault}"
+
+    cli_path = _clean_optional_str(config.get("cli_path")) or _DEFAULT_CLI_NAME
+    if os.sep in cli_path or (os.altsep and os.altsep in cli_path):
+        cli = Path(cli_path).expanduser()
+        if not cli.exists():
+            return False, f"Obsidian CLI 不存在：{cli}"
+    elif config.get("cli_available") is False:
+        return False, "Obsidian CLI 不可用。请在 officev3 的 设置-连接数据源 中检测或安装 CLI。"
+    return True, ""
+
+
+def _safe_note_path(title: str, folder: str | None = None, path: str | None = None) -> tuple[bool, str]:
+    raw = (path or "").strip()
+    if raw:
+        candidate = raw
+    else:
+        cleaned = _NOTE_TITLE_RE.sub("", (title or "").strip()).strip(" .")
+        if not cleaned:
+            return False, "title 不能为空，且必须能生成有效 Markdown 文件名。"
+        candidate = cleaned if cleaned.endswith(".md") else f"{cleaned}.md"
+        if folder:
+            candidate = f"{folder.strip().strip('/')}/{candidate}"
+
+    candidate = candidate.replace("\\", "/")
+    pure = Path(candidate)
+    if pure.is_absolute():
+        return False, "Obsidian 写入路径必须是 Vault 相对路径，不能是绝对路径。"
+    candidate = candidate.strip("/")
+    pure = Path(candidate)
+    if any(part in ("", ".", "..") for part in pure.parts):
+        return False, "Obsidian 写入路径不能包含空路径段、'.' 或 '..'。"
+    if pure.suffix.lower() != ".md":
+        return False, "Obsidian 写入目标必须是 .md Markdown 笔记。"
+    return True, pure.as_posix()
+
+
+def _encode_cli_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("\n", "\\n").replace("\t", "\\t")
+
+
+def _cli_executable(config: dict[str, Any]) -> str:
+    return _clean_optional_str(config.get("cli_path")) or _DEFAULT_CLI_NAME
+
+
+async def _run_process(args: list[str], timeout: int = 60) -> tuple[int, str, str]:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return 124, "", "Obsidian CLI 命令执行超时。"
+    return (
+        int(proc.returncode or 0),
+        stdout.decode("utf-8", errors="replace").strip(),
+        stderr.decode("utf-8", errors="replace").strip(),
+    )
+
+
+async def _launch_obsidian(config: dict[str, Any]) -> tuple[bool, str]:
+    app_path = _clean_optional_str(config.get("app_path"))
+    system = platform.system()
+    if system == "Darwin":
+        if app_path:
+            args = ["open", app_path]
+        else:
+            args = ["open", "-a", "Obsidian"]
+    elif app_path:
+        args = [app_path]
+    else:
+        args = ["obsidian"]
+
+    try:
+        if system == "Darwin":
+            code, _out, err = await _run_process(args, timeout=20)
+            return code == 0, err
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        await asyncio.sleep(0.1)
+        return proc.returncode in (None, 0), ""
+    except Exception as exc:
+        return False, str(exc)
+
+
+async def _wait_cli_ready(config: dict[str, Any], timeout: float = 30.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            code, _out, _err = await _run_process([_cli_executable(config), "version"], timeout=5)
+            if code == 0:
+                return True
+        except Exception:
+            pass
+        await asyncio.sleep(1)
+    return False
+
+
+class ObsidianCliClient:
+    def __init__(self, env_context: Any = None):
+        self.env_context = env_context
+        self._launch_approved_once = False
+        self._launch_performed_once = False
+
+    def approve_permission_request(self, permission_request: dict[str, Any]) -> None:
+        if permission_request.get("scope") == OBSIDIAN_PERMISSION_SCOPE and permission_request.get("requested_scope") == OBSIDIAN_LAUNCH_SCOPE:
+            self._launch_approved_once = True
+
+    async def run(self, args: list[str], *, open_operation: bool = False) -> ToolResult:
+        config = load_obsidian_config(self.env_context)
+        ok, error = _validate_config(config)
+        if not ok:
+            return ToolResult(success=False, error=error)
+
+        if config.get("app_running") is False and not self._launch_performed_once:
+            if not self._launch_approved_once:
+                return ToolResult(
+                    success=False,
+                    error="需要启动 Obsidian 才能继续执行该操作。",
+                    permission_request=_launch_permission_request("需要启动 Obsidian 以写入或打开笔记。"),
+                )
+            launched, launch_error = await _launch_obsidian(config)
+            if not launched:
+                return ToolResult(success=False, error=f"无法启动 Obsidian：{launch_error or 'unknown error'}")
+            self._launch_performed_once = True
+            await _wait_cli_ready(config)
+
+        code, stdout, stderr = await _run_process([_cli_executable(config), *args])
+        if code != 0:
+            return ToolResult(success=False, error=stderr or stdout or f"Obsidian CLI 退出码 {code}")
+        return ToolResult(success=True, content=stdout or "Obsidian 操作已完成。", raw_output={"argv": args})
+
+
+class _ObsidianToolBase(Tool):
+    parallel_safe = False
+
+    def __init__(self, env_context: Any = None, client: ObsidianCliClient | None = None):
+        self.client = client or ObsidianCliClient(env_context)
+
+    def approve_permission_request(self, permission_request: dict[str, Any]) -> None:
+        self.client.approve_permission_request(permission_request)
+
+
+class ObsidianCreateNoteTool(_ObsidianToolBase):
+    @property
+    def name(self) -> str:
+        return "obsidian_create_note"
+
+    @property
+    def description(self) -> str:
+        return "在已绑定的 Obsidian Vault 中新建 Markdown 笔记。写入 Obsidian 时必须优先使用本工具，不要用 bash 直接拼 obsidian create。"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "笔记标题；未提供 path 时用于生成文件名。"},
+                "content": {"type": "string", "description": "要写入笔记的 Markdown 内容。"},
+                "folder": {"type": "string", "description": "可选 Vault 相对文件夹。"},
+                "path": {"type": "string", "description": "可选 Vault 相对 .md 路径；提供后优先于 title/folder。"},
+                "overwrite": {"type": "boolean", "description": "是否覆盖同名笔记。", "default": False},
+                "open_after": {"type": "boolean", "description": "写入后是否打开笔记。", "default": True},
+            },
+            "required": ["title", "content"],
+        }
+
+    async def execute(self, title: str, content: str, folder: str | None = None, path: str | None = None, overwrite: bool = False, open_after: bool = True) -> ToolResult:
+        ok, note_path = _safe_note_path(title=title, folder=folder, path=path)
+        if not ok:
+            return ToolResult(success=False, error=note_path)
+        if not isinstance(content, str) or not content.strip():
+            return ToolResult(success=False, error="content 不能为空。")
+        args = ["create", f"path={note_path}", f"content={_encode_cli_value(content)}"]
+        if overwrite:
+            args.append("overwrite")
+        if open_after:
+            args.append("open")
+        result = await self.client.run(args, open_operation=open_after)
+        if result.success:
+            result.content = f"已创建 Obsidian 笔记：{note_path}"
+            result.raw_output = {"path": note_path, "operation": "create"}
+        return result
+
+
+class ObsidianUpdateNoteTool(_ObsidianToolBase):
+    @property
+    def name(self) -> str:
+        return "obsidian_update_note"
+
+    @property
+    def description(self) -> str:
+        return "追加、前置或覆盖更新已绑定 Obsidian Vault 中的 Markdown 笔记。"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Vault 相对 .md 路径。"},
+                "content": {"type": "string", "description": "要写入的 Markdown 内容。"},
+                "mode": {"type": "string", "enum": ["append", "prepend", "overwrite"], "default": "append"},
+                "inline": {"type": "boolean", "description": "append/prepend 时是否以内联方式写入。", "default": False},
+                "open_after": {"type": "boolean", "description": "写入后是否打开笔记。", "default": True},
+            },
+            "required": ["path", "content"],
+        }
+
+    async def execute(self, path: str, content: str, mode: str = "append", inline: bool = False, open_after: bool = True) -> ToolResult:
+        ok, note_path = _safe_note_path(title="", path=path)
+        if not ok:
+            return ToolResult(success=False, error=note_path)
+        if not isinstance(content, str) or not content.strip():
+            return ToolResult(success=False, error="content 不能为空。")
+        mode = (mode or "append").strip()
+        if mode not in {"append", "prepend", "overwrite"}:
+            return ToolResult(success=False, error="mode 必须是 append、prepend 或 overwrite。")
+        if mode == "overwrite":
+            args = ["create", f"path={note_path}", f"content={_encode_cli_value(content)}", "overwrite"]
+            if open_after:
+                args.append("open")
+            result = await self.client.run(args, open_operation=open_after)
+        else:
+            args = [mode, f"path={note_path}", f"content={_encode_cli_value(content)}"]
+            if inline:
+                args.append("inline")
+            result = await self.client.run(args, open_operation=False)
+            if result.success and open_after:
+                result = await self.client.run(["open", f"path={note_path}"], open_operation=True)
+        if result.success:
+            result.content = f"已更新 Obsidian 笔记：{note_path}"
+            result.raw_output = {"path": note_path, "operation": mode}
+        return result
+
+
+class ObsidianDailyNoteTool(_ObsidianToolBase):
+    @property
+    def name(self) -> str:
+        return "obsidian_daily_note"
+
+    @property
+    def description(self) -> str:
+        return "打开、读取、追加或前置写入 Obsidian Daily Note。适合'生成今天的 todo 到 Obsidian'这类请求。"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {"type": "string", "enum": ["open", "read", "append", "prepend"], "default": "open"},
+                "content": {"type": "string", "description": "append/prepend 时要写入的 Markdown 内容。"},
+                "inline": {"type": "boolean", "default": False},
+                "open_after": {"type": "boolean", "default": True},
+            },
+            "required": [],
+        }
+
+    async def execute(self, action: str = "open", content: str | None = None, inline: bool = False, open_after: bool = True) -> ToolResult:
+        action = (action or "open").strip()
+        if action not in {"open", "read", "append", "prepend"}:
+            return ToolResult(success=False, error="action 必须是 open、read、append 或 prepend。")
+        if action in {"append", "prepend"} and (not isinstance(content, str) or not content.strip()):
+            return ToolResult(success=False, error=f"action={action} 时 content 不能为空。")
+
+        if action == "open":
+            args = ["daily"]
+            result = await self.client.run(args, open_operation=True)
+        elif action == "read":
+            args = ["daily:read"]
+            result = await self.client.run(args, open_operation=False)
+        else:
+            args = [f"daily:{action}", f"content={_encode_cli_value(content or '')}"]
+            if inline:
+                args.append("inline")
+            result = await self.client.run(args, open_operation=False)
+            if result.success and open_after:
+                result = await self.client.run(["daily"], open_operation=True)
+        if result.success:
+            result.raw_output = {"operation": f"daily:{action}"}
+        return result
+
+
+def create_obsidian_tools(env_context: Any = None) -> list[Tool]:
+    return [
+        ObsidianCreateNoteTool(env_context=env_context),
+        ObsidianUpdateNoteTool(env_context=env_context),
+        ObsidianDailyNoteTool(env_context=env_context),
+    ]

--- a/box_agent/tools/obsidian_tool.py
+++ b/box_agent/tools/obsidian_tool.py
@@ -23,6 +23,10 @@ _DEFAULT_CLI_NAME = "obsidian"
 _NOTE_TITLE_RE = re.compile(r"[^A-Za-z0-9\u4e00-\u9fff._ -]+")
 
 
+def obsidian_config_path() -> Path:
+    return Path(os.environ.get(OBSIDIAN_CONFIG_ENV, str(_DEFAULT_CONFIG_PATH))).expanduser()
+
+
 def _launch_permission_request(reason: str) -> dict[str, Any]:
     return {
         "type": "permission_request",
@@ -75,8 +79,7 @@ def _config_from_env_context(env_context: Any) -> dict[str, Any]:
 
 
 def load_obsidian_config(env_context: Any = None) -> dict[str, Any]:
-    config_path = Path(os.environ.get(OBSIDIAN_CONFIG_ENV, str(_DEFAULT_CONFIG_PATH))).expanduser()
-    file_config = _read_json(config_path)
+    file_config = _read_json(obsidian_config_path())
     host_config = _config_from_env_context(env_context)
     merged = {**file_config, **{k: v for k, v in host_config.items() if v is not None}}
 
@@ -218,7 +221,7 @@ class ObsidianCliClient:
         if permission_request.get("scope") == OBSIDIAN_PERMISSION_SCOPE and permission_request.get("requested_scope") == OBSIDIAN_LAUNCH_SCOPE:
             self._launch_approved_once = True
 
-    async def run(self, args: list[str], *, open_operation: bool = False) -> ToolResult:
+    async def run(self, args: list[str]) -> ToolResult:
         config = load_obsidian_config(self.env_context)
         ok, error = _validate_config(config)
         if not ok:
@@ -237,7 +240,20 @@ class ObsidianCliClient:
             self._launch_performed_once = True
             await _wait_cli_ready(config)
 
-        code, stdout, stderr = await _run_process([_cli_executable(config), *args])
+        try:
+            code, stdout, stderr = await _run_process([_cli_executable(config), *args])
+        except FileNotFoundError:
+            return ToolResult(
+                success=False,
+                error="Obsidian CLI 未找到。请在 officev3 的 设置-连接数据源 中检测或安装 CLI。",
+            )
+        except PermissionError:
+            return ToolResult(
+                success=False,
+                error=f"Obsidian CLI 无法执行，请检查权限：{_cli_executable(config)}",
+            )
+        except OSError as exc:
+            return ToolResult(success=False, error=f"Obsidian CLI 执行失败：{exc}")
         if code != 0:
             return ToolResult(success=False, error=stderr or stdout or f"Obsidian CLI 退出码 {code}")
         return ToolResult(success=True, content=stdout or "Obsidian 操作已完成。", raw_output={"argv": args})
@@ -288,7 +304,7 @@ class ObsidianCreateNoteTool(_ObsidianToolBase):
             args.append("overwrite")
         if open_after:
             args.append("open")
-        result = await self.client.run(args, open_operation=open_after)
+        result = await self.client.run(args)
         if result.success:
             result.content = f"已创建 Obsidian 笔记：{note_path}"
             result.raw_output = {"path": note_path, "operation": "create"}
@@ -331,14 +347,14 @@ class ObsidianUpdateNoteTool(_ObsidianToolBase):
             args = ["create", f"path={note_path}", f"content={_encode_cli_value(content)}", "overwrite"]
             if open_after:
                 args.append("open")
-            result = await self.client.run(args, open_operation=open_after)
+            result = await self.client.run(args)
         else:
             args = [mode, f"path={note_path}", f"content={_encode_cli_value(content)}"]
             if inline:
                 args.append("inline")
-            result = await self.client.run(args, open_operation=False)
+            result = await self.client.run(args)
             if result.success and open_after:
-                result = await self.client.run(["open", f"path={note_path}"], open_operation=True)
+                result = await self.client.run(["open", f"path={note_path}"])
         if result.success:
             result.content = f"已更新 Obsidian 笔记：{note_path}"
             result.raw_output = {"path": note_path, "operation": mode}
@@ -376,17 +392,17 @@ class ObsidianDailyNoteTool(_ObsidianToolBase):
 
         if action == "open":
             args = ["daily"]
-            result = await self.client.run(args, open_operation=True)
+            result = await self.client.run(args)
         elif action == "read":
             args = ["daily:read"]
-            result = await self.client.run(args, open_operation=False)
+            result = await self.client.run(args)
         else:
             args = [f"daily:{action}", f"content={_encode_cli_value(content or '')}"]
             if inline:
                 args.append("inline")
-            result = await self.client.run(args, open_operation=False)
+            result = await self.client.run(args)
             if result.success and open_after:
-                result = await self.client.run(["daily"], open_operation=True)
+                result = await self.client.run(["daily"])
         if result.success:
             result.raw_output = {"operation": f"daily:{action}"}
         return result

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -25,6 +25,7 @@ from box_agent.tools.jupyter_tool import (
 )
 from box_agent.tools.mcp_loader import load_mcp_tools_async, set_mcp_timeout_config
 from box_agent.tools.memory_tool import MemoryReadTool, MemorySearchTool, MemoryWriteTool
+from box_agent.tools.obsidian_tool import create_obsidian_tools
 from box_agent.tools.plan_tool import PlanReadTool, PlanStore, PlanWriteTool
 from box_agent.tools.runtime import SkillRuntimeContext, build_skill_runtime_context
 from box_agent.tools.schedule_tool import CreateScheduledTaskTool
@@ -272,7 +273,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         allow_full_access: bool = True, non_interactive: bool = False, output=None,
                         llm=None, permission_engine: PermissionEngine | None = None,
                         skill_runtime_context: SkillRuntimeContext | None = None,
-                        use_output_dir: bool = True):
+                        use_output_dir: bool = True, env_context=None):
     """Add workspace-dependent tools
 
     These tools need to know the workspace directory.
@@ -382,6 +383,12 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
         )
     )
     _out(f"{Colors.GREEN}✅ Loaded image generation tool (generate_image){Colors.RESET}")
+
+    # Obsidian tools — host/Vault dependent, so register with workspace tools
+    # before sub-agent so child agents inherit the native Obsidian capability.
+    obsidian_tools = create_obsidian_tools(env_context=env_context)
+    tools.extend(obsidian_tools)
+    _out(f"{Colors.GREEN}✅ Loaded Obsidian tools (obsidian_create_note, obsidian_update_note, obsidian_daily_note){Colors.RESET}")
 
     # Sub-agent tool — must be registered last so it can reference all other tools
     if config.tools.enable_sub_agent and llm is not None:

--- a/tests/test_cli_obsidian.py
+++ b/tests/test_cli_obsidian.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from box_agent.acp.env_context import build_env_context_prompt
+from box_agent.cli import _doctor_obsidian_status_line, build_cli_env_context
+from box_agent.tools.obsidian_tool import OBSIDIAN_APP_ENV, OBSIDIAN_CLI_ENV, OBSIDIAN_CONFIG_ENV
+
+
+def _clear_obsidian_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OBSIDIAN_CLI_ENV, raising=False)
+    monkeypatch.delenv(OBSIDIAN_APP_ENV, raising=False)
+
+
+def _write_obsidian_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: dict) -> Path:
+    config_path = tmp_path / "obsidian.json"
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setenv(OBSIDIAN_CONFIG_ENV, str(config_path))
+    _clear_obsidian_env(monkeypatch)
+    return config_path
+
+
+def _fake_cli(tmp_path: Path) -> Path:
+    cli = tmp_path / "obsidian"
+    cli.write_text("#!/bin/sh\n", encoding="utf-8")
+    cli.chmod(0o755)
+    return cli
+
+
+def _fake_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "Vault"
+    (vault / ".obsidian").mkdir(parents=True)
+    return vault
+
+
+def test_cli_env_context_reads_obsidian_json_and_renders_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _fake_vault(tmp_path)
+    cli = _fake_cli(tmp_path)
+    _write_obsidian_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "enabled": True,
+            "vault_path": str(vault),
+            "vault_name": "工作笔记",
+            "cli_path": str(cli),
+            "cli_available": True,
+            "app_running": False,
+        },
+    )
+
+    ctx = build_cli_env_context()
+
+    assert ctx is not None
+    assert ctx.obsidian is not None
+    assert ctx.obsidian.vault_path == str(vault)
+    out = build_env_context_prompt(ctx)
+    assert "Obsidian 状态" in out
+    assert "`obsidian_create_note`" in out
+    assert "不要用 bash" in out
+
+
+def test_cli_env_context_absent_without_obsidian_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OBSIDIAN_CONFIG_ENV, str(tmp_path / "missing.json"))
+    _clear_obsidian_env(monkeypatch)
+
+    assert build_cli_env_context() is None
+
+
+def test_doctor_obsidian_reports_unconfigured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OBSIDIAN_CONFIG_ENV, str(tmp_path / "missing.json"))
+    _clear_obsidian_env(monkeypatch)
+
+    assert "not configured" in _doctor_obsidian_status_line()
+
+
+def test_doctor_obsidian_reports_non_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    not_vault = tmp_path / "not-vault"
+    not_vault.mkdir()
+    cli = _fake_cli(tmp_path)
+    _write_obsidian_config(
+        tmp_path,
+        monkeypatch,
+        {"enabled": True, "vault_path": str(not_vault), "cli_path": str(cli)},
+    )
+
+    line = _doctor_obsidian_status_line()
+
+    assert "❌ Obsidian" in line
+    assert ".obsidian" in line
+
+
+def test_doctor_obsidian_reports_missing_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = _fake_cli(tmp_path)
+    _write_obsidian_config(
+        tmp_path,
+        monkeypatch,
+        {"enabled": True, "vault_path": str(tmp_path / "missing-vault"), "cli_path": str(cli)},
+    )
+
+    line = _doctor_obsidian_status_line()
+
+    assert "❌ Obsidian" in line
+    assert "Vault missing" in line
+
+
+def test_doctor_obsidian_reports_missing_cli(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _fake_vault(tmp_path)
+    _write_obsidian_config(
+        tmp_path,
+        monkeypatch,
+        {"enabled": True, "vault_path": str(vault), "cli_path": "definitely-missing-obsidian-cli"},
+    )
+
+    line = _doctor_obsidian_status_line()
+
+    assert "❌ Obsidian" in line
+    assert "CLI not found" in line
+
+
+def test_doctor_obsidian_reports_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _fake_vault(tmp_path)
+    cli = _fake_cli(tmp_path)
+    _write_obsidian_config(
+        tmp_path,
+        monkeypatch,
+        {"enabled": True, "vault_path": str(vault), "vault_name": "工作笔记", "cli_path": str(cli)},
+    )
+
+    line = _doctor_obsidian_status_line()
+
+    assert "✅ Obsidian" in line
+    assert "工作笔记" in line
+    assert str(cli) in line

--- a/tests/test_env_context.py
+++ b/tests/test_env_context.py
@@ -71,6 +71,32 @@ def test_from_meta_parses_runtimes() -> None:
     assert ctx.runtimes["python"].sandbox_path == "/opt/officev3/sandbox-python"
 
 
+def test_from_meta_parses_obsidian_state() -> None:
+    ctx = EnvContext.from_meta(
+        {
+            "obsidian": {
+                "enabled": True,
+                "vault_path": "/Users/me/Vault",
+                "vault_name": "工作笔记",
+                "cli_path": "/usr/local/bin/obsidian",
+                "app_path": "/Applications/Obsidian.app",
+                "cli_available": True,
+                "app_running": False,
+                "ignored": "not rendered",
+            }
+        }
+    )
+    assert ctx is not None
+    assert ctx.obsidian is not None
+    assert ctx.obsidian.enabled is True
+    assert ctx.obsidian.vault_path == "/Users/me/Vault"
+    assert ctx.obsidian.vault_name == "工作笔记"
+    assert ctx.obsidian.cli_path == "/usr/local/bin/obsidian"
+    assert ctx.obsidian.app_path == "/Applications/Obsidian.app"
+    assert ctx.obsidian.cli_available is True
+    assert ctx.obsidian.app_running is False
+
+
 def test_from_meta_passthrough_unknown_keys() -> None:
     raw = {
         "platform": "linux",
@@ -214,6 +240,30 @@ def test_prompt_renders_memory_configured() -> None:
 
     ctx_pending = EnvContext.from_meta({"memory_configured": False})
     assert "未完成" in build_env_context_prompt(ctx_pending)
+
+
+def test_prompt_renders_obsidian_policy() -> None:
+    ctx = EnvContext.from_meta(
+        {
+            "obsidian": {
+                "enabled": True,
+                "vault_path": "/Users/me/Vault",
+                "vault_name": "工作笔记",
+                "cli_path": "/usr/local/bin/obsidian",
+                "cli_available": True,
+                "app_running": True,
+            }
+        }
+    )
+
+    out = build_env_context_prompt(ctx)
+
+    assert "Obsidian 状态" in out
+    assert "enabled=true" in out
+    assert "工作笔记" in out
+    assert "`/Users/me/Vault`" in out
+    assert "`obsidian_create_note`" in out
+    assert "不要用 bash" in out
 
 
 def test_prompt_includes_truth_anchor_instruction() -> None:

--- a/tests/test_obsidian_tool.py
+++ b/tests/test_obsidian_tool.py
@@ -153,6 +153,28 @@ async def test_non_vault_directory_fails(tmp_path: Path, monkeypatch: pytest.Mon
     assert ".obsidian" in (result.error or "")
 
 
+async def test_missing_bare_cli_returns_friendly_error(
+    tmp_path: Path,
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "enabled": True,
+            "vault_path": str(vault),
+            "cli_path": "definitely-missing-obsidian-cli",
+            "app_running": True,
+        },
+    )
+
+    result = await ObsidianCreateNoteTool().execute(title="t", content="c", open_after=False)
+
+    assert not result.success
+    assert "Obsidian CLI 未找到" in (result.error or "")
+
+
 async def test_permission_request_then_retry_launches_app(
     tmp_path: Path,
     vault: Path,

--- a/tests/test_obsidian_tool.py
+++ b/tests/test_obsidian_tool.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from box_agent.tools.obsidian_tool import (
+    OBSIDIAN_CONFIG_ENV,
+    OBSIDIAN_LAUNCH_SCOPE,
+    OBSIDIAN_PERMISSION_SCOPE,
+    ObsidianCreateNoteTool,
+    ObsidianDailyNoteTool,
+    ObsidianUpdateNoteTool,
+)
+from box_agent.tools.skill_loader import SkillLoader
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    path = tmp_path / "Vault"
+    (path / ".obsidian").mkdir(parents=True)
+    return path
+
+
+@pytest.fixture
+def cli(tmp_path: Path) -> Path:
+    path = tmp_path / "obsidian"
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def write_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: dict) -> Path:
+    config_path = tmp_path / "obsidian.json"
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setenv(OBSIDIAN_CONFIG_ENV, str(config_path))
+    return config_path
+
+
+async def test_create_note_invokes_cli_with_safe_argv(
+    tmp_path: Path,
+    vault: Path,
+    cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_config(tmp_path, monkeypatch, {"enabled": True, "vault_path": str(vault), "cli_path": str(cli), "app_running": True})
+    calls: list[list[str]] = []
+
+    async def fake_run_process(args: list[str], timeout: int = 60):
+        calls.append(args)
+        return 0, "ok", ""
+
+    monkeypatch.setattr("box_agent.tools.obsidian_tool._run_process", fake_run_process)
+
+    result = await ObsidianCreateNoteTool().execute(
+        title="今日 TODO",
+        content="- [ ] 写测试\n- [ ] 发报告",
+        folder="Daily",
+        open_after=True,
+    )
+
+    assert result.success
+    assert calls == [[
+        str(cli),
+        "create",
+        "path=Daily/今日 TODO.md",
+        "content=- [ ] 写测试\\n- [ ] 发报告",
+        "open",
+    ]]
+    assert result.raw_output == {"path": "Daily/今日 TODO.md", "operation": "create"}
+
+
+async def test_update_note_append_then_open(
+    tmp_path: Path,
+    vault: Path,
+    cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_config(tmp_path, monkeypatch, {"enabled": True, "vault_path": str(vault), "cli_path": str(cli), "app_running": True})
+    calls: list[list[str]] = []
+
+    async def fake_run_process(args: list[str], timeout: int = 60):
+        calls.append(args)
+        return 0, "", ""
+
+    monkeypatch.setattr("box_agent.tools.obsidian_tool._run_process", fake_run_process)
+
+    result = await ObsidianUpdateNoteTool().execute(
+        path="Notes/weekly.md",
+        content="补充内容",
+        mode="append",
+        inline=True,
+        open_after=True,
+    )
+
+    assert result.success
+    assert calls == [
+        [str(cli), "append", "path=Notes/weekly.md", "content=补充内容", "inline"],
+        [str(cli), "open", "path=Notes/weekly.md"],
+    ]
+
+
+async def test_daily_note_append_then_open(
+    tmp_path: Path,
+    vault: Path,
+    cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_config(tmp_path, monkeypatch, {"enabled": True, "vault_path": str(vault), "cli_path": str(cli), "app_running": True})
+    calls: list[list[str]] = []
+
+    async def fake_run_process(args: list[str], timeout: int = 60):
+        calls.append(args)
+        return 0, "", ""
+
+    monkeypatch.setattr("box_agent.tools.obsidian_tool._run_process", fake_run_process)
+
+    result = await ObsidianDailyNoteTool().execute(action="append", content="- [ ] 今日待办")
+
+    assert result.success
+    assert calls == [
+        [str(cli), "daily:append", "content=- [ ] 今日待办"],
+        [str(cli), "daily"],
+    ]
+
+
+async def test_rejects_unsafe_paths() -> None:
+    tool = ObsidianUpdateNoteTool()
+
+    for path in ("/tmp/x.md", "../x.md", "x.txt", "folder/../x.md"):
+        result = await tool.execute(path=path, content="content")
+        assert not result.success
+
+
+async def test_missing_vault_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cli: Path) -> None:
+    write_config(tmp_path, monkeypatch, {"enabled": True, "vault_path": str(tmp_path / "missing"), "cli_path": str(cli)})
+
+    result = await ObsidianCreateNoteTool().execute(title="t", content="c", open_after=False)
+
+    assert not result.success
+    assert "Vault" in (result.error or "")
+
+
+async def test_non_vault_directory_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cli: Path) -> None:
+    not_vault = tmp_path / "not-vault"
+    not_vault.mkdir()
+    write_config(tmp_path, monkeypatch, {"enabled": True, "vault_path": str(not_vault), "cli_path": str(cli)})
+
+    result = await ObsidianCreateNoteTool().execute(title="t", content="c", open_after=False)
+
+    assert not result.success
+    assert ".obsidian" in (result.error or "")
+
+
+async def test_permission_request_then_retry_launches_app(
+    tmp_path: Path,
+    vault: Path,
+    cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_config(tmp_path, monkeypatch, {"enabled": True, "vault_path": str(vault), "cli_path": str(cli), "app_running": False})
+    calls: list[list[str]] = []
+    launched: list[bool] = []
+
+    async def fake_run_process(args: list[str], timeout: int = 60):
+        calls.append(args)
+        return 0, "ok", ""
+
+    async def fake_launch(_config: dict):
+        launched.append(True)
+        return True, ""
+
+    async def fake_wait(_config: dict, timeout: float = 30.0):
+        return True
+
+    monkeypatch.setattr("box_agent.tools.obsidian_tool._run_process", fake_run_process)
+    monkeypatch.setattr("box_agent.tools.obsidian_tool._launch_obsidian", fake_launch)
+    monkeypatch.setattr("box_agent.tools.obsidian_tool._wait_cli_ready", fake_wait)
+
+    tool = ObsidianCreateNoteTool()
+    first = await tool.execute(title="t", content="c")
+
+    assert not first.success
+    assert first.permission_request is not None
+    assert first.permission_request["scope"] == OBSIDIAN_PERMISSION_SCOPE
+    assert first.permission_request["requested_scope"] == OBSIDIAN_LAUNCH_SCOPE
+
+    tool.approve_permission_request(first.permission_request)
+    second = await tool.execute(title="t", content="c")
+
+    assert second.success
+    assert launched == [True]
+    assert calls == [[str(cli), "create", "path=t.md", "content=c", "open"]]
+
+
+def test_obsidian_skill_is_discoverable() -> None:
+    skills_dir = Path(__file__).resolve().parent.parent / "box_agent" / "skills"
+    loader = SkillLoader(sources=[(skills_dir, "builtin")])
+    loader.discover_skills()
+
+    assert loader.get_skill("obsidian") is not None
+    assert "obsidian" in loader.list_skills()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from box_agent.tools import BashTool, EditTool, ReadTool, WriteTool
+from box_agent.config import AgentConfig, Config, LLMConfig, ToolsConfig
+from box_agent.tools import BashTool, EditTool, ReadTool, WriteTool, add_workspace_tools
 
 
 @pytest.mark.asyncio
@@ -204,6 +205,58 @@ async def test_bash_tool_allows_setting_lark_cli_env_without_invoking_cli():
     result = await tool.execute(command='export BOX_AGENT_LARK_CLI=/tmp/lark-cli')
 
     assert result.success
+
+
+@pytest.mark.asyncio
+async def test_bash_tool_blocks_direct_obsidian_write_commands():
+    tool = BashTool()
+
+    for command in [
+        "obsidian create path=t.md content=hi",
+        "/usr/local/bin/obsidian append path=t.md content=hi",
+        "$BOX_AGENT_OBSIDIAN_CLI open path=t.md",
+        "obsidian daily:append content=hi",
+    ]:
+        result = await tool.execute(command=command)
+        assert not result.success
+        assert "obsidian_create_note" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_bash_tool_allows_obsidian_diagnostics():
+    tool = BashTool()
+
+    for command in [
+        "which obsidian",
+        "obsidian help",
+        "obsidian version",
+    ]:
+        result = await tool.execute(command=command)
+        # The command may fail when Obsidian CLI is not installed; the point is
+        # that BashTool itself must not block diagnostics with the native-tool policy.
+        assert "Blocked:" not in (result.error or "")
+
+
+def test_add_workspace_tools_registers_obsidian_tools(tmp_path: Path):
+    tools = []
+
+    add_workspace_tools(
+        tools,
+        Config(
+            llm=LLMConfig(api_key="test-key"),
+            agent=AgentConfig(workspace_dir=str(tmp_path)),
+            tools=ToolsConfig(enable_mcp=False),
+        ),
+        tmp_path,
+        allow_full_access=False,
+        output=lambda *_: None,
+        llm=None,
+    )
+
+    names = {tool.name for tool in tools}
+    assert "obsidian_create_note" in names
+    assert "obsidian_update_note" in names
+    assert "obsidian_daily_note" in names
 
 
 async def main():


### PR DESCRIPTION
## Summary
- 新增 Obsidian 原生工具：create/update/daily note，通过官方 CLI 写入和打开笔记
- 新增 Obsidian skill 和 env_context 注入，让本地 Agent 能稳定选择 obsidian_* 工具
- 拦截 bash 直接调用写入/打开类 obsidian CLI 命令，保留 help/version/which 诊断命令

## Tests
- uv run pytest tests/test_obsidian_tool.py tests/test_env_context.py tests/test_tools.py -q