### PR TITLE
fix(mcp): 补齐 Windows stdio MCP 子进程遗漏的系统环境变量

### DIFF
--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 import sys
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
@@ -337,9 +338,80 @@ class MCPServerConnection:
             traceback.print_exc()
             return False
 
+    # Windows system variables that non-trivial CLIs (ssh.exe, git.exe, etc.)
+    # rely on during early process init but that the MCP SDK's default env
+    # allowlist (``mcp.client.stdio.DEFAULT_INHERITED_ENV_VARS``) does not
+    # include. Supplementing these fixed sshmcp startup on Windows; the SDK's
+    # allowlist covers PATH / APPDATA / SYSTEMROOT / ... but omits e.g.
+    # ``ComSpec`` and ``ProgramData``, which ssh's DLL init path resolves.
+    #
+    # Casing note: Windows itself treats env-var names case-insensitively, so
+    # the exact spelling below is only a readability convention — we do NOT
+    # depend on any casing invariant surviving into CreateProcess. An earlier
+    # revision of this code tried to enforce single-casing on both sides of
+    # the SDK's merge; that was found to be unnecessary and has been removed.
+    _WINDOWS_ENV_SUPPLEMENT = (
+        "windir",
+        "ComSpec",
+        "ProgramData",
+        "ALLUSERSPROFILE",
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramW6432",
+        "USERDOMAIN",
+    )
+
+    def _build_stdio_env(self) -> dict[str, str] | None:
+        """Build the ``env`` argument passed to ``StdioServerParameters``.
+
+        Windows-only fix. On macOS and Linux the behavior is unchanged: we
+        return the server's own ``env`` (or ``None`` so the SDK applies its
+        default inherited-env allowlist).
+
+        On Windows the MCP SDK's ``get_default_environment()`` allowlist is
+        conservative and omits several variables that non-trivial CLIs read
+        at startup — see ``_WINDOWS_ENV_SUPPLEMENT`` above. Without them,
+        ssh.exe (as launched by sshmcp) exits before emitting any output and
+        the MCP loader only sees the stdout pipe close. We supplement those
+        variables from the host process's own environment; ``os.environ``
+        lookups on Windows are case-insensitive, so we don't chase casing.
+
+        Important interaction with the SDK: ``stdio_client()`` re-merges the
+        env we return as ``{**get_default_environment(), **server.env}``
+        (see ``mcp/client/stdio/__init__.py``). That means:
+
+          1. Server-specific ``env`` entries from ``mcp.json`` win over both
+             the SDK defaults and our supplement (Python dict merge order).
+          2. Supplemented variables end up in the final env because the SDK
+             defaults don't declare them, so nothing overrides them.
+
+        The regression test in ``tests/test_mcp.py`` exercises the SDK's
+        merge and asserts the final env shape, so future SDK changes to
+        that merge order are caught in CI.
+        """
+        if sys.platform != "win32":
+            return self.env if self.env else None
+
+        # Start from the server's env from mcp.json — its keys will remain
+        # ours to override once the SDK re-merges with its defaults.
+        env: dict[str, str] = dict(self.env or {})
+
+        for name in self._WINDOWS_ENV_SUPPLEMENT:
+            value = os.environ.get(name)
+            if value is None:
+                continue
+            # Respect a case-variant already supplied via mcp.json; users
+            # who set ``PROGRAMDATA=...`` explicitly should not be shadowed
+            # by our CamelCase copy.
+            if any(k.lower() == name.lower() for k in env):
+                continue
+            env[name] = value
+
+        return env or None
+
     async def _connect_stdio(self):
         """Connect via STDIO transport."""
-        server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env if self.env else None)
+        server_params = StdioServerParameters(command=self.command, args=self.args, env=self._build_stdio_env())
         return await self.exit_stack.enter_async_context(stdio_client(server_params))
 
     async def _connect_sse(self):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -200,6 +201,156 @@ class TestMCPServerConnectionInit:
         assert conn.connect_timeout == 15.0
         assert conn.execute_timeout == 90.0
         assert conn.sse_read_timeout == 180.0
