### PR TITLE
fix: keep memory maintenance from blocking ACP

### DIFF
--- a/box_agent/memory.py
+++ b/box_agent/memory.py
@@ -10,15 +10,19 @@ Directory layout::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
+import threading
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from functools import wraps
 from pathlib import Path
 from time import monotonic
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator
 
 if TYPE_CHECKING:
     from .schema import Message
@@ -477,6 +481,17 @@ class TopicStore:
         }
 
 
+def _serialized_context(method):
+    """Run one complete context-memory operation under the manager transaction."""
+
+    @wraps(method)
+    def wrapped(self, *args, **kwargs):
+        with self.context_transaction():
+            return method(self, *args, **kwargs)
+
+    return wrapped
+
+
 class MemoryManager:
     """Two-tier memory: MEMORY.md (core) + topic-sharded searchable context.
 
@@ -504,6 +519,7 @@ class MemoryManager:
         self.memory_dir = Path(memory_dir).expanduser()
         self.memory_dir.mkdir(parents=True, exist_ok=True)
         self.dedup_jaccard_threshold = dedup_jaccard_threshold
+        self._context_transaction_lock = threading.RLock()
 
         # v2 is an overlay, not a migration.  New context/experience writes go
         # here; old context files remain untouched and are searched only as a
@@ -518,6 +534,13 @@ class MemoryManager:
         self._ensure_v2_state()
         self._topic_store.ensure_index()
         self.refresh_memory_summary()
+
+    @contextmanager
+    def context_transaction(self) -> Iterator[None]:
+        """Serialize a complete context-memory read-modify-write transaction."""
+
+        with self._context_transaction_lock:
+            yield
 
     # ── File paths ──────────────────────────────────────────────
 
@@ -635,6 +658,7 @@ class MemoryManager:
             return ""
         return "\n".join(e.content for e in entries).strip()
 
+    @_serialized_context
     def write_context(self, content: str, *, topic: str = "general") -> None:
         """Overwrite context entries for *topic* with *content*.
 
@@ -653,6 +677,7 @@ class MemoryManager:
         all_entries.extend(replacement)
         self._write_context_entries(all_entries)
 
+    @_serialized_context
     def append_context(self, content: str, *, topic: str = "general") -> None:
         """Append to CONTEXT.md, skipping lines already present in Core or Context.
 
@@ -736,10 +761,12 @@ class MemoryManager:
         self._topic_store.write_topics(entries)
         self.refresh_memory_summary()
 
+    @_serialized_context
     def read_all_context_entries(self) -> list[ContextEntry]:
         """Public: read every context entry across all topics."""
         return self._topic_store.read_all()
 
+    @_serialized_context
     def write_all_context_entries(self, entries: list[ContextEntry]) -> None:
         """Public: replace all context entries (sharded by ``entry.topic``)."""
         self._topic_store.write_all(entries)
@@ -896,6 +923,7 @@ class MemoryManager:
 
     # ── Search ──────────────────────────────────────────────────
 
+    @_serialized_context
     def search(self, query: str, *, limit: int = 5, topic: str | None = None) -> list[str]:
         """Keyword search across v2 experiences, then legacy fallback.
 
@@ -1241,9 +1269,9 @@ class MemoryManager:
 
         from .schema import Message as Msg
 
-        context = self.read_context()
+        context = await asyncio.to_thread(self.read_context)
         prompt = _CONTEXT_UPDATE_USER_PROMPT.format(
-            core_memory=self.read_core() or "(empty)",
+            core_memory=await asyncio.to_thread(self.read_core) or "(empty)",
             context_memory=context or "(empty)",
             candidate=content.strip(),
         )
@@ -1258,18 +1286,20 @@ class MemoryManager:
             data = json.loads(_strip_json_fences(response.content))
         except Exception:
             logger.exception("Context memory update planning failed; falling back to append")
-            before = self.read_context()
-            self.append_context(content, topic=topic)
-            return "fallback_appended" if self.read_context() != before else "no_change"
+            before = await asyncio.to_thread(self.read_context)
+            await asyncio.to_thread(self.append_context, content, topic=topic)
+            after = await asyncio.to_thread(self.read_context)
+            return "fallback_appended" if after != before else "no_change"
 
         operations = data.get("operations", [])
         # Stamp default topic on add operations that didn't specify one.
         for op in operations:
             if isinstance(op, dict) and op.get("action") == "add" and not op.get("topic"):
                 op["topic"] = topic
-        changed = self.apply_context_operations(operations)
+        changed = await asyncio.to_thread(self.apply_context_operations, operations)
         return "applied" if changed else "no_change"
 
