### PR TITLE
fix: 优化 MCP Token 鉴权失败提示

### DIFF
--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -450,12 +450,18 @@ class MCPServerConnection:
         except TimeoutError as e:
             self.last_error = f"Connection timed out after {connect_timeout}s during {stage}"
             cleanup_error = await _close_exit_stack()
-            if _is_mcp_authentication_error(cleanup_error):
+            auth_failure = _is_mcp_authentication_error(cleanup_error)
+            if auth_failure:
                 self.last_error = _mcp_connection_error_message(e, cleanup_error)
-            _warn(
-                f"[mcp] connect:timeout server={self.name!r} stage={stage} "
-                f"timeout_s={connect_timeout} elapsed_ms={elapsed_ms()} error={self.last_error}"
-            )
+                _warn(
+                    f"[mcp] connect:failed server={self.name!r} stage={stage} "
+                    f"elapsed_ms={elapsed_ms()} error={self.last_error}"
+                )
+            else:
+                _warn(
+                    f"[mcp] connect:timeout server={self.name!r} stage={stage} "
+                    f"timeout_s={connect_timeout} elapsed_ms={elapsed_ms()} error={self.last_error}"
+                )
             _warn_unexpected_cleanup_error(cleanup_error)
             return False
 

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -69,6 +69,74 @@ def _structured_mcp_error_message(content: str) -> str | None:
     return None
 
 
+def _walk_exception_tree(error: BaseException | None):
+    """Yield an exception and its nested group/cause/context exceptions once."""
+    if error is None:
+        return
+
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        yield current
+
+        nested = getattr(current, "exceptions", ())
+        if isinstance(nested, tuple):
+            pending.extend(reversed(nested))
+
+        cause = getattr(current, "__cause__", None)
+        if isinstance(cause, BaseException):
+            pending.append(cause)
+        context = getattr(current, "__context__", None)
+        if isinstance(context, BaseException):
+            pending.append(context)
+
+
+def _http_status_from_exception(error: BaseException | None) -> int | None:
+    for current in _walk_exception_tree(error):
+        status = getattr(current, "status_code", None)
+        if status is None:
+            status = getattr(getattr(current, "response", None), "status_code", None)
+        try:
+            normalized = int(status)
+        except (TypeError, ValueError):
+            continue
+        if 100 <= normalized <= 599:
+            return normalized
+    return None
+
+
+def _is_mcp_authentication_error(error: BaseException | None) -> bool:
+    return _http_status_from_exception(error) in {401, 403}
+
+
+def _mcp_connection_error_message(
+    primary_error: BaseException,
+    cleanup_error: BaseException | None = None,
+) -> str:
+    """Prefer the transport's real HTTP failure over cancellation side effects."""
+    for error in (primary_error, cleanup_error):
+        status = _http_status_from_exception(error)
+        if status in {401, 403}:
+            return f"Authentication failed: Token is invalid or expired (HTTP {status})"
+
+    # Streamable HTTP may cancel ``session.initialize()`` and only expose the
+    # actionable transport error while its task group is being closed.
+    if isinstance(primary_error, asyncio.CancelledError) and cleanup_error is not None:
+        for current in _walk_exception_tree(cleanup_error):
+            if getattr(current, "exceptions", ()):
+                continue
+            message = str(current).strip()
+            if message and not isinstance(current, asyncio.CancelledError):
+                return message
+
+    return str(primary_error).strip() or type(primary_error).__name__
+
+
 # Connection type aliases
 ConnectionType = Literal["stdio", "sse", "http", "streamable_http"]
 
@@ -299,15 +367,23 @@ class MCPServerConnection:
             f"timeout_s={connect_timeout}{command_label}"
         )
 
-        async def _close_exit_stack() -> None:
+        async def _close_exit_stack() -> BaseException | None:
             if not self.exit_stack:
-                return
+                return None
+            cleanup_error: BaseException | None = None
             try:
                 await self.exit_stack.aclose()
-            except BaseException as cleanup_error:  # noqa: BLE001
-                _warn(f"⚠ Failed to clean up MCP connection '{self.name}': {cleanup_error}")
+            except BaseException as error:  # noqa: BLE001
+                cleanup_error = error
             finally:
                 self.exit_stack = None
+                self.session = None
+            return cleanup_error
+
+        def _warn_unexpected_cleanup_error(cleanup_error: BaseException | None) -> None:
+            if cleanup_error is None or _is_mcp_authentication_error(cleanup_error):
+                return
+            _warn(f"⚠ Failed to clean up MCP connection '{self.name}': {cleanup_error}")
 
         try:
             self.exit_stack = AsyncExitStack()
