### PR TITLE
feat: 支持会话级文件与命令权限

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1291,9 +1291,38 @@ class BoxACPAgent:
         perm_engine = None
         grant_store = GrantStore()
         effective_policy: CapabilityPolicy | None = None
-        if self._has_officev3_policy():
+        raw_permission_mode = meta.get("permission_mode") if isinstance(meta, dict) else None
+        permission_mode = raw_permission_mode if raw_permission_mode in {"default", "full_access"} else None
+        if raw_permission_mode is not None and permission_mode is None:
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message=f"Invalid permission_mode={raw_permission_mode!r}; using default permissions",
+            )
+            permission_mode = "default"
+        session_allow_full_access = (
+            permission_mode == "full_access"
+            or (permission_mode is None and self._config.tools.allow_full_access)
+        )
+        # Keep the managed Python/Jupyter runtime available in every ACP
+        # permission mode. Full access bypasses the host permission engine via
+        # session_allow_full_access/perm_engine; it must not require users to
+        # have a separate host Python installation.
+        session_sandbox_mode = True
+
+        if self._has_officev3_policy() and permission_mode != "full_access":
             try:
                 base_policy = CapabilityPolicy.from_config(self._config)
+                if permission_mode == "default":
+                    # Explicit session-default mode must fail closed even when
+                    # the host omits its filesystem context. Host-provided
+                    # values below may narrow or extend this session baseline.
+                    base_policy = base_policy.with_filesystem_overrides(
+                        session_workspace_root=str(workspace),
+                        allowed_directories=[],
+                        filesystem_scope="session_workspace",
+                        replace_allowed_directories=True,
+                    )
 
                 # officev3_permissions_override is DEPRECATED — kept for parsing only.
                 # In-band permission/request negotiation handles escalation now.
@@ -1329,6 +1358,7 @@ class BoxACPAgent:
                         session_workspace_root=swr,
                         allowed_directories=extra_dirs,
                         filesystem_scope=fs_scope,
+                        replace_allowed_directories=permission_mode == "default",
                     )
                     log.info(
                         "session/permissions",
@@ -1355,9 +1385,28 @@ class BoxACPAgent:
                 )
                 effective_policy = fallback_policy
                 perm_engine = PermissionEngine(fallback_policy, workspace, grant_store=grant_store)
+        elif permission_mode == "default":
+            fallback_policy = CapabilityPolicy(
+                filesystem_scope="session_workspace",
+                session_workspace_root=str(workspace),
+            )
+            effective_policy = fallback_policy
+            perm_engine = PermissionEngine(fallback_policy, workspace, grant_store=grant_store)
+            session_allow_full_access = False
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message="No officev3 policy configured; using restrictive session policy",
+            )
+        elif permission_mode == "full_access":
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message="Full access enabled for this session; permission checks are bypassed",
+            )
 
         skill_runtime_context = build_skill_runtime_context(
-            sandbox_mode=True,
+            sandbox_mode=session_sandbox_mode,
             env_context=env_context,
         )
         session_skill_loader = self._skill_loader
@@ -1420,8 +1469,8 @@ class BoxACPAgent:
                 tools,
                 self._config,
                 workspace,
-                sandbox_mode=True,
-                allow_full_access=self._config.tools.allow_full_access,
+                sandbox_mode=session_sandbox_mode,
+                allow_full_access=session_allow_full_access,
                 non_interactive=True,  # ACP cannot do interactive terminal prompts
                 output=lambda msg: sys.stderr.write(msg + "\n"),
                 llm=session_llm,
@@ -1433,6 +1482,7 @@ class BoxACPAgent:
                 artifact_root_dir=output_dir,
                 env_context=env_context,
                 process_owner_id=session_id,
+                bypass_dangerous_command_approval=permission_mode == "full_access",
             )
             system_prompt = (
                 f"{system_prompt.rstrip()}\n\n"

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -767,6 +767,7 @@ class BashTool(Tool):
         permission_engine: PermissionEngine | None = None,
         runtime_env: dict[str, str] | None = None,
         process_owner_id: str | None = None,
+        bypass_dangerous_command_approval: bool = False,
     ):
         """Initialize BashTool with OS-specific shell detection.
 
@@ -783,6 +784,8 @@ class BashTool(Tool):
                                so subprocess commands use the sandbox Python.
             permission_engine: If provided, use capability-based permission checks.
             runtime_env: Extra runtime environment variables exposed to commands.
+            bypass_dangerous_command_approval: If True, skip approval for dangerous
+                                                commands in an explicitly trusted session.
         """
         self.is_windows = platform.system() == "Windows"
         self.shell_name = "PowerShell" if self.is_windows else "bash"