+    @_serialized_context
     def apply_context_operations(self, operations: list[dict]) -> bool:
         """Safely apply model-planned context memory operations.
 
@@ -1405,6 +1435,7 @@ class MemoryManager:
             candidates.append(e)
         return candidates
 
+    @_serialized_context
     def mark_proposed(self, candidate_ids: list[str]) -> None:
         """Bump ``last_proposed`` on the given entries and persist."""
         if not candidate_ids:
@@ -1420,6 +1451,7 @@ class MemoryManager:
         if changed:
             self._write_context_entries(entries)
 
+    @_serialized_context
     def consume_core_proposal(self, decisions: dict[str, str]) -> dict[str, int]:
         """Apply user decisions to promotion candidates.
 
@@ -1588,6 +1620,7 @@ class MemoryManager:
             rationale=rationale,
         )
 
+    @_serialized_context
     def apply_promotion_plan(self, plan: "MemoryPromotionPlan") -> dict[str, int]:
         """Apply *plan*: overwrite MEMORY.md, drop consumed CONTEXT entries.
 
@@ -1602,6 +1635,7 @@ class MemoryManager:
             self._write_context_entries(keep)
         return {"applied": 1, "consumed": removed}
 
+    @_serialized_context
     def reject_promotion_plan(self, plan: "MemoryPromotionPlan") -> dict[str, int]:
         """Mark every consumed candidate ``core_status="rejected"`` (no core change)."""
         consumed_set = set(plan.consumed_entry_ids)
@@ -2292,11 +2326,14 @@ class MemoryExtractor:
 
         transcript = transcript[-6000:]  # Keep last ~6k chars
 
-        core_memory = self._mgr.read_core() or "(empty)"
+        core_memory, context_raw = await asyncio.gather(
+            asyncio.to_thread(self._mgr.read_core),
+            asyncio.to_thread(self._mgr.read_context),
+        )
+        core_memory = core_memory or "(empty)"
 
         # Only send last ~100 lines of Context for dedup reference (not the whole file).
         # Code-level dedup in append_context() handles Core overlap regardless.
-        context_raw = self._mgr.read_context()
         if context_raw:
             context_lines = context_raw.splitlines()
             context_memory = "\n".join(context_lines[-100:])
@@ -2317,7 +2354,12 @@ class MemoryExtractor:
             session_id=self._session_id,
         )
 
-        self._apply_updates(response.content, trigger=trigger, turn_id=turn_id)
+        await asyncio.to_thread(
+            self._apply_updates,
+            response.content,
+            trigger=trigger,
+            turn_id=turn_id,
+        )
 
     def _apply_updates(self, llm_output: str, *, trigger: str, turn_id: str) -> None:
         """Parse LLM JSON output and apply to CONTEXT.md.

--- a/box_agent/memory_maintainer.py
+++ b/box_agent/memory_maintainer.py
@@ -183,6 +183,10 @@ class MemoryMaintainer:
     # ── Phase 1: decay ──────────────────────────────────────────
 
     def _decay(self, now: datetime) -> None:
+        with self._mgr.context_transaction():
+            self._decay_transaction(now)
+
+    def _decay_transaction(self, now: datetime) -> None:
         threshold = now - timedelta(days=self._cfg.memory_decay_days)
         entries = self._mgr.read_all_context_entries()
         if not entries:
@@ -210,6 +214,10 @@ class MemoryMaintainer:
     # ── Phase 2: archive cleanup → trash ────────────────────────
 
     def _cleanup_archive(self, now: datetime) -> None:
+        with self._mgr.context_transaction():
+            self._cleanup_archive_transaction(now)
+
+    def _cleanup_archive_transaction(self, now: datetime) -> None:
         cutoff_days = self._cfg.memory_decay_days + self._cfg.memory_archive_days
         threshold = now - timedelta(days=cutoff_days)
         entries = parse_context_file(self._mgr.archive_file)
@@ -240,6 +248,10 @@ class MemoryMaintainer:
     # ── Phase 3: dedup ──────────────────────────────────────────
 
     def _dedup(self, _now: datetime) -> None:
+        with self._mgr.context_transaction():
+            self._dedup_transaction(_now)
+
+    def _dedup_transaction(self, _now: datetime) -> None:
         threshold = self._cfg.memory_dedup_jaccard
         entries = self._mgr.read_all_context_entries()
         if len(entries) < 2:
@@ -407,50 +419,77 @@ class MemoryMaintainer_Compact:  # placeholder so the file parses; will be inlin
             logger.warning("MemoryMaintainer: compact output invalid; keeping original")
             return
 