@@ -371,31 +447,42 @@ class MCPServerConnection:
             self.last_error = None
             return True
 
-        except TimeoutError:
+        except TimeoutError as e:
             self.last_error = f"Connection timed out after {connect_timeout}s during {stage}"
+            cleanup_error = await _close_exit_stack()
+            if _is_mcp_authentication_error(cleanup_error):
+                self.last_error = _mcp_connection_error_message(e, cleanup_error)
             _warn(
                 f"[mcp] connect:timeout server={self.name!r} stage={stage} "
-                f"timeout_s={connect_timeout} elapsed_ms={elapsed_ms()}"
+                f"timeout_s={connect_timeout} elapsed_ms={elapsed_ms()} error={self.last_error}"
             )
-            await _close_exit_stack()
+            _warn_unexpected_cleanup_error(cleanup_error)
             return False
 
         except asyncio.CancelledError as e:
-            self.last_error = f"Connection cancelled: {e}"
-            _warn(
-                f"[mcp] connect:cancelled server={self.name!r} stage={stage} "
-                f"elapsed_ms={elapsed_ms()}"
-            )
-            await _close_exit_stack()
+            cleanup_error = await _close_exit_stack()
+            self.last_error = _mcp_connection_error_message(e, cleanup_error)
+            if _is_mcp_authentication_error(cleanup_error):
+                _warn(
+                    f"[mcp] connect:failed server={self.name!r} stage={stage} "
+                    f"elapsed_ms={elapsed_ms()} error={self.last_error}"
+                )
+            else:
+                _warn(
+                    f"[mcp] connect:cancelled server={self.name!r} stage={stage} "
+                    f"elapsed_ms={elapsed_ms()} error={self.last_error}"
+                )
+            _warn_unexpected_cleanup_error(cleanup_error)
             return False
 
         except Exception as e:
-            self.last_error = str(e)
+            cleanup_error = await _close_exit_stack()
+            self.last_error = _mcp_connection_error_message(e, cleanup_error)
             _warn(
                 f"[mcp] connect:failed server={self.name!r} stage={stage} "
-                f"elapsed_ms={elapsed_ms()} error={e}"
+                f"elapsed_ms={elapsed_ms()} error={self.last_error}"
             )
-            await _close_exit_stack()
+            _warn_unexpected_cleanup_error(cleanup_error)
             import traceback
 
             traceback.print_exc()

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -96,7 +96,8 @@ def _walk_exception_tree(error: BaseException | None):
             pending.append(context)
 
 
-def _http_status_from_exception(error: BaseException | None) -> int | None:
+def _http_statuses_from_exception(error: BaseException | None) -> set[int]:
+    statuses: set[int] = set()
     for current in _walk_exception_tree(error):
         status = getattr(current, "status_code", None)
         if status is None:
@@ -106,12 +107,24 @@ def _http_status_from_exception(error: BaseException | None) -> int | None:
         except (TypeError, ValueError):
             continue
         if 100 <= normalized <= 599:
-            return normalized
+            statuses.add(normalized)
+    return statuses
+
+
+def _mcp_auth_status(*errors: BaseException | None) -> int | None:
+    statuses = {
+        status
+        for error in errors
+        for status in _http_statuses_from_exception(error)
+    }
+    for preferred in (401, 403):
+        if preferred in statuses:
+            return preferred
     return None
 
 
 def _is_mcp_authentication_error(error: BaseException | None) -> bool:
