### PR TITLE
fix: harden web search result handling

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -707,6 +707,7 @@ class SessionState:
     source_text: str = ""  # accumulated real user requests for source-bound artifact checks
     pending_completion_gate: CompletionGate | None = None
     waiting_for_user_input: bool = False
+    last_error: str | None = None
 
 
 _MAX_SOURCE_TEXT_ENV_CHARS = 120_000
@@ -1837,7 +1838,17 @@ class BoxACPAgent:
             and state.agent.goal.status == "active"
         ):
             acp_stop_reason = "max_turn_requests"
+        failed = stop_reason == StopReason.ERROR.value
+        # ACP has no generic error stop reason. Keep stopReason protocol-valid
+        # and expose the internal outcome in stable response metadata instead.
         response_meta: dict[str, Any] = {
+            "ok": not failed,
+            "error": (
+                state.last_error or "Agent execution failed."
+                if failed
+                else None
+            ),
+            "lastStopReason": stop_reason,
             "usage": {
                 "totalTokens": turn_total_tokens,
                 "sessionId": billing_session_id,
@@ -2407,6 +2418,7 @@ class BoxACPAgent:
     ) -> str:
         """Consume the shared execution core and translate events to ACP updates."""
         agent = state.agent
+        state.last_error = None
 
         # Clear prompt-level grants at the start of each prompt
         if state.grant_store:
@@ -2972,6 +2984,7 @@ class BoxACPAgent:
 
                     case ErrorEvent(message=msg, is_fatal=True):
                         log.error("error", session_id=session_id, message=msg, is_fatal=True)
+                        state.last_error = msg
                         await self._send(session_id, update_agent_message(text_block(f"Error: {msg}")))
                         # Don't return yet — let the loop consume the subsequent DoneEvent
                         # so the async generator is properly exhausted.

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -45,6 +45,7 @@ from box_agent.agent import (
 )
 from box_agent.config import Config
 from box_agent.completion import build_auto_completion_gate
+from box_agent.events import StopReason
 from box_agent.schema import LLMProvider, Message
 from box_agent.tools.base import Tool
 from box_agent.tools.jupyter_tool import JupyterSandboxTool, SandboxStatusTool
@@ -2197,6 +2198,7 @@ async def run_agent(
         auto_budget_exhausted = False
         auto_no_progress_turns = 0
         auto_no_progress_exhausted = False
+        final_content = ""
         auto_enabled = (
             goal_autopilot_enabled
             and config.agent.goal_autopilot_enabled
@@ -2204,7 +2206,7 @@ async def run_agent(
         )
         auto_started = perf_counter()
         try:
-            await agent.run(
+            final_content = await agent.run(
                 force_plan_start=force_plan_start,
                 completion_gate=completion_gate,
             )
@@ -2231,7 +2233,7 @@ async def run_agent(
                     )
                 )
                 before_signature = goal_autopilot_progress_signature(agent.goal)
-                await agent.run(completion_gate=completion_gate)
+                final_content = await agent.run(completion_gate=completion_gate)
                 after_signature = goal_autopilot_progress_signature(agent.goal)
                 if should_continue_goal_autopilot(agent, agent.last_stop_reason):
                     if after_signature == before_signature:
@@ -2244,6 +2246,9 @@ async def run_agent(
                     ):
                         auto_no_progress_exhausted = True
                         break
+            if agent.last_stop_reason == StopReason.ERROR.value:
+                ok = False
+                error = final_content.strip() or "Agent execution failed."
         except Exception as e:
             ok = False
             error = str(e)

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -191,13 +191,16 @@ def final_summary_wrapup_text(tool_call_count: int) -> str:
     )
 
 
-def final_summary_empty_retry_text(tool_call_count: int) -> str:
+def empty_final_answer_retry_text(tool_call_count: int) -> str:
     return (
-        "The previous natural end produced no visible final answer after a long tool-heavy turn "
-        f"({tool_call_count} visible tool calls). "
+        "The previous natural end produced no visible final answer after using "
+        f"{tool_call_count} visible tool call(s). "
         "Answer the user now with a concise final conclusion. Do not call tools unless the task is impossible "
         "to summarize without one."
     )
+
+
+_EMPTY_FINAL_ANSWER_ERROR = "工具已执行完成，但模型未生成最终答复，请重试。"
 
 
 # Regex to match file references like [foo.png] in tool output.
@@ -418,7 +421,7 @@ _MODEL_CONTEXT_PATH_NAMES = {"qa.json", "html_self_check.json", "visual_review.m
 _MODEL_CONTEXT_PATH_PARTS = {"qa", "rendered", "slides", "vision_inputs"}
 _MODEL_CONTEXT_CONTENT_THRESHOLD = 12_000
 _GENERIC_MODEL_CONTEXT_CHAR_LIMIT = 24_000
-_WEB_SEARCH_MODEL_CONTEXT_CHAR_LIMIT = 48_000
+_WEB_SEARCH_MODEL_CONTEXT_CHAR_LIMIT = 10_000
 
 
 def _strip_plot_data(text: str) -> str:
@@ -461,17 +464,16 @@ def _compact_visible_tool_content_for_model(
 ) -> str:
     """Fallback compaction for tool content before it is appended to history."""
     if tool_name == WEB_SEARCH_TOOL_NAME:
-        # Search depth depends on the model seeing the returned evidence, not
-        # only five title/snippet previews. Keep ordinary structured results
-        # verbatim for the next reasoning step. Only pathological payloads are
-        # bounded here; old tool turns are still compacted later by
-        # ``_micro_compact`` after the model has had a chance to use them.
+        # Search is a discovery step. Large page bodies returned inline by an
+        # MCP server crowd out the synthesis turn and should be fetched later
+        # through a direct page-read tool. Keep the full payload in the visible
+        # tool event/log, but give the model a compact evidence index.
         if len(content) <= _WEB_SEARCH_MODEL_CONTEXT_CHAR_LIMIT:
             return content
         compacted = _compact_web_search_result_for_model(
             content,
-            max_items=12,
-            snippet_limit=2_500,
+            max_items=5,
+            snippet_limit=600,
         )
         if compacted is not None:
             return (
@@ -2241,9 +2243,10 @@ async def run_agent_loop(
     tool_budget_wrapup_injected: set[str] = set()
     visible_tool_call_total = 0
     final_summary_guidance_injected = False
-    final_summary_empty_retry_injected = False
+    empty_final_answer_retry_injected = False
     web_search_seen_queries: set[str] = set()
     web_search_seen_result_keys: set[str] = set()
+    discovered_evidence_urls: set[str] = set()
     verified_evidence_urls: set[str] = set()
     web_search_unique_results = 0
     web_search_duplicate_results = 0
@@ -3103,30 +3106,67 @@ async def run_agent_loop(
                 yield StepEnd(step=step + 1, elapsed_seconds=elapsed, total_elapsed_seconds=total)
                 continue
 
-            if (
-                visible_tool_call_total > FINAL_SUMMARY_TOOL_CALL_THRESHOLD
-                and final_summary_guidance_injected
-                and not final_summary_empty_retry_injected
-                and not response.content.strip()
-            ):
-                final_summary_empty_retry_injected = True
-                retry_text = final_summary_empty_retry_text(visible_tool_call_total)
-                messages.append(Message(role="user", content=format_injected_message(retry_text)))
-                yield InjectedMessageEvent(content=retry_text, injection_id=None, user_visible=False)
+            if visible_tool_call_total > 0 and not response.content.strip():
+                if not empty_final_answer_retry_injected:
+                    empty_final_answer_retry_injected = True
+                    retry_text = empty_final_answer_retry_text(visible_tool_call_total)
+                    messages.append(
+                        Message(role="user", content=format_injected_message(retry_text))
+                    )
+                    yield InjectedMessageEvent(
+                        content=retry_text,
+                        injection_id=None,
+                        user_visible=False,
+                    )
+                    elapsed = perf_counter() - step_start
+                    total = perf_counter() - run_start
+                    if hook_mgr.hooks:
+                        await hook_mgr.fire_step_end(
+                            step=step + 1,
+                            elapsed_seconds=elapsed,
+                            total_elapsed_seconds=total,
+                        )
+                    yield StepEnd(
+                        step=step + 1,
+                        elapsed_seconds=elapsed,
+                        total_elapsed_seconds=total,
+                    )
+                    continue
+
                 elapsed = perf_counter() - step_start
                 total = perf_counter() - run_start
+                _log.error(
+                    "empty final answer after bounded retry: visible_tool_calls=%d request_id=%s",
+                    visible_tool_call_total,
+                    provider_request_id,
+                )
+                _cleanup_incomplete_messages(messages)
                 if hook_mgr.hooks:
                     await hook_mgr.fire_step_end(
                         step=step + 1,
                         elapsed_seconds=elapsed,
                         total_elapsed_seconds=total,
                     )
+                    await hook_mgr.fire_error(
+                        message=_EMPTY_FINAL_ANSWER_ERROR,
+                        is_fatal=True,
+                        exception=None,
+                    )
+                    await hook_mgr.fire_done(
+                        stop_reason=StopReason.ERROR,
+                        final_content=_EMPTY_FINAL_ANSWER_ERROR,
+                    )
                 yield StepEnd(
                     step=step + 1,
                     elapsed_seconds=elapsed,
                     total_elapsed_seconds=total,
                 )
-                continue
+                yield ErrorEvent(message=_EMPTY_FINAL_ANSWER_ERROR, is_fatal=True)
+                yield DoneEvent(
+                    stop_reason=StopReason.ERROR,
+                    final_content=_EMPTY_FINAL_ANSWER_ERROR,
+                )
+                return
 
             elapsed = perf_counter() - step_start
             total = perf_counter() - run_start
@@ -3655,7 +3695,7 @@ async def run_agent_loop(
                 if inspected:
                     web_search_step_structured_results += 1
                 web_search_step_labels.extend(new_labels[:3])
-                verified_evidence_urls.update(_web_search_urls(tc_content))
+                discovered_evidence_urls.update(_web_search_urls(tc_content))
             elif (
                 result.success
                 and workflow_policy is not None
@@ -4109,7 +4149,7 @@ async def run_agent_loop(
                     if inspected:
                         web_search_step_structured_results += 1
                     web_search_step_labels.extend(new_labels[:3])
-                    verified_evidence_urls.update(_web_search_urls(par_content))
+                    discovered_evidence_urls.update(_web_search_urls(par_content))
                 elif (
                     result.success
                     and workflow_policy is not None

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -482,8 +482,8 @@ def _compact_visible_tool_content_for_model(
                 f"Characters returned: {len(content)}\n"
                 f"{compacted}"
             )
-        head_limit = 36_000
-        tail_limit = 8_000
+        head_limit = 7_000
+        tail_limit = 2_000
         return (
             "[Large unstructured web_search result bounded for model history]\n"
             f"Characters returned: {len(content)}\n"
@@ -2246,7 +2246,6 @@ async def run_agent_loop(
     empty_final_answer_retry_injected = False
     web_search_seen_queries: set[str] = set()
     web_search_seen_result_keys: set[str] = set()
-    discovered_evidence_urls: set[str] = set()
     verified_evidence_urls: set[str] = set()
     web_search_unique_results = 0
     web_search_duplicate_results = 0
@@ -3695,7 +3694,7 @@ async def run_agent_loop(
                 if inspected:
                     web_search_step_structured_results += 1
                 web_search_step_labels.extend(new_labels[:3])
-                discovered_evidence_urls.update(_web_search_urls(tc_content))
+                verified_evidence_urls.update(_web_search_urls(tc_content))
             elif (
                 result.success
                 and workflow_policy is not None
@@ -4149,7 +4148,7 @@ async def run_agent_loop(
                     if inspected:
                         web_search_step_structured_results += 1
                     web_search_step_labels.extend(new_labels[:3])
-                    discovered_evidence_urls.update(_web_search_urls(par_content))
+                    verified_evidence_urls.update(_web_search_urls(par_content))
                 elif (
                     result.success
                     and workflow_policy is not None

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -3106,7 +3106,10 @@ async def run_agent_loop(
                 continue
 
             if visible_tool_call_total > 0 and not response.content.strip():
-                if not empty_final_answer_retry_injected:
+                if (
+                    not empty_final_answer_retry_injected
+                    and step + 1 < max_steps
+                ):
                     empty_final_answer_retry_injected = True
                     retry_text = empty_final_answer_retry_text(visible_tool_call_total)
                     messages.append(

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -56,8 +56,10 @@ def _structured_mcp_error_message(content: str) -> str | None:
     if not isinstance(payload, dict) or "error" not in payload:
         return None
     error = payload["error"]
+    if not error:
+        return None
     if isinstance(error, str):
-        return error.strip() or "Tool returned error"
+        return error.strip() or None
     if isinstance(error, dict):
         message = error.get("message")
         if isinstance(message, str) and message.strip():

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -46,6 +46,25 @@ def _warn(msg: str) -> None:
     """Write diagnostic message to stderr (never stdout)."""
     sys.stderr.write(msg + "\n")
 
+
+def _structured_mcp_error_message(content: str) -> str | None:
+    """Recover error envelopes from servers that forget MCP ``isError=true``."""
+    try:
+        payload = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict) or "error" not in payload:
+        return None
+    error = payload["error"]
+    if isinstance(error, str):
+        return error.strip() or "Tool returned error"
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    return "Tool returned error"
+
+
 # Connection type aliases
 ConnectionType = Literal["stdio", "sse", "http", "streamable_http"]
 
@@ -193,8 +212,9 @@ class MCPTool(Tool):
 
             is_error = result.isError if hasattr(result, "isError") else False
 
-            if is_error:
-                err_msg = content_str.strip() or "Tool returned error"
+            structured_error = _structured_mcp_error_message(content_str)
+            if is_error or structured_error:
+                err_msg = structured_error or content_str.strip() or "Tool returned error"
                 return ToolResult(success=False, content=content_str, error=err_msg)
             return ToolResult(success=True, content=content_str, error=None)
 

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -64,7 +64,9 @@ def _structured_mcp_error_message(content: str) -> str | None:
         message = error.get("message")
         if isinstance(message, str) and message.strip():
             return message.strip()
-    return "Tool returned error"
+        if any(error.get(key) not in (None, "", False) for key in ("code", "type")):
+            return "Tool returned error"
+    return None
 
 
 # Connection type aliases

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -361,6 +361,31 @@ class DoneLLM:
         return LLMResponse(content="done", finish_reason="stop")
 
 
+class EmptyFinalAnswerLLM:
+    def __init__(self):
+        self.calls = 0
+
+    async def generate_stream(self, messages, tools=None, **_):
+        self.calls += 1
+        if self.calls == 1:
+            yield StreamEvent(
+                type="finish",
+                finish_reason="tool_use",
+                tool_calls=[
+                    ToolCall(
+                        id="empty-final-echo",
+                        type="function",
+                        function=FunctionCall(
+                            name="echo",
+                            arguments={"text": "evidence"},
+                        ),
+                    )
+                ],
+            )
+            return
+        yield StreamEvent(type="finish", finish_reason="stop")
+
+
 class SkillUsageLLM:
     def __init__(self):
         self.calls = 0
@@ -3426,6 +3451,38 @@ async def test_acp_prompt_response_reports_turn_token_total(tmp_path):
         "turnId": "turn-response-1",
         "turn_id": "turn-response-1",
     }
+
+
+@pytest.mark.asyncio
+async def test_acp_prompt_response_marks_done_error_as_failure(tmp_path):
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_todo=False),
+    )
+    conn = DummyConn()
+    agent = BoxACPAgent(
+        conn,
+        config,
+        EmptyFinalAnswerLLM(),
+        [EchoTool()],
+        "system",
+    )
+
+    session = await agent.newSession(
+        SimpleNamespace(cwd=None, field_meta={"session_mode": "general"})
+    )
+    response = await agent.prompt(
+        SimpleNamespace(
+            sessionId=session.sessionId,
+            prompt=[{"text": "Use echo and summarize the result"}],
+        )
+    )
+
+    assert response.stopReason == "end_turn"
+    assert response.field_meta["ok"] is False
+    assert response.field_meta["error"]
+    assert response.field_meta["lastStopReason"] == "error"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import box_agent.cli as cli
 from box_agent.config import AgentConfig, Config, LLMConfig, ToolsConfig
 from box_agent.schema import FunctionCall, LLMResponse, StreamEvent, ToolCall
+from box_agent.tools.base import Tool, ToolResult
 from box_agent.tools.skill_loader import SkillLoader
 from box_agent.tools.runtime import build_skill_runtime_context, build_skill_runtime_prompt
 from box_agent.tools.setup import add_workspace_tools
@@ -89,6 +90,52 @@ class _PreloadedSkillThenGetSkillLLM(_CaptureStreamLLM):
             return
         yield StreamEvent(type="text", delta="done.")
         yield StreamEvent(type="finish", finish_reason="stop")
+
+
+class _EmptyFinalAnswerLLM:
+    def __init__(self, *args, **kwargs) -> None:
+        self.calls = 0
+
+    async def generate_stream(self, *, messages, **kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            yield StreamEvent(
+                type="finish",
+                finish_reason="tool_use",
+                tool_calls=[
+                    ToolCall(
+                        id="echo-1",
+                        type="function",
+                        function=FunctionCall(
+                            name="echo",
+                            arguments={"text": "evidence"},
+                        ),
+                    )
+                ],
+            )
+            return
+        yield StreamEvent(type="finish", finish_reason="stop")
+
+
+class _EchoTool(Tool):
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def description(self) -> str:
+        return "Echo input"
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        }
+
+    async def execute(self, text: str) -> ToolResult:
+        return ToolResult(success=True, content=text)
 
 
 def test_cli_workspace_tools_receive_self_managed_node_runtime(tmp_path: Path) -> None:
@@ -247,3 +294,65 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
         "Follow its system instructions directly."
     ]
     assert "# PPTX FULL RULES" not in tool_messages[0]
+
+
+def test_cli_task_returns_failure_for_done_error(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("api_key: test\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(
+            max_steps=3,
+            workspace_dir=str(workspace),
+            enable_memory=False,
+            enable_memory_extraction=False,
+            memory_maintainer_enabled=False,
+            memory_promotion_proposal_enabled=False,
+        ),
+        tools=ToolsConfig(
+            enable_file_tools=False,
+            enable_bash=False,
+            enable_todo=False,
+            enable_plan=False,
+            enable_sub_agent=False,
+            enable_mcp=False,
+            enable_skills=False,
+            allow_full_access=True,
+        ),
+    )
+    async def fake_initialize_base_tools(*args, **kwargs):
+        return [_EchoTool()], None, None, None
+
+    monkeypatch.setattr(
+        cli.Config,
+        "get_default_config_path",
+        staticmethod(lambda: config_path),
+    )
+    monkeypatch.setattr(cli.Config, "from_yaml", staticmethod(lambda _path: config))
+    monkeypatch.setattr(cli, "LLMClient", _EmptyFinalAnswerLLM)
+    monkeypatch.setattr(cli, "initialize_base_tools", fake_initialize_base_tools)
+    monkeypatch.setattr(cli, "add_workspace_tools", lambda *args, **kwargs: None)
+
+    exit_code = asyncio.run(
+        cli.run_agent(
+            workspace,
+            task="Use echo and summarize the result",
+            sandbox_mode=False,
+            verify_api=False,
+            json_summary=True,
+            completion_gate_enabled=False,
+            goal_autopilot_enabled=False,
+        )
+    )
+
+    output = capsys.readouterr().out
+    summary = json.loads(output[output.rfind("\n{") + 1 :])
+    assert exit_code == 1
+    assert summary["ok"] is False
+    assert summary["error"]
+    assert summary["goalAutopilot"]["lastStopReason"] == "error"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2189,6 +2189,40 @@ async def test_repeated_empty_final_answer_after_tool_returns_error():
 
 
 @pytest.mark.asyncio
+async def test_empty_final_answer_on_last_step_returns_error():
+    llm = MockLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=_echo_tool_calls(1),
+                finish_reason="tool",
+            ),
+            LLMResponse(content="", finish_reason="stop"),
+        ]
+    )
+
+    events = await collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={"echo": EchoTool()},
+            max_steps=2,
+        )
+    )
+
+    retry_messages = [
+        event
+        for event in events
+        if isinstance(event, InjectedMessageEvent)
+        and "produced no visible final answer" in event.content
+    ]
+    assert retry_messages == []
+    assert any(isinstance(event, ErrorEvent) for event in events)
+    done = [event for event in events if isinstance(event, DoneEvent)]
+    assert done[-1].stop_reason == StopReason.ERROR
+
+
+@pytest.mark.asyncio
 async def test_setup_tools_do_not_count_toward_final_summary_threshold():
     """Setup/bookkeeping tools (skills, plan, todos, memory) must not trip the
     wrap-up nudge — even far beyond the threshold they are not 'process log' work."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1993,6 +1993,79 @@ async def test_controlled_research_batches_public_page_reads(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_controlled_outline_accepts_url_from_prior_web_search(tmp_path):
+    query = "official product release"
+    source_url = "https://example.gov/releases/latest"
+    outline_content = json.dumps(
+        {
+            "source_mode": "public_authoritative_research",
+            "slides": [{"evidence": [source_url]}],
+        }
+    )
+    llm = MockLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="search-evidence",
+                        type="function",
+                        function=FunctionCall(
+                            name="web_search",
+                            arguments={"query": query},
+                        ),
+                    )
+                ],
+                finish_reason="tool",
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="write-outline",
+                        type="function",
+                        function=FunctionCall(
+                            name="write_file",
+                            arguments={
+                                "path": "outline.json",
+                                "content": outline_content,
+                            },
+                        ),
+                    )
+                ],
+                finish_reason="tool",
+            ),
+        ]
+    )
+
+    events = await collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={
+                "web_search": JsonWebSearchTool({query: source_url}),
+                "write_file": WriteTool(workspace_dir=str(tmp_path)),
+            },
+            max_steps=2,
+            completion_gate=CompletionGate(
+                workflow_checkpoint_kind="controlled_presentation",
+                workflow_options={"research_mode": "deep"},
+            ),
+            workspace_dir=str(tmp_path),
+        )
+    )
+
+    write_result = next(
+        event
+        for event in events
+        if isinstance(event, ToolCallResult)
+        and event.tool_call_id == "write-outline"
+    )
+    assert write_result.success is True
+    assert (tmp_path / "outline.json").is_file()
+
+
+@pytest.mark.asyncio
 async def test_at_threshold_does_not_inject_final_summary_guidance():
     """Exactly at the threshold (boundary) does not trigger the wrap-up nudge."""
     llm = MockLLM(
@@ -3874,6 +3947,26 @@ def test_large_web_search_result_is_compact_for_synthesis_turn():
     assert "Large web_search result bounded for model history" in model_content
     assert "https://example.com/result-1" in model_content
     assert "https://example.com/result-5" in model_content
+
+
+@pytest.mark.parametrize("size", [12_000, 20_000, 50_000])
+def test_unstructured_web_search_compaction_is_smaller_than_input(size):
+    from box_agent.core import _tool_message_content_for_model
+    from box_agent.tools.base import ToolResult
+
+    full_content = "x" * size
+    model_content = _tool_message_content_for_model(
+        tool_name="web_search",
+        arguments={"Query": "latest official release"},
+        result=ToolResult(success=True, content=full_content),
+        visible_content=full_content,
+        visible_error=None,
+    )
+
+    assert len(model_content) < len(full_content)
+    assert len(model_content) <= 10_000
+    assert f"Characters omitted: {size - 9_000}" in model_content
+    assert "Characters omitted: -" not in model_content
 
 
 def test_micro_compact_token_budget_shrinks_keep_window_when_recent_oversized():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2053,6 +2053,69 @@ async def test_tool_heavy_empty_final_answer_retries_for_conclusion():
 
 
 @pytest.mark.asyncio
+async def test_single_visible_tool_empty_final_answer_retries_for_conclusion():
+    """Even a short tool turn must not end successfully without a visible answer."""
+    llm = MockLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=_echo_tool_calls(1),
+                finish_reason="tool",
+            ),
+            LLMResponse(content="", finish_reason="stop"),
+            LLMResponse(content="最终结论：搜索结果已整理。", finish_reason="stop"),
+        ]
+    )
+
+    events = await collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={"echo": EchoTool()},
+            max_steps=5,
+        )
+    )
+
+    injected = [e for e in events if isinstance(e, InjectedMessageEvent)]
+    assert any("produced no visible final answer" in e.content for e in injected)
+    done = [e for e in events if isinstance(e, DoneEvent)]
+    assert done[-1].stop_reason == StopReason.END_TURN
+    assert done[-1].final_content == "最终结论：搜索结果已整理。"
+
+
+@pytest.mark.asyncio
+async def test_repeated_empty_final_answer_after_tool_returns_error():
+    """A bounded retry failure is explicit instead of a successful empty END_TURN."""
+    llm = MockLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=_echo_tool_calls(1),
+                finish_reason="tool",
+            ),
+            LLMResponse(content="", finish_reason="stop"),
+            LLMResponse(content="", finish_reason="stop"),
+        ]
+    )
+
+    events = await collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={"echo": EchoTool()},
+            max_steps=5,
+        )
+    )
+
+    errors = [e for e in events if isinstance(e, ErrorEvent)]
+    assert errors
+    assert "未生成最终答复" in errors[-1].message
+    done = [e for e in events if isinstance(e, DoneEvent)]
+    assert done[-1].stop_reason == StopReason.ERROR
+    assert done[-1].final_content
+
+
+@pytest.mark.asyncio
 async def test_setup_tools_do_not_count_toward_final_summary_threshold():
     """Setup/bookkeeping tools (skills, plan, todos, memory) must not trip the
     wrap-up nudge — even far beyond the threshold they are not 'process log' work."""
@@ -2572,7 +2635,7 @@ async def test_web_search_site_query_filters_nested_web_results_payload():
 
 
 @pytest.mark.asyncio
-async def test_web_search_tool_result_is_preserved_for_the_next_model_step():
+async def test_web_search_tool_result_is_compacted_for_the_next_model_step():
     tool_call = ToolCall(
         id="web-large",
         type="function",
@@ -2605,13 +2668,13 @@ async def test_web_search_tool_result_is_preserved_for_the_next_model_step():
         for m in llm.message_calls[1]
         if m.role == "tool" and m.name == "web_search" and m.tool_call_id == "web-large"
     )
-    assert tool_message.content == visible_result.content
-    assert '"Query": "policy 400g"' in tool_message.content
+    assert tool_message.content != visible_result.content
+    assert "query=policy 400g" in tool_message.content
     assert "Official policy result" in tool_message.content
     assert "https://example.gov/policy" in tool_message.content
     assert "A concise summary of the policy" in tool_message.content
-    assert "RAW_SEARCH_BODY_" in tool_message.content
-    assert len(tool_message.content) > 20_000
+    assert "RAW_SEARCH_BODY_" not in tool_message.content
+    assert len(tool_message.content) < 10_000
 
 
 @pytest.mark.asyncio
@@ -3779,6 +3842,38 @@ def test_generic_large_tool_result_is_bounded_only_for_model_history():
     assert "Characters returned: 100027" in model_content
     assert "final exit status: 0" in model_content
     assert full_content.endswith("final exit status: 0")
+
+
+def test_large_web_search_result_is_compact_for_synthesis_turn():
+    from box_agent.core import _tool_message_content_for_model
+    from box_agent.tools.base import ToolResult
+
+    refs = [
+        {
+            "Title": f"Official result {index}",
+            "Url": f"https://example.com/result-{index}",
+            "Content": f"Evidence {index} " + ("x" * 5_000),
+        }
+        for index in range(1, 6)
+    ]
+    full_content = json.dumps(
+        {"Result": {"ResultCount": len(refs), "WebResults": refs}},
+        ensure_ascii=False,
+    )
+
+    model_content = _tool_message_content_for_model(
+        tool_name="web_search",
+        arguments={"Query": "latest official release"},
+        result=ToolResult(success=True, content=full_content),
+        visible_content=full_content,
+        visible_error=None,
+    )
+
+    assert len(full_content) > 10_000
+    assert len(model_content) < 10_000
+    assert "Large web_search result bounded for model history" in model_content
+    assert "https://example.com/result-1" in model_content
+    assert "https://example.com/result-5" in model_content
 
 
 def test_micro_compact_token_budget_shrinks_keep_window_when_recent_oversized():

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,11 +5,13 @@ import json
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from box_agent.tools.mcp_loader import (
     MCPServerConnection,
+    MCPTool,
     MCPTimeoutConfig,
     _determine_connection_type,
     cleanup_mcp_connections,
@@ -129,6 +131,43 @@ class TestMCPToolRegistration:
         merge_mcp_tools(base_tools, [mcp_tool])
 
         assert base_tools == [mcp_tool]
+
+
+class TestMCPToolExecution:
+    """Tests for defensive normalization of remote MCP results."""
+
+    @pytest.mark.asyncio
+    async def test_structured_error_envelope_is_failure_without_is_error_flag(self):
+        class FakeSession:
+            async def call_tool(self, name, arguments):
+                return SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            text=json.dumps(
+                                {
+                                    "error": {
+                                        "message": "Query 不能为空。",
+                                        "type": "search_error",
+                                    }
+                                },
+                                ensure_ascii=False,
+                            )
+                        )
+                    ],
+                    isError=False,
+                )
+
+        tool = MCPTool(
+            name="web_search",
+            description="search",
+            parameters={"type": "object"},
+            session=FakeSession(),
+        )
+
+        result = await tool.execute(Query="")
+
+        assert result.success is False
+        assert result.error == "Query 不能为空。"
 
 
 # =============================================================================

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -169,8 +169,12 @@ class TestMCPToolExecution:
         assert result.success is False
         assert result.error == "Query 不能为空。"
 
+    @pytest.mark.parametrize(
+        "error_value",
+        [None, "", {}, {"count": 0}, []],
+    )
     @pytest.mark.asyncio
-    async def test_null_error_field_remains_a_success(self):
+    async def test_non_error_values_remain_a_success(self, error_value):
         class FakeSession:
             async def call_tool(self, name, arguments):
                 return SimpleNamespace(
@@ -178,7 +182,7 @@ class TestMCPToolExecution:
                         SimpleNamespace(
                             text=json.dumps(
                                 {
-                                    "error": None,
+                                    "error": error_value,
                                     "data": {"status": "ok"},
                                 }
                             )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -169,6 +169,36 @@ class TestMCPToolExecution:
         assert result.success is False
         assert result.error == "Query 不能为空。"
 
+    @pytest.mark.asyncio
+    async def test_null_error_field_remains_a_success(self):
+        class FakeSession:
+            async def call_tool(self, name, arguments):
+                return SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            text=json.dumps(
+                                {
+                                    "error": None,
+                                    "data": {"status": "ok"},
+                                }
+                            )
+                        )
+                    ],
+                    isError=False,
+                )
+
+        tool = MCPTool(
+            name="status",
+            description="status",
+            parameters={"type": "object"},
+            session=FakeSession(),
+        )
+
+        result = await tool.execute()
+
+        assert result.success is True
+        assert json.loads(result.content)["data"] == {"status": "ok"}
+
 
 # =============================================================================
 # MCPServerConnection Initialization Tests


### PR DESCRIPTION
**PR**

**Task**

**What changed:** 修复工具调用后没有最终回答、Web Search 返回过大，以及 MCP 错误响应被错误标记为成功的问题，并补充回归测试。

**Why:** 避免搜索完成后无答案、超大结果占满模型上下文，以及错误响应继续进入模型。

**Affected entry points:** Box-Agent 核心循环和 MCP 工具执行；压缩只针对 Web Search。

**Out of scope:** Web Search Server 的分词、召回、排序和去重。

**Proof**

**Tests or checks run:** 聚焦测试 16 个全部通过；`py_compile` 和 `git diff --check` 通过。

**Logs, screenshots, probes, or manifests:** officev3 实际复测可以正常生成带官方来源的最终答案。

**Not run, with reason:** 未运行完整测试目录；已运行所有涉及模块的测试。

**Risk**

**Compatibility:** 无接口和配置变更；空答案时最多增加一次模型调用。

**Packaging/runtime impact:** 无依赖变化；打包版需要更新 Box-Agent runtime。

**Config, secrets, or migration:** 无。

**Rollback:** 回滚本 PR 的三个 commit。

**Cross-repository follow-up:** officev3 已增加空答案客户端兜底；Web Search Server 的检索质量需要后续单独优化。