-        # Backup before overwrite — dump every topic file we currently have.
         trash_dir = self._mgr.trash_dir / now.strftime("%Y-%m-%d") / "compact"
-        def _backup_context() -> None:
-            trash_dir.mkdir(parents=True, exist_ok=True)
-            stamp = _now_iso_stamp().replace(":", "-")
-            for topic_path in sorted(self._mgr.context_dir.glob("*.md")):
-                backup_path = trash_dir / f"{topic_path.stem}.{stamp}.md"
-                backup_path.write_text(
-                    topic_path.read_text(encoding="utf-8"),
-                    encoding="utf-8",
-                )
+        snapshot_by_id = {e.id: e for e in entries}
+
+        def _commit_compaction() -> tuple[int, int] | None:
+            from .memory import _new_entry as _make_entry
+
+            with self._mgr.context_transaction():
+                current_entries = self._mgr.read_all_context_entries()
+                current_by_id = {e.id: e for e in current_entries}
+
+                # A concurrent replace/drop changes the semantic input that the
+                # LLM saw. Keep current data instead of committing stale output.
+                for entry_id, snapshot in snapshot_by_id.items():
+                    current = current_by_id.get(entry_id)
+                    if current is None or current.content != snapshot.content:
+                        logger.info(
+                            "MemoryMaintainer: compact snapshot changed; "
+                            "keeping current memory"
+                        )
+                        return None
+
+                compacted: list[ContextEntry] = []
+                for item in parsed:
+                    sources = [current_by_id[sid] for sid in item["sources"]]
+                    source_topics = {s.topic or "general" for s in sources}
+                    topic = (
+                        next(iter(source_topics))
+                        if len(source_topics) == 1
+                        else "general"
+                    )
+                    new = _make_entry(item["content"], source="compact", topic=topic)
+                    # Recompute metadata from the locked current state so search
+                    # hits recorded while the LLM was running are not lost.
+                    new.hits = sum(s.hits for s in sources)
+                    new.created = min(s.created for s in sources)
+                    new.last_used = max(s.last_used for s in sources)
+                    new.confidence = max(s.confidence for s in sources)
+                    if any(s.core_status == "rejected" for s in sources):
+                        new.core_status = "rejected"
+                    compacted.append(new)
+
+                # Entries added after the LLM snapshot were never part of its
+                # input and must survive the replacement.
+                concurrent = [
+                    e for e in current_entries if e.id not in snapshot_by_id
+                ]
+                final_entries = compacted + concurrent
+
+                trash_dir.mkdir(parents=True, exist_ok=True)
+                stamp = _now_iso_stamp().replace(":", "-")
+                for topic_path in sorted(self._mgr.context_dir.glob("*.md")):
+                    backup_path = trash_dir / f"{topic_path.stem}.{stamp}.md"
+                    backup_path.write_text(
+                        topic_path.read_text(encoding="utf-8"),
+                        encoding="utf-8",
+                    )
+
+                self._mgr.write_all_context_entries(final_entries)
+                return len(current_entries), len(final_entries)
 
         try:
-            await asyncio.to_thread(_backup_context)
+            committed_counts = await asyncio.to_thread(_commit_compaction)
         except OSError:
             logger.exception("MemoryMaintainer: compact backup failed; aborting")
             return
+        if committed_counts is None:
+            return
 
-        # Build new entries — preserve oldest created + most-recent last_used + max confidence
-        # from source entries; assign fresh ids. If a compacted entry only
-        # consumes one topic, keep it in that topic so topic-routed retrieval
-        # remains useful. Mixed-topic merges fall back to "general".
-        from .memory import _new_entry as _make_entry
-        by_id = {e.id: e for e in entries}
-        new_entries: list[ContextEntry] = []
-        for item in parsed:
-            sources = [by_id[sid] for sid in item["sources"]]
-            source_topics = {s.topic or "general" for s in sources}
-            topic = next(iter(source_topics)) if len(source_topics) == 1 else "general"
-            new = _make_entry(item["content"], source="compact", topic=topic)
-            new.hits = item["hits"]
-            new.created = min(s.created for s in sources)
-            new.last_used = max(s.last_used for s in sources)
-            new.confidence = max(s.confidence for s in sources)
-            # If any source was promoted-rejected, keep that flag so rejected
-            # facts can't sneak back into core through compaction.
-            if any(s.core_status == "rejected" for s in sources):
-                new.core_status = "rejected"
-            new_entries.append(new)
-
-        await asyncio.to_thread(self._mgr.write_all_context_entries, new_entries)
         logger.info(
             "MemoryMaintainer: compacted %d → %d entries (backup_dir=%s)",
-            len(entries), len(new_entries), trash_dir,
+            committed_counts[0], committed_counts[1], trash_dir,
         )
 
 