@@ -839,6 +842,7 @@ class BashTool(Tool):
         self.non_interactive = non_interactive
         self._perm = permission_engine
         self.process_owner_id = process_owner_id
+        self.bypass_dangerous_command_approval = bypass_dangerous_command_approval
         self._approved_safety_commands: set[str] = set()
         self._subprocess_env = None
         self._use_login_shell = True
@@ -1291,9 +1295,10 @@ Examples:
                     exit_code=1,
                 )
 
-            # 1. Dangerous command detection (always active)
+            # 1. Dangerous command approval is bypassed only for an explicitly
+            # trusted full-access session. Hard product blocks above still apply.
             danger_reason = detect_dangerous_command(command)
-            if danger_reason:
+            if danger_reason and not self.bypass_dangerous_command_approval:
                 if not self._consume_safety_approval(command, danger_reason):
                     return BashOutputResult(
                         success=False,

--- a/box_agent/tools/permissions.py
+++ b/box_agent/tools/permissions.py
@@ -90,6 +90,7 @@ class CapabilityPolicy(BaseModel):
         session_workspace_root: str | None = None,
         allowed_directories: tuple[str, ...] | list[str] | None = None,
         filesystem_scope: str | None = None,
+        replace_allowed_directories: bool = False,
     ) -> CapabilityPolicy:
         """Apply per-session filesystem context from a trusted host.
 
@@ -105,12 +106,15 @@ class CapabilityPolicy(BaseModel):
         if session_workspace_root is not None:
             updates["session_workspace_root"] = session_workspace_root
         if allowed_directories is not None:
-            # Merge with existing rather than replace, so host injection adds
-            # to whatever is configured globally.
-            merged = list(self.allowed_directories) + [
-                d for d in allowed_directories if d not in self.allowed_directories
-            ]
-            updates["allowed_directories"] = tuple(merged)
+            if replace_allowed_directories:
+                updates["allowed_directories"] = tuple(dict.fromkeys(allowed_directories))
+            else:
+                # Legacy host context remains additive for clients that have
+                # not opted into the session permission protocol.
+                merged = list(self.allowed_directories) + [
+                    d for d in allowed_directories if d not in self.allowed_directories
+                ]
+                updates["allowed_directories"] = tuple(merged)
         if filesystem_scope is not None:
             updates["filesystem_scope"] = filesystem_scope
         if not updates:

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -530,7 +530,8 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         use_output_dir: bool = True,
                         artifact_root_dir: str | Path | None = None,
                         env_context=None,
-                        process_owner_id: str | None = None):
+                        process_owner_id: str | None = None,
+                        bypass_dangerous_command_approval: bool = False):
     """Add workspace-dependent tools
 
     These tools need to know the workspace directory.
@@ -590,6 +591,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             permission_engine=permission_engine,
             runtime_env=runtime_env,
             process_owner_id=process_owner_id,
