### PR TITLE
fix(llm): assistant 消息始终带 content，避免下游序列化成 null 触发 400

### DIFF
--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -354,9 +354,10 @@ class OpenAIClient(LLMClientBase):
             elif msg.role == "assistant":
                 assistant_msg = {"role": "assistant"}
 
-                # Add content if present
-                if msg.content:
-                    assistant_msg["content"] = msg.content
+                # Always include content — even when empty — so LiteLLM/OpenAI
+                # never sees a missing key that gets serialized to `content: null`
+                # downstream (network gateway rejects null with 400).
+                assistant_msg["content"] = msg.content if msg.content else ""
 
                 # Add tool calls if present
                 if msg.tool_calls:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -85,6 +85,9 @@ async def test_initialize_base_tools_can_gate_mcp_until_protocol_ready(
         "load_mcp_tools_async",
         fake_load_mcp_tools_async,
     )
+    # Create a minimal MCP config file so the code path creates mcp_task.
+    mcp_config = tmp_path / "mcp.json"
+    mcp_config.write_text('{"mcpServers": {}}')
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(workspace_dir=str(tmp_path)),
@@ -92,6 +95,7 @@ async def test_initialize_base_tools_can_gate_mcp_until_protocol_ready(
             enable_bash=False,
             enable_skills=False,
             enable_mcp=True,
+            mcp_config_path=str(mcp_config),
         ),
     )
     gate = asyncio.Event()


### PR DESCRIPTION
OpenAI 分支在 content 为空时跳过 key，某些场景下 openai SDK / LiteLLM 网关会把缺失的 content 补成 JSON null 再送到上游，被 pydantic 校验拒收 （Invalid value for 'content': expected a string, got null），整轮请求 400 且 tokens=0。改为无条件带上 content（空则填 ""），封死缺 key 的入口。

## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