+
+
+# =============================================================================
+# Windows stdio env supplement tests
+# =============================================================================
+
+
+class TestStdioEnvBuild:
+    """Cover ``MCPServerConnection._build_stdio_env`` on both platforms.
+
+    The unit-level checks pin the return value we produce. The integration
+    checks then simulate the MCP SDK's ``{**get_default_environment(),
+    **server.env}`` merge to prove the final env handed to CreateProcess
+    contains the variables we care about — this is what actually gets a
+    Windows stdio MCP server started, and it's the invariant that must
+    survive future SDK changes.
+    """
+
+    def _fake_default_env(self):
+        # Mirrors ``mcp.client.stdio.DEFAULT_INHERITED_ENV_VARS`` on Windows
+        # closely enough for the merge behavior we care about.
+        return {
+            "APPDATA": r"C:\Users\test\AppData\Roaming",
+            "HOMEDRIVE": "C:",
+            "HOMEPATH": r"\Users\test",
+            "LOCALAPPDATA": r"C:\Users\test\AppData\Local",
+            "PATH": r"C:\Windows\System32",
+            "PATHEXT": ".COM;.EXE;.BAT",
+            "PROCESSOR_ARCHITECTURE": "AMD64",
+            "SYSTEMDRIVE": "C:",
+            "SYSTEMROOT": r"C:\Windows",
+            "TEMP": r"C:\Users\test\AppData\Local\Temp",
+            "USERNAME": "test",
+            "USERPROFILE": r"C:\Users\test",
+        }
+
+    def _final_sdk_env(self, server_env):
+        """Simulate ``stdio_client``'s env merge for a Windows spawn."""
+        default = self._fake_default_env()
+        return {**default, **server_env} if server_env is not None else default
+
+    def test_non_windows_returns_server_env_untouched(self, monkeypatch):
+        """macOS/Linux path must not diverge from the pre-fix baseline."""
+        monkeypatch.setattr("box_agent.tools.mcp_loader.sys.platform", "linux")
+
+        conn = MCPServerConnection(name="ssh", command="ssh", env={"FOO": "bar"})
+        assert conn._build_stdio_env() == {"FOO": "bar"}
+
+        # Empty env → None so the SDK applies its own default allowlist.
+        conn_empty = MCPServerConnection(name="ssh", command="ssh", env={})
+        assert conn_empty._build_stdio_env() is None
+
+    def test_windows_supplements_missing_system_vars(self, monkeypatch):
+        """Windows path adds vars the SDK allowlist misses (ComSpec etc.)."""
+        monkeypatch.setattr("box_agent.tools.mcp_loader.sys.platform", "win32")
+        # Only the variables our supplement covers — plus a distractor
+        # that must NOT be pulled in blindly.
+        fake_os_env = {
+            "windir": r"C:\Windows",
+            "ComSpec": r"C:\Windows\System32\cmd.exe",
+            "ProgramData": r"C:\ProgramData",
+            "ALLUSERSPROFILE": r"C:\ProgramData",
+            "ProgramFiles": r"C:\Program Files",
+            "ProgramFiles(x86)": r"C:\Program Files (x86)",
+            "ProgramW6432": r"C:\Program Files",
+            "USERDOMAIN": "TESTDOMAIN",
+            "SECRETS_NOT_INHERITED": "should-not-leak",
+        }
+        monkeypatch.setattr("box_agent.tools.mcp_loader.os.environ", fake_os_env)
+
+        conn = MCPServerConnection(name="ssh", command="ssh", env={})
+        built = conn._build_stdio_env()
+        assert built is not None
+        # Every supplement entry present.
+        for name in MCPServerConnection._WINDOWS_ENV_SUPPLEMENT:
+            assert built[name] == fake_os_env[name], name
+        # Only the allowlisted supplement leaked through; nothing else.
+        assert "SECRETS_NOT_INHERITED" not in built
+
+    def test_windows_final_env_after_sdk_merge_has_all_vars(self, monkeypatch):
+        """End-to-end: after the SDK re-merges, the final env is sufficient.
+
+        This is the invariant that matters for CreateProcess. If the SDK ever
+        changes its default allowlist or merge order, this catches it.
+        """
+        monkeypatch.setattr("box_agent.tools.mcp_loader.sys.platform", "win32")
+        fake_os_env = {
+            "windir": r"C:\Windows",
+            "ComSpec": r"C:\Windows\System32\cmd.exe",
+            "ProgramData": r"C:\ProgramData",
+            "ALLUSERSPROFILE": r"C:\ProgramData",
+            "ProgramFiles": r"C:\Program Files",
+            "ProgramFiles(x86)": r"C:\Program Files (x86)",
+            "ProgramW6432": r"C:\Program Files",
+            "USERDOMAIN": "TESTDOMAIN",
+        }
+        monkeypatch.setattr("box_agent.tools.mcp_loader.os.environ", fake_os_env)
+
+        conn = MCPServerConnection(name="ssh", command="ssh", env={"MY_VAR": "yes"})
+        server_env = conn._build_stdio_env()
+        final = self._final_sdk_env(server_env)
+
+        # SDK defaults still land (nothing above should have shadowed them).
+        assert final["SYSTEMROOT"] == r"C:\Windows"
+        assert final["PATH"] == r"C:\Windows\System32"
+        # Our supplement lands.
+        for name in MCPServerConnection._WINDOWS_ENV_SUPPLEMENT:
+            assert final[name] == fake_os_env[name], name
+        # Server-specific mcp.json env wins.
+        assert final["MY_VAR"] == "yes"
+
+    def test_windows_user_env_wins_over_supplement(self, monkeypatch):
+        """User-supplied ``env`` in mcp.json must not be shadowed by us."""
+        monkeypatch.setattr("box_agent.tools.mcp_loader.sys.platform", "win32")
+        monkeypatch.setattr(
+            "box_agent.tools.mcp_loader.os.environ",
+            {"ComSpec": r"C:\Windows\System32\cmd.exe"},
+        )
+        # Explicit user override, both same casing and a lower-case variant.
+        conn = MCPServerConnection(
+            name="ssh",
+            command="ssh",
+            env={"ComSpec": r"C:\custom\shell.exe"},
+        )
+        built = conn._build_stdio_env()
+        assert built["ComSpec"] == r"C:\custom\shell.exe"
+
+        # Case-variant supplied by user: we must not re-add our CamelCase
+        # copy on top (would leave two entries pointing at different values).
+        conn2 = MCPServerConnection(
+            name="ssh",
+            command="ssh",
+            env={"COMSPEC": r"C:\custom\shell.exe"},
+        )
+        built2 = conn2._build_stdio_env()
+        # Only one case variant remains — the user's — with their value.
+        comspec_keys = [k for k in built2 if k.lower() == "comspec"]
+        assert comspec_keys == ["COMSPEC"]
+        assert built2["COMSPEC"] == r"C:\custom\shell.exe"
+
+    def test_windows_missing_host_vars_are_silently_skipped(self, monkeypatch):
+        """A minimal host env (e.g. CI runner) must not crash env-build."""
+        monkeypatch.setattr("box_agent.tools.mcp_loader.sys.platform", "win32")
+        monkeypatch.setattr("box_agent.tools.mcp_loader.os.environ", {})
+
+        conn = MCPServerConnection(name="ssh", command="ssh", env={})
+        # Empty user env + no host vars → None, so the SDK applies its own
+        # defaults unmodified. This preserves the pre-fix behavior on hosts
+        # where none of our supplement variables exist.
+        assert conn._build_stdio_env() is None
 
 
 # =============================================================================


### PR DESCRIPTION
sshmcp 在 Windows 上启动失败：ssh.exe 早期 DLL init 会读 windir、 ComSpec、ProgramData、ProgramFiles* 等系统环境变量，而 MCP SDK 的 DEFAULT_INHERITED_ENV_VARS 默认 allowlist 偏保守没包含它们。子进程 拉起后立刻退出，loader 只看到 stdout 管道被关闭。

本次只在 Windows 上把这些遗漏的变量从宿主进程补进传给
StdioServerParameters 的 env。macOS / Linux 完全不变；mcp.json 里 用户显式设的 env（任意大小写）优先。

回归测试模拟 SDK 侧 `{**get_default_environment(), **server.env}` 合并，断言最终传给 CreateProcess 的 env 形态，SDK 默认列表或合并
顺序未来变动会在 CI 上被立刻发现。

## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