+            bypass_dangerous_command_approval=bypass_dangerous_command_approval,
         )
         tools.append(bash_tool)
         if process_owner_id is not None:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -3842,6 +3842,119 @@ async def test_acp_prompt_lists_officev3_allowed_directories(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_acp_default_permission_mode_replaces_global_allowed_directories(tmp_path):
+    global_allowed = tmp_path / "global"
+    session_allowed = tmp_path / "session-allowed"
+    workspace = tmp_path / "workspace"
+    global_allowed.mkdir()
+    session_allowed.mkdir()
+
+    officev3 = Officev3Config(
+        permissions=Officev3Permissions(
+            filesystem=FilesystemPermissions(
+                scope="user_home",
+                allowed_directories=[str(global_allowed)],
+            )
+        ),
+        paths=Officev3Paths(session_workspace_root=str(tmp_path / "legacy-root")),
+    )
+    officev3._present = True
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=True),
+        officev3=officev3,
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={
+                "permission_mode": "default",
+                "filesystem_policy": {
+                    "filesystem_scope": "session_workspace",
+                    "session_workspace_root": str(workspace),
+                    "allowed_directories": [str(session_allowed)],
+                },
+            },
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+
+    assert bash_tool.allow_full_access is False
+    assert bash_tool._perm is not None
+    assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
+    assert bash_tool._perm.policy.allowed_directories == (str(session_allowed),)
+
+
+@pytest.mark.asyncio
+async def test_acp_default_permission_mode_without_filesystem_policy_fails_closed(tmp_path):
+    global_allowed = tmp_path / "global"
+    workspace = tmp_path / "workspace"
+    global_allowed.mkdir()
+
+    officev3 = Officev3Config(
+        permissions=Officev3Permissions(
+            filesystem=FilesystemPermissions(
+                scope="user_home",
+                allowed_directories=[str(global_allowed)],
+            )
+        ),
+        paths=Officev3Paths(session_workspace_root=str(tmp_path / "legacy-root")),
+    )
+    officev3._present = True
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=True),
+        officev3=officev3,
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={"permission_mode": "default"},
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+
+    assert bash_tool.allow_full_access is False
+    assert bash_tool.bypass_dangerous_command_approval is False
+    assert bash_tool._perm is not None
+    assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
+    assert bash_tool._perm.policy.session_workspace_root == str(workspace)
+    assert bash_tool._perm.policy.allowed_directories == ()
+
+
+@pytest.mark.asyncio
+async def test_acp_full_access_mode_bypasses_permission_engine(tmp_path):
+    workspace = tmp_path / "workspace"
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={"permission_mode": "full_access"},
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+    session_tools = agent._sessions[session.sessionId].agent.tools
+
+    assert bash_tool.allow_full_access is True
+    assert bash_tool.bypass_dangerous_command_approval is True
+    assert bash_tool._perm is None
+    assert "execute_code" in session_tools
+    assert "sandbox_status" in session_tools
+
+
+@pytest.mark.asyncio
 async def test_acp_prompt_includes_skill_runtime_context(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     sandbox_base = tmp_path / "sandbox-runtime"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -583,6 +583,16 @@ class TestFilesystemOverrides:
         # No duplicate
         assert list(new.allowed_directories).count("/a") == 1
 
+    def test_allowed_directories_replaced_for_session_policy(self):
+        base = CapabilityPolicy(allowed_directories=("/global",))
+        new = base.with_filesystem_overrides(
+            allowed_directories=["/session", "/session"],
+            replace_allowed_directories=True,
+        )
+
+        assert new.allowed_directories == ("/session",)
+        assert base.allowed_directories == ("/global",)
+
     def test_no_args_returns_self(self):
         base = CapabilityPolicy(session_workspace_root="/r")
         new = base.with_filesystem_overrides()
@@ -802,6 +812,21 @@ class TestBashPermissionPhase1:
             permission_engine=perm_engine,
         )
         return await tool.execute(command)
+
+    async def test_full_access_bypasses_dangerous_command_approval(self, workspace: Path):
+        from box_agent.tools.bash_tool import BashTool
+
+        tool = BashTool(
+            workspace_dir=str(workspace),
+            allow_full_access=True,
+            non_interactive=True,
+            permission_engine=None,
+            bypass_dangerous_command_approval=True,
+        )
+        result = await tool.execute(f'rm -rf "{workspace / "missing-target"}"')
+
+        assert result.permission_request is None
+        assert "Approval required" not in (result.stderr or "")
 
     def _make_engine(self, workspace: Path) -> PermissionEngine:
         policy = CapabilityPolicy()  # session_workspace scope


### PR DESCRIPTION
TPR
Task
What changed:Box-Agent ACP 新增会话级 permission_mode，支持 default 和 full_access。
默认权限按当前 session 的工作区和授权目录创建 PermissionEngine。
完全访问仅对当前 session 生效，不影响其他会话和 CLI。
宿主漏传 filesystem_policy 时，默认仅允许当前 workspace，避免继承全局业务目录。

Why:支持 Officev3 按会话隔离权限，并让无人值守定时任务使用完全访问。

Affected entry points:ACP newSession
CapabilityPolicy
BashTool

Out of scope:Officev3 前端 UI
CLI 全局 tools.allow_full_access 行为
Windows/macOS 既有内置白名单
权限配置持久化

Proof
Tests or checks run:执行了 git diff --check。
新增了默认权限、完全访问、目录替换及危险命令行为的回归测试。

Logs, screenshots, probes, or manifests:完成源码调用链和兼容路径审查。
分支相对最新 main 仅包含 1 个提交、5 个文件。

Not run, with reason:未运行 pytest 和打包运行时验证，由客户端联调阶段统一验证。

Risk
Compatibility:未传 permission_mode 时继续使用旧的 tools.allow_full_access 兼容逻辑。
CLI 行为不变。

Packaging/runtime impact:Box-Agent 运行时代码有修改，Officev3 内置版本需要更新或重新打包后才能生效。
本次未执行运行时构建、安装或打包探测。

Config, secrets, or migration:无配置迁移，无新增依赖或敏感信息。
保留现有 tools.allow_full_access 字段。

Rollback:回退提交 690c4aa 即可恢复旧行为。

Cross-repository follow-up:Officev3 需传递 permission_mode 和对应的 filesystem_policy。
定时任务固定传递 permission_mode: full_access。

Checklist

This PR has one clear behavior or subsystem scope.

Code path and ownership were verified from source; .understand-anything was used as an index when available.

Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.