### PR TITLE
fix: restore MCP and runtime compatibility

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -117,7 +117,12 @@ from box_agent.loop_guards import (
     CompletionGate,
     completion_gate_gaps,
 )
-from box_agent.workflows import recover_completion_gate
+from box_agent.workflows import (
+    build_presentation_preflight_result,
+    build_presentation_recommendation_prompt,
+    load_presentation_preflight_config,
+    recover_completion_gate,
+)
 from box_agent.acp.action_hints import (
     ActionHintStreamNormalizer,
     build_action_hints_prompt,
@@ -2200,12 +2205,6 @@ class BoxACPAgent:
         params: dict[str, Any],
     ) -> dict[str, Any]:
         """Recommend bounded startup options for a new presentation task."""
-        from box_agent.workflows.presentation_preflight import (
-            build_presentation_preflight_result,
-            build_presentation_recommendation_prompt,
-            load_presentation_preflight_config,
-        )
-
         prompt = params.get("prompt", "")
         if not isinstance(prompt, str) or not prompt.strip():
             return {

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -1018,65 +1018,62 @@ Examples:
             # 2. Scope control (capability-based or legacy)
             if self._perm:
                 escape_reason = detect_scope_escape(command, workspace_dir=self.scope_root_dir)
-                if escape_reason:
-                    from .permissions import FILESYSTEM_READ, FILESYSTEM_WRITE, extract_absolute_paths
+                from .permissions import FILESYSTEM_READ, FILESYSTEM_WRITE, extract_absolute_paths
 
-                    abs_paths = extract_absolute_paths(command)
-                    log.debug(
-                        "bash/perm/extracted paths=%s reason=%s cmd=%r",
-                        abs_paths, escape_reason, command[:200],
+                abs_paths = extract_absolute_paths(command)
+                log.debug(
+                    "bash/perm/extracted paths=%s reason=%s cmd=%r",
+                    abs_paths, escape_reason, command[:200],
+                )
+
+                # CONSERVATIVE: if an escape pattern has no extractable path,
+                # deny it rather than silently allowing an unverifiable command.
+                if escape_reason and not abs_paths:
+                    return BashOutputResult(
+                        success=False,
+                        error=(
+                            f"Command blocked (phase 1 permission engine): {escape_reason}. "
+                            f"Cannot verify path permissions for this command pattern. "
+                            f"Use absolute paths or request broader access."
+                        ),
+                        stdout="",
+                        stderr=f"Blocked: {escape_reason}",
+                        exit_code=1,
                     )
 
-                    # CONSERVATIVE: if no absolute paths extracted, we cannot verify safety.
-                    # deny the command rather than silently allowing it.
-                    # This covers: relative paths, $HOME/~, shell expansion, embedded
-                    # interpreters (python -c), heredocs, variable-based paths (phase 1 limit).
-                    if not abs_paths:
+                for p in abs_paths:
+                    if _is_temp_shell_redirect_path(command, p):
+                        continue
+                    # Classify each concrete path separately. A redirect to
+                    # another path (or 2>&1) must not make this path writable.
+                    cap = (
+                        FILESYSTEM_WRITE
+                        if _path_requires_write_permission(command, p)
+                        else FILESYSTEM_READ
+                    )
+                    decision = self._perm.check(
+                        capability=cap,
+                        resource={"path": p},
+                        tool_name="bash",
+                    )
+                    if not decision.allowed:
+                        log.warning(
+                            "bash/perm/denied path=%s cap=%s extracted=%s cmd=%r",
+                            p, cap, abs_paths, command[:200],
+                        )
+                        extracted_summary = (
+                            f" Extracted paths from command: {abs_paths}."
+                            if len(abs_paths) > 1
+                            else ""
+                        )
                         return BashOutputResult(
                             success=False,
-                            error=(
-                                f"Command blocked (phase 1 permission engine): {escape_reason}. "
-                                f"Cannot verify path permissions for this command pattern. "
-                                f"Use absolute paths or request broader access."
-                            ),
+                            error=(decision.reason or "Permission denied") + extracted_summary,
                             stdout="",
-                            stderr=f"Blocked: {escape_reason}",
+                            stderr=decision.reason or "Permission denied",
                             exit_code=1,
+                            permission_request=decision.permission_request,
                         )
-
-                    for p in abs_paths:
-                        if _is_temp_shell_redirect_path(command, p):
-                            continue
-                        # Classify each concrete path separately. A redirect to
-                        # another path (or 2>&1) must not make this path writable.
-                        cap = (
-                            FILESYSTEM_WRITE
-                            if _path_requires_write_permission(command, p)
-                            else FILESYSTEM_READ
-                        )
-                        decision = self._perm.check(
-                            capability=cap,
-                            resource={"path": p},
-                            tool_name="bash",
-                        )
-                        if not decision.allowed:
-                            log.warning(
-                                "bash/perm/denied path=%s cap=%s extracted=%s cmd=%r",
-                                p, cap, abs_paths, command[:200],
-                            )
-                            extracted_summary = (
-                                f" Extracted paths from command: {abs_paths}."
-                                if len(abs_paths) > 1
-                                else ""
-                            )
-                            return BashOutputResult(
-                                success=False,
-                                error=(decision.reason or "Permission denied") + extracted_summary,
-                                stdout="",
-                                stderr=decision.reason or "Permission denied",
-                                exit_code=1,
-                                permission_request=decision.permission_request,
-                            )
             elif not self.allow_full_access:
                 escape_reason = detect_scope_escape(command, workspace_dir=self.scope_root_dir)
                 if escape_reason:

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -35,7 +35,12 @@ else:
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamable_http_client
+
+try:
+    from mcp.client.streamable_http import streamable_http_client
+except ImportError:
+    # MCP <= 1.19 exports the same client without the separator.
+    from mcp.client.streamable_http import streamablehttp_client as streamable_http_client
 
 from box_agent.auth import request_auth_headers, resolve_auth_token, should_attach_auth_header
 

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -35,7 +35,7 @@ else:
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 from box_agent.auth import request_auth_headers, resolve_auth_token, should_attach_auth_header
 
@@ -614,9 +614,9 @@ class MCPServerConnection:
         connect_timeout = self._get_connect_timeout()
         sse_read_timeout = self._get_sse_read_timeout()
 
-        # streamablehttp_client returns (read, write, get_session_id)
+        # streamable_http_client returns (read, write, get_session_id)
         read_stream, write_stream, _ = await self.exit_stack.enter_async_context(
-            streamablehttp_client(
+            streamable_http_client(
                 url=self.url,
                 headers=self.headers if self.headers else None,
                 timeout=connect_timeout,

--- a/box_agent/workflows/__init__.py
+++ b/box_agent/workflows/__init__.py
@@ -8,6 +8,11 @@ from ..loop_guards import CompletionGate
 from ..workflow_policy import WorkflowPolicy
 from .controlled_presentation import ControlledPresentationPolicy
 from .presentation_contract import RESEARCH_MODE_OPTION
+from .presentation_preflight import (
+    build_presentation_preflight_result,
+    build_presentation_recommendation_prompt,
+    load_presentation_preflight_config,
+)
 
 
 def create_workflow_policy(
@@ -41,6 +46,9 @@ def recover_completion_gate(
 
 __all__ = [
     "ControlledPresentationPolicy",
+    "build_presentation_preflight_result",
+    "build_presentation_recommendation_prompt",
     "create_workflow_policy",
+    "load_presentation_preflight_config",
     "recover_completion_gate",
 ]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -25,6 +25,11 @@ from box_agent.tools.setup import merge_mcp_tools, register_mcp_tools
 from box_agent.tools.base import Tool, ToolResult
 
 
+def test_streamable_http_client_is_available():
+    """The loader resolves the client exported by the installed MCP SDK."""
+    assert callable(mcp_loader.streamable_http_client)
+
+
 class NamedDummyTool(Tool):
     """Small test double for a named tool."""
 


### PR DESCRIPTION
## Overview

修复 MCP Streamable HTTP 客户端在不同 SDK 版本中的导出名称兼容问题，并修复主线 CI 暴露的工作流架构边界和 Linux Bash 路径授权问题。仓库锁定的 MCP 1.19.0 仅导出 `streamablehttp_client`，较新环境可能导出 `streamable_http_client`；加载器现在兼容两者。ACP 通过工作流公共门面调用演示文稿预检，Bash 在启用 PermissionEngine 时始终检查可提取的绝对路径。

## Task

- 兼容 MCP SDK 新旧 Streamable HTTP 客户端导出名称
- 添加 MCP 客户端解析回归测试
- 将演示文稿预检能力通过 `box_agent.workflows` 公共门面导出，移除 ACP 对具体工作流模块的直接依赖
- 修复 Linux `/tmp` 场景下路径逃逸启发式绕过 PermissionEngine 的问题
- 不涉及 MCP 连接参数、超时策略或配置格式调整

## Proof

- MCP 定向测试：45 passed, 3 skipped, 1 deselected
- MCP、预检及两个原 CI 失败的联合回归：139 passed, 3 skipped, 1 deselected
- 权限、Bash、架构及权限协商测试：178 passed, 1 skipped
- GitHub Actions Python 3.10：通过
- GitHub Actions Python 3.11：通过
- GitHub Actions Python 3.12：通过
- `git diff --check`：通过

## Risk

- MCP 风险较低，仅兼容 SDK 符号名称差异
- ACP 仅将具体工作流导入移动到公共门面，对外协议不变
- Bash 权限检查更严格：启用 PermissionEngine 后，所有可提取绝对路径都会接受真实能力检查，修复 Linux 下的绕过；合法工作区、内置技能只读路径和受控临时重定向由现有规则继续放行
- 回滚方式：回退提交 `7861a58`、`1ecab5f` 和 `599f6da`