@@ -638,13 +677,30 @@ class MemoryMaintainer_Conflict:  # placeholder — bound onto MemoryMaintainer 
         if not all_loser_ids:
             return
 
+        snapshot_by_id = {e.id: e for e in entries}
+
         def _apply_conflict_results() -> int:
-            losers = [e for e in entries if e.id in all_loser_ids]
-            kept = [e for e in entries if e.id not in all_loser_ids]
-            existing_archive = parse_context_file(self._mgr.archive_file)
-            write_context_file(self._mgr.archive_file, existing_archive + losers)
-            self._mgr.write_all_context_entries(kept)
-            return len(losers)
+            with self._mgr.context_transaction():
+                current_entries = self._mgr.read_all_context_entries()
+                current_by_id = {e.id: e for e in current_entries}
+                decided_ids = all_loser_ids | winners_touched
+                for entry_id in decided_ids:
+                    snapshot = snapshot_by_id[entry_id]
+                    current = current_by_id.get(entry_id)
+                    if current is None or current.content != snapshot.content:
+                        logger.info(
+                            "MemoryMaintainer: conflict snapshot changed; "
+                            "keeping current memory"
+                        )
+                        return 0
+                losers = [e for e in current_entries if e.id in all_loser_ids]
+                if not losers:
+                    return 0
+                kept = [e for e in current_entries if e.id not in all_loser_ids]
+                existing_archive = parse_context_file(self._mgr.archive_file)
+                write_context_file(self._mgr.archive_file, existing_archive + losers)
+                self._mgr.write_all_context_entries(kept)
+                return len(losers)
 
         loser_count = await asyncio.to_thread(_apply_conflict_results)
         logger.info(

--- a/box_agent/memory_maintainer.py
+++ b/box_agent/memory_maintainer.py
@@ -33,9 +33,11 @@ on change):
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING
 
 from .memory import (
@@ -109,35 +111,78 @@ class MemoryMaintainer:
 
         Returns True if maintenance ran, False if skipped (disabled or
         marker too recent). All phases are best-effort: a failure in one
-        phase is logged and the rest still execute.
+        phase is logged and the rest still execute. Local filesystem and
+        CPU-heavy phases run in worker threads so ACP stdio remains responsive.
         """
         now = datetime.now(timezone.utc)
         if not self._due(now):
             return False
 
-        logger.info("MemoryMaintainer: starting run at %s", now.isoformat())
-        for phase_name, phase in (
-            ("decay", self._decay),
-            ("cleanup_archive", self._cleanup_archive),
-            ("dedup", self._dedup),
-            ("resolve_conflicts", self._resolve_conflicts),
-            ("compact", self._compact),
+        run_started = monotonic()
+        try:
+            entries_before = await asyncio.to_thread(
+                lambda: len(self._mgr.read_all_context_entries())
+            )
+        except Exception:
+            entries_before = -1
+            logger.exception("MemoryMaintainer: failed to count entries before run")
+
+        logger.info(
+            "MemoryMaintainer: run start entries=%d interval_hours=%d",
+            entries_before,
+            self._cfg.memory_maintainer_interval_hours,
+        )
+        phase_durations_ms: dict[str, int] = {}
+        for phase_name, phase, run_in_worker in (
+            ("decay", self._decay, True),
+            ("cleanup_archive", self._cleanup_archive, True),
+            ("dedup", self._dedup, True),
+            ("resolve_conflicts", self._resolve_conflicts, False),
+            ("compact", self._compact, False),
         ):
+            logger.info("MemoryMaintainer: phase start name=%s", phase_name)
+            phase_started = monotonic()
             try:
-                await phase(now)
+                if run_in_worker:
+                    await asyncio.to_thread(phase, now)
+                else:
+                    await phase(now)
             except Exception:
                 logger.exception("MemoryMaintainer: %s phase failed", phase_name)
+            finally:
+                phase_durations_ms[phase_name] = int(
+                    (monotonic() - phase_started) * 1000
+                )
 
         try:
-            self._last_run_marker.write_text(_now_iso_stamp() + "\n", encoding="utf-8")
+            await asyncio.to_thread(
+                self._last_run_marker.write_text,
+                _now_iso_stamp() + "\n",
+                encoding="utf-8",
+            )
         except OSError:
             logger.exception("MemoryMaintainer: could not write last-run marker")
 
+        try:
+            entries_after = await asyncio.to_thread(
+                lambda: len(self._mgr.read_all_context_entries())
+            )
+        except Exception:
+            entries_after = -1
+            logger.exception("MemoryMaintainer: failed to count entries after run")
+
+        logger.info(
+            "MemoryMaintainer: run complete entries=%d->%d duration_ms=%d phase_ms=%s",
+            entries_before,
+            entries_after,
+            int((monotonic() - run_started) * 1000),
+            phase_durations_ms,
+        )
         return True
 
     # ── Phase 1: decay ──────────────────────────────────────────
 
-    async def _decay(self, now: datetime) -> None:
+    def _decay(self, now: datetime) -> None:
         threshold = now - timedelta(days=self._cfg.memory_decay_days)
         entries = self._mgr.read_all_context_entries()
         if not entries:
@@ -164,7 +209,7 @@ class MemoryMaintainer:
 
     # ── Phase 2: archive cleanup → trash ────────────────────────
 
-    async def _cleanup_archive(self, now: datetime) -> None:
+    def _cleanup_archive(self, now: datetime) -> None:
         cutoff_days = self._cfg.memory_decay_days + self._cfg.memory_archive_days
         threshold = now - timedelta(days=cutoff_days)
         entries = parse_context_file(self._mgr.archive_file)
@@ -194,7 +239,7 @@ class MemoryMaintainer:
 
     # ── Phase 3: dedup ──────────────────────────────────────────
 
-    async def _dedup(self, _now: datetime) -> None:
+    def _dedup(self, _now: datetime) -> None:
         threshold = self._cfg.memory_dedup_jaccard
         entries = self._mgr.read_all_context_entries()
         if len(entries) < 2:
@@ -325,7 +370,7 @@ class MemoryMaintainer_Compact:  # placeholder so the file parses; will be inlin
         if not self._cfg.memory_compaction_enabled or self._llm is None:
             return
 
-        entries = self._mgr.read_all_context_entries()
+        entries = await asyncio.to_thread(self._mgr.read_all_context_entries)
         if len(entries) < 2:
             return
 
@@ -364,15 +409,18 @@ class MemoryMaintainer_Compact:  # placeholder so the file parses; will be inlin
 
         # Backup before overwrite — dump every topic file we currently have.
         trash_dir = self._mgr.trash_dir / now.strftime("%Y-%m-%d") / "compact"
-        try:
+        def _backup_context() -> None:
             trash_dir.mkdir(parents=True, exist_ok=True)
-            stamp = _now_iso_stamp()
+            stamp = _now_iso_stamp().replace(":", "-")
             for topic_path in sorted(self._mgr.context_dir.glob("*.md")):
                 backup_path = trash_dir / f"{topic_path.stem}.{stamp}.md"
                 backup_path.write_text(
                     topic_path.read_text(encoding="utf-8"),
                     encoding="utf-8",
                 )
+
+        try:
+            await asyncio.to_thread(_backup_context)
         except OSError:
             logger.exception("MemoryMaintainer: compact backup failed; aborting")
             return
@@ -399,7 +447,7 @@ class MemoryMaintainer_Compact:  # placeholder so the file parses; will be inlin
                 new.core_status = "rejected"
             new_entries.append(new)
 
-        self._mgr.write_all_context_entries(new_entries)
+        await asyncio.to_thread(self._mgr.write_all_context_entries, new_entries)
         logger.info(
             "MemoryMaintainer: compacted %d → %d entries (backup_dir=%s)",
             len(entries), len(new_entries), trash_dir,
@@ -529,11 +577,15 @@ class MemoryMaintainer_Conflict:  # placeholder — bound onto MemoryMaintainer 
         if not self._cfg.memory_conflict_resolution_enabled or self._llm is None:
             return
 
-        entries = self._mgr.read_all_context_entries()
+        entries = await asyncio.to_thread(self._mgr.read_all_context_entries)
         if len(entries) < 2:
             return
 
-        clusters = _cluster_by_jaccard(entries, self._cfg.memory_conflict_cluster_threshold)
+        clusters = await asyncio.to_thread(
+            _cluster_by_jaccard,
+            entries,
+            self._cfg.memory_conflict_cluster_threshold,
+        )
         if not clusters:
             return
 
@@ -586,15 +638,18 @@ class MemoryMaintainer_Conflict:  # placeholder — bound onto MemoryMaintainer 
         if not all_loser_ids:
             return
 
-        losers = [e for e in entries if e.id in all_loser_ids]
-        kept = [e for e in entries if e.id not in all_loser_ids]
+        def _apply_conflict_results() -> int:
+            losers = [e for e in entries if e.id in all_loser_ids]
+            kept = [e for e in entries if e.id not in all_loser_ids]
+            existing_archive = parse_context_file(self._mgr.archive_file)
+            write_context_file(self._mgr.archive_file, existing_archive + losers)
+            self._mgr.write_all_context_entries(kept)
+            return len(losers)
 
-        existing_archive = parse_context_file(self._mgr.archive_file)
-        write_context_file(self._mgr.archive_file, existing_archive + losers)
-        self._mgr.write_all_context_entries(kept)
+        loser_count = await asyncio.to_thread(_apply_conflict_results)
         logger.info(
             "MemoryMaintainer: resolved %d conflict losers across %d winners (clusters scanned=%d)",
-            len(losers), len(winners_touched), len(clusters),
+            loser_count, len(winners_touched), len(clusters),
         )
 
 

--- a/box_agent/tools/memory_tool.py
+++ b/box_agent/tools/memory_tool.py
@@ -7,6 +7,7 @@ memory is searchable on demand.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from .base import Tool, ToolResult
@@ -77,21 +78,29 @@ class MemoryWriteTool(Tool):
         try:
             if category == "context":
                 if mode == "overwrite":
-                    self._mgr.write_context(content, topic=topic)
+                    await asyncio.to_thread(
+                        self._mgr.write_context,
+                        content,
+                        topic=topic,
+                    )
                     strategy = "overwrite"
                 elif self._llm is not None:
                     strategy = await self._mgr.update_context_with_llm(content, self._llm, topic=topic)
                 else:
-                    self._mgr.append_context(content, topic=topic)
+                    await asyncio.to_thread(
+                        self._mgr.append_context,
+                        content,
+                        topic=topic,
+                    )
                     strategy = "append_dedup"
-                current = self._mgr.read_context()
+                current = await asyncio.to_thread(self._mgr.read_context)
                 label = "context"
             else:
                 if mode == "overwrite":
-                    self._mgr.write_core(content)
+                    await asyncio.to_thread(self._mgr.write_core, content)
                 else:
-                    self._mgr.append_core(content)
-                current = self._mgr.read_core()
+                    await asyncio.to_thread(self._mgr.append_core, content)
+                current = await asyncio.to_thread(self._mgr.read_core)
                 label = "core"
                 strategy = mode
 
@@ -131,8 +140,10 @@ class MemoryReadTool(Tool):
 
     async def execute(self) -> ToolResult:
         try:
-            core = self._mgr.read_core()
-            context = self._mgr.read_context()
+            core, context = await asyncio.gather(
+                asyncio.to_thread(self._mgr.read_core),
+                asyncio.to_thread(self._mgr.read_context),
+            )
             if not core and not context:
                 return ToolResult(success=True, content="No long-term memory saved yet.")
 
@@ -200,7 +211,11 @@ class MemorySearchTool(Tool):
 
     async def execute(self, query: str, topic: str | None = None) -> ToolResult:
         try:
-            results = self._mgr.search(query, topic=topic)
+            results = await asyncio.to_thread(
+                self._mgr.search,
+                query,
+                topic=topic,
+            )
             if not results:
                 topic_suffix = f" in topic '{topic}'" if topic else ""
                 return ToolResult(

--- a/tests/test_memory_maintainer.py
+++ b/tests/test_memory_maintainer.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from time import monotonic
 
 import pytest
 
@@ -68,6 +71,57 @@ def _entry(content: str, *, hits: int = 0, last_used_days_ago: int = 0,
 
 
 # ── Decay ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_maintenance_phase_does_not_block_event_loop(
+    mgr: MemoryManager,
+    config: AgentConfig,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_decay(self, now):
+        started.set()
+        assert release.wait(timeout=1.0)
+
+    monkeypatch.setattr(MemoryMaintainer, "_decay", blocking_decay)
+    release_timer = threading.Timer(0.3, release.set)
+    release_timer.start()
+    started_at = monotonic()
+    task = asyncio.create_task(MemoryMaintainer(mgr, config).run_if_due())
+    try:
+        assert await asyncio.to_thread(started.wait, 1.0)
+        assert monotonic() - started_at < 0.15
+        await asyncio.wait_for(task, timeout=2.0)
+    finally:
+        release.set()
+        release_timer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_maintenance_logs_bounded_phase_diagnostics(
+    mgr: MemoryManager,
+    config: AgentConfig,
+    caplog: pytest.LogCaptureFixture,
+):
+    write_context_file(mgr.context_file, [_entry("- diagnostic entry")])
+
+    with caplog.at_level("INFO", logger="box_agent.memory_maintainer"):
+        await MemoryMaintainer(mgr, config).run_if_due()
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "box_agent.memory_maintainer"
+    ]
+    assert any("run start entries=1" in message for message in messages)
+    assert sum("phase start name=" in message for message in messages) == 5
+    assert any(
+        "run complete entries=1->1" in message and "phase_ms=" in message
+        for message in messages
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_maintainer.py
+++ b/tests/test_memory_maintainer.py
@@ -101,6 +101,86 @@ async def test_sync_maintenance_phase_does_not_block_event_loop(
 
 
 @pytest.mark.asyncio
+async def test_maintenance_transaction_preserves_concurrent_append_and_search_hit(
+    mgr: MemoryManager,
+    config: AgentConfig,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stale = _entry("- stale memory", hits=0, last_used_days_ago=60)
+    active = _entry("- active durable memory", hits=0, last_used_days_ago=1)
+    mgr.write_all_context_entries([stale, active])
+
+    maintenance_ready_to_write = threading.Event()
+    allow_maintenance_write = threading.Event()
+    append_started = threading.Event()
+    search_started = threading.Event()
+    original_write_all = mgr.write_all_context_entries
+
+    def paused_maintenance_write(entries):
+        maintenance_ready_to_write.set()
+        assert allow_maintenance_write.wait(timeout=2.0)
+        original_write_all(entries)
+
+    monkeypatch.setattr(mgr, "write_all_context_entries", paused_maintenance_write)
+
+    maintenance_task = asyncio.create_task(
+        MemoryMaintainer(mgr, config).run_if_due()
+    )
+    try:
+        assert await asyncio.to_thread(
+            maintenance_ready_to_write.wait,
+            2.0,
+        )
+
+        def append_in_foreground():
+            append_started.set()
+            mgr.append_context(
+                "- concurrently added memory",
+                topic="project",
+            )
+
+        def search_in_foreground():
+            search_started.set()
+            return mgr.search("active durable memory")
+
+        append_task = asyncio.create_task(asyncio.to_thread(append_in_foreground))
+        search_task = asyncio.create_task(asyncio.to_thread(search_in_foreground))
+        assert await asyncio.to_thread(append_started.wait, 2.0)
+        assert await asyncio.to_thread(search_started.wait, 2.0)
+
+        # Both foreground operations reached the shared transaction boundary
+        # while maintenance still owns it.
+        await asyncio.sleep(0.05)
+        assert not append_task.done()
+        assert not search_task.done()
+
+        allow_maintenance_write.set()
+        search_results = await asyncio.wait_for(search_task, timeout=2.0)
+        await asyncio.wait_for(append_task, timeout=2.0)
+        await asyncio.wait_for(maintenance_task, timeout=2.0)
+    finally:
+        allow_maintenance_write.set()
+
+    entries = mgr.read_all_context_entries()
+    by_content = {entry.content: entry for entry in entries}
+    assert "- stale memory" not in by_content
+    assert "- active durable memory" in by_content
+    assert "- concurrently added memory" in by_content
+    assert by_content["- active durable memory"].hits == 1
+    assert search_results == ["- active durable memory"]
+
+    grouped = mgr.topic_store.read_all_grouped()
+    index = mgr.topic_store.read_index()
+    assert set(index) == set(grouped)
+    for topic, topic_entries in grouped.items():
+        assert index[topic]["count"] == len(topic_entries)
+        assert index[topic]["hits_total"] == sum(e.hits for e in topic_entries)
+        assert index[topic]["last_updated"] == max(
+            e.last_used for e in topic_entries
+        )
+
+
+@pytest.mark.asyncio
 async def test_maintenance_logs_bounded_phase_diagnostics(
     mgr: MemoryManager,
     config: AgentConfig,
@@ -360,6 +440,18 @@ class FakeCompactLLM:
         return FakeLLMResponse(self.response_text)
 
 
+class PausedCompactLLM(FakeCompactLLM):
+    def __init__(self, response_text: str):
+        super().__init__(response_text)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def generate(self, messages, **kwargs):
+        self.started.set()
+        await self.release.wait()
+        return await super().generate(messages, **kwargs)
+
+
 def _maint_cfg(**overrides) -> AgentConfig:
     base = dict(
         memory_maintainer_enabled=True,
@@ -469,6 +561,65 @@ async def test_compact_merges_topics_and_preserves_metadata(memory_dir):
     assert merged.source == "compact"
     # Strong-preference entry untouched in spirit (content + hits preserved).
     assert after["- project uses uv, never use pip"].hits == 12
+
+
+@pytest.mark.asyncio
+async def test_compact_preserves_concurrent_append_and_search_hit(memory_dir):
+    import json as _json
+
+    mgr = MemoryManager(memory_dir=str(memory_dir))
+    a = _new_entry("- alpha durable memory", topic="general")
+    b = _new_entry("- beta retained fact", topic="general")
+    c = _new_entry("- gamma retained fact", topic="general")
+    a.hits = b.hits = c.hits = 1
+    mgr.write_all_context_entries([a, b, c])
+
+    canned = _json.dumps([
+        {
+            "content": "- compacted durable memories",
+            "hits": 3,
+            "sources": [a.id, b.id, c.id],
+        },
+    ])
+    llm = PausedCompactLLM(canned)
+    maintainer = MemoryMaintainer(
+        mgr,
+        _maint_cfg(memory_context_max_entries=2),
+        llm=llm,
+    )
+
+    compact_task = asyncio.create_task(
+        maintainer._compact(datetime.now(timezone.utc))
+    )
+    await asyncio.wait_for(llm.started.wait(), timeout=2.0)
+
+    await asyncio.to_thread(
+        mgr.append_context,
+        "- concurrently added during compaction",
+        topic="project",
+    )
+    assert await asyncio.to_thread(mgr.search, "alpha durable memory") == [
+        "- alpha durable memory"
+    ]
+
+    llm.release.set()
+    await asyncio.wait_for(compact_task, timeout=2.0)
+
+    entries = mgr.read_all_context_entries()
+    by_content = {entry.content: entry for entry in entries}
+    assert set(by_content) == {
+        "- compacted durable memories",
+        "- concurrently added during compaction",
+    }
+    # Three original hits plus the concurrent search hit.
+    assert by_content["- compacted durable memories"].hits == 4
+
+    grouped = mgr.topic_store.read_all_grouped()
+    index = mgr.topic_store.read_index()
+    assert set(index) == set(grouped)
+    assert index["general"]["count"] == 1
+    assert index["general"]["hits_total"] == 4
+    assert index["project"]["count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_tool.py
+++ b/tests/test_memory_tool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -47,6 +49,43 @@ async def test_memory_write_context_without_llm_uses_append_dedup(mgr: MemoryMan
     context = mgr.read_context()
     assert context.lower().count("q2 goal: dashboard") == 1
     assert "team lead: Bob" in context
+
+
+async def test_memory_write_waits_off_loop_for_maintenance_transaction(
+    mgr: MemoryManager,
+):
+    transaction_acquired = threading.Event()
+    release_transaction = threading.Event()
+
+    def hold_maintenance_transaction():
+        with mgr.context_transaction():
+            transaction_acquired.set()
+            assert release_transaction.wait(timeout=2.0)
+
+    holder = asyncio.create_task(
+        asyncio.to_thread(hold_maintenance_transaction)
+    )
+    assert await asyncio.to_thread(transaction_acquired.wait, 2.0)
+
+    write_task = asyncio.create_task(
+        MemoryWriteTool(mgr).execute(
+            "- first-turn concurrent memory",
+            category="context",
+        )
+    )
+    await asyncio.sleep(0)
+
+    loop_responsive = asyncio.Event()
+    asyncio.get_running_loop().call_soon(loop_responsive.set)
+    await asyncio.wait_for(loop_responsive.wait(), timeout=0.1)
+    assert not write_task.done()
+
+    release_transaction.set()
+    result = await asyncio.wait_for(write_task, timeout=2.0)
+    await asyncio.wait_for(holder, timeout=2.0)
+
+    assert result.success is True
+    assert "- first-turn concurrent memory" in mgr.read_context()
 
 
 async def test_memory_search_returns_structured_matches_for_host_ui(mgr: MemoryManager):

--- a/tests/test_pptx_html_export.py
+++ b/tests/test_pptx_html_export.py
@@ -41,6 +41,7 @@ def _run_node(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
     unavailable = (
         "Cannot find module 'playwright'",
+        "Missing dependency: playwright",
         "Executable doesn't exist",
         "Playwright Chromium is not available",
     )
@@ -49,6 +50,25 @@ def _run_node(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
     ):
         pytest.skip("Managed Playwright browser is unavailable")
     return result
+
+
+def test_run_node_skips_when_managed_playwright_dependency_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(globals(), "NODE", "node")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout="",
+            stderr="Missing dependency: playwright\n",
+        ),
+    )
+
+    with pytest.raises(pytest.skip.Exception, match="Managed Playwright browser"):
+        _run_node(Path("unused.js"))
 
 
 def _last_json_object(output: str) -> dict:


### PR DESCRIPTION
## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