-    return _http_status_from_exception(error) in {401, 403}
+    return _mcp_auth_status(error) is not None
 
 
 def _mcp_connection_error_message(
@@ -119,10 +132,11 @@ def _mcp_connection_error_message(
     cleanup_error: BaseException | None = None,
 ) -> str:
     """Prefer the transport's real HTTP failure over cancellation side effects."""
-    for error in (primary_error, cleanup_error):
-        status = _http_status_from_exception(error)
-        if status in {401, 403}:
-            return f"Authentication failed: Token is invalid or expired (HTTP {status})"
+    auth_status = _mcp_auth_status(primary_error, cleanup_error)
+    if auth_status == 401:
+        return "Authentication failed: Token is invalid or expired (HTTP 401)"
+    if auth_status == 403:
+        return "Authorization failed: Access denied or insufficient permissions (HTTP 403)"
 
     # Streamable HTTP may cancel ``session.initialize()`` and only expose the
     # actionable transport error while its task group is being closed.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -551,22 +551,47 @@ class TestMCPServerConnectionTimeout:
         assert "[mcp] connect:start server='slow-stdio' transport=stdio" in stderr
         assert "[mcp] connect:timeout server='slow-stdio' stage=open-stdio-transport" in stderr
 
+    @pytest.mark.parametrize(
+        ("statuses", "expected_error"),
+        [
+            (
+                (500, 401),
+                "Authentication failed: Token is invalid or expired (HTTP 401)",
+            ),
+            (
+                (401, 500),
+                "Authentication failed: Token is invalid or expired (HTTP 401)",
+            ),
+            (
+                (500, 403),
+                "Authorization failed: Access denied or insufficient permissions (HTTP 403)",
+            ),
+            (
+                (403, 500),
+                "Authorization failed: Access denied or insufficient permissions (HTTP 403)",
+            ),
+        ],
+    )
     @pytest.mark.asyncio
     async def test_streamable_http_auth_failure_survives_transport_cancellation(
-        self, monkeypatch, capsys
+        self, monkeypatch, capsys, statuses, expected_error
     ):
-        """A transport 401 raised during cleanup must replace cancel-scope noise."""
+        """Transport auth failures must replace cancel-scope noise regardless of order."""
 
-        request = httpx.Request("POST", "https://example.com/mcp")
-        response = httpx.Response(401, request=request)
-        auth_error = httpx.HTTPStatusError(
-            "401 Authorization Required",
-            request=request,
-            response=response,
-        )
+        errors = []
+        for status in statuses:
+            request = httpx.Request("POST", "https://example.com/mcp")
+            response = httpx.Response(status, request=request)
+            errors.append(
+                httpx.HTTPStatusError(
+                    f"HTTP {status}",
+                    request=request,
+                    response=response,
+                )
+            )
 
         class FakeCleanupError(Exception):
-            exceptions = (auth_error,)
+            exceptions = tuple(errors)
 
         class FakeExitStack:
             async def enter_async_context(self, context):
@@ -593,7 +618,7 @@ class TestMCPServerConnectionTimeout:
         monkeypatch.setattr(conn, "_connect_streamable_http", fake_transport)
 
         assert await conn.connect() is False
-        assert conn.last_error == "Authentication failed: Token is invalid or expired (HTTP 401)"
+        assert conn.last_error == expected_error
         assert conn.exit_stack is None
         assert conn.session is None
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,8 +7,10 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
+from box_agent.tools import mcp_loader
 from box_agent.tools.mcp_loader import (
     MCPServerConnection,
     MCPTool,
@@ -548,6 +550,56 @@ class TestMCPServerConnectionTimeout:
         stderr = capsys.readouterr().err
         assert "[mcp] connect:start server='slow-stdio' transport=stdio" in stderr
         assert "[mcp] connect:timeout server='slow-stdio' stage=open-stdio-transport" in stderr
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_auth_failure_survives_transport_cancellation(
+        self, monkeypatch, capsys
+    ):
+        """A transport 401 raised during cleanup must replace cancel-scope noise."""
+
+        request = httpx.Request("POST", "https://example.com/mcp")
+        response = httpx.Response(401, request=request)
+        auth_error = httpx.HTTPStatusError(
+            "401 Authorization Required",
+            request=request,
+            response=response,
+        )
+
+        class FakeCleanupError(Exception):
+            exceptions = (auth_error,)
+
+        class FakeExitStack:
+            async def enter_async_context(self, context):
+                return context
+
+            async def aclose(self):
+                raise FakeCleanupError("unhandled errors in a TaskGroup")
+
+        class FakeSession:
+            async def initialize(self):
+                raise asyncio.CancelledError("Cancelled via cancel scope")
+
+        conn = MCPServerConnection(
+            name="invalid-token",
+            connection_type="streamable_http",
+            url="https://example.com/mcp",
+        )
+
+        async def fake_transport():
+            return object(), object()
+
+        monkeypatch.setattr(mcp_loader, "AsyncExitStack", FakeExitStack)
+        monkeypatch.setattr(mcp_loader, "ClientSession", lambda *_args: FakeSession())
+        monkeypatch.setattr(conn, "_connect_streamable_http", fake_transport)
+
+        assert await conn.connect() is False
+        assert conn.last_error == "Authentication failed: Token is invalid or expired (HTTP 401)"
+        assert conn.exit_stack is None
+        assert conn.session is None
+
+        stderr = capsys.readouterr().err
+        assert "[mcp] connect:failed server='invalid-token'" in stderr
+        assert "Failed to clean up MCP connection" not in stderr
 
 
 # =============================================================================


### PR DESCRIPTION
## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
