### PR TITLE
feat(mcp): improve deferred tool search ranking

### DIFF
--- a/box_agent/tools/mcp_tool_catalog.py
+++ b/box_agent/tools/mcp_tool_catalog.py
@@ -61,7 +61,6 @@ class MCPToolEntry:
     tool_id: str
     model_name: str
     server_name: str
-    raw_tool_name: str
     description: str
     tool: Tool
     generation: int
@@ -166,7 +165,6 @@ class MCPToolCatalog:
                     tool_id=tool_id,
                     model_name=raw_name,
                     server_name=server_name,
-                    raw_tool_name=raw_name,
                     description=tool.description,
                     tool=tool,
                     generation=generation,
@@ -265,7 +263,7 @@ class MCPToolCatalog:
         *,
         server_name: str | None = None,
     ) -> tuple[list[MCPToolEntry], list[str]]:
-        """Resolve exact catalog IDs, qualified names, or model/raw names."""
+        """Resolve exact catalog IDs, qualified names, or model names."""
         entries = [
             entry
             for entry in self.snapshot()
@@ -284,10 +282,9 @@ class MCPToolCatalog:
                 if normalized_name
                 in {
                     _normalize(entry.tool_id),
-                    _normalize(f"{entry.server_name}/{entry.raw_tool_name}"),
-                    _normalize(f"{entry.server_name}:{entry.raw_tool_name}"),
+                    _normalize(f"{entry.server_name}/{entry.model_name}"),
+                    _normalize(f"{entry.server_name}:{entry.model_name}"),
                     _normalize(entry.model_name),
-                    _normalize(entry.raw_tool_name),
                 }
             ]
             if not matches:
@@ -314,27 +311,41 @@ class MCPToolCatalog:
         for entry in self.snapshot():
             if server_name and entry.server_name != server_name:
                 continue
+            model_terms = tuple(dict.fromkeys(_tokenize(entry.model_name)))
+            model_term_set = set(model_terms)
+            server_terms = tuple(
+                term
+                for term in dict.fromkeys(_tokenize(entry.server_name))
+                if term not in model_term_set
+            )
             documents.append(
                 (
                     entry,
                     _normalize(entry.model_name),
                     _normalize(entry.tool_id),
                     _normalize(f"{entry.server_name} {entry.model_name}"),
-                    _tokenize(f"{entry.server_name} {entry.model_name} {entry.tool_id}"),
-                    _tokenize(entry.description),
+                    model_terms,
+                    server_terms,
+                    tuple(dict.fromkeys(_tokenize(entry.description))),
                 )
             )
         if not documents:
             return []
 
-        average_name_length = sum(len(item[4]) for item in documents) / len(documents)
-        average_description_length = sum(len(item[5]) for item in documents) / len(
+        average_model_name_length = sum(len(item[4]) for item in documents) / len(
+            documents
+        )
+        average_server_name_length = sum(len(item[5]) for item in documents) / len(
+            documents
+        )
+        average_description_length = sum(len(item[6]) for item in documents) / len(
             documents
         )
         document_frequencies = {
             term: (
                 sum(_prefix_term_frequency(term, item[4]) > 0 for item in documents),
                 sum(_prefix_term_frequency(term, item[5]) > 0 for item in documents),
+                sum(_prefix_term_frequency(term, item[6]) > 0 for item in documents),
             )
             for term in query_terms
         }
@@ -345,7 +356,8 @@ class MCPToolCatalog:
             normalized_name,
             normalized_id,
             normalized_server_name,
-            name_terms,
+            model_name_terms,
+            server_name_terms,
             description_terms,
         ) in documents:
             exact_priority = 3
@@ -364,19 +376,29 @@ class MCPToolCatalog:
             relevance = 0.0
             matched_terms = 0
             for term in query_terms:
-                name_frequency = _prefix_term_frequency(term, name_terms)
+                model_name_frequency = _prefix_term_frequency(term, model_name_terms)
+                server_name_frequency = _prefix_term_frequency(term, server_name_terms)
                 description_frequency = _prefix_term_frequency(term, description_terms)
-                if name_frequency or description_frequency:
+                if model_name_frequency or server_name_frequency or description_frequency:
                     matched_terms += 1
-                name_document_frequency, description_document_frequency = (
-                    document_frequencies[term]
-                )
+                (
+                    model_name_document_frequency,
+                    server_name_document_frequency,
+                    description_document_frequency,
+                ) = document_frequencies[term]
                 relevance += 2.0 * _bm25_term_score(
-                    term_frequency=name_frequency,
-                    document_frequency=name_document_frequency,
+                    term_frequency=model_name_frequency,
+                    document_frequency=model_name_document_frequency,
                     document_count=len(documents),
-                    field_length=len(name_terms),
-                    average_field_length=average_name_length,
+                    field_length=len(model_name_terms),
+                    average_field_length=average_model_name_length,
+                )
+                relevance += 0.5 * _bm25_term_score(
+                    term_frequency=server_name_frequency,
+                    document_frequency=server_name_document_frequency,
+                    document_count=len(documents),
+                    field_length=len(server_name_terms),
+                    average_field_length=average_server_name_length,
                 )
                 relevance += _bm25_term_score(
                     term_frequency=description_frequency,
@@ -402,7 +424,6 @@ class MCPToolCatalog:
                 tool_id=entry.tool_id,
                 model_name=entry.model_name,
                 server_name=entry.server_name,
-                raw_tool_name=entry.raw_tool_name,
                 description=entry.description,
                 tool=entry.tool,
                 generation=entry.generation,

--- a/box_agent/tools/mcp_tool_catalog.py
+++ b/box_agent/tools/mcp_tool_catalog.py
@@ -7,6 +7,7 @@ an LLM is decided per Agent session by :mod:`mcp_tool_search`.
 from __future__ import annotations
 
 import asyncio
+import math
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -18,6 +19,41 @@ from .base import Tool
 def _normalize(value: str) -> str:
     value = value.strip().lower().replace("_", " ").replace("-", " ")
     return re.sub(r"\s+", " ", value)
+
+
+def _tokenize(value: str) -> tuple[str, ...]:
+    """Split searchable metadata into lowercase word-like terms."""
+    return tuple(re.findall(r"[^\W_]+", _normalize(value), flags=re.UNICODE))
+
+
+def _prefix_term_frequency(term: str, field_terms: tuple[str, ...]) -> int:
+    return sum(candidate.startswith(term) for candidate in field_terms)
+
+
+def _bm25_term_score(
+    *,
+    term_frequency: int,
+    document_frequency: int,
+    document_count: int,
+    field_length: int,
+    average_field_length: float,
+) -> float:
+    """Return a small dependency-free BM25 relevance component."""
+    if term_frequency <= 0 or document_frequency <= 0 or document_count <= 0:
+        return 0.0
+    k1 = 1.2
+    b = 0.7
+    inverse_document_frequency = math.log(
+        1 + (document_count - document_frequency + 0.5)
+        / (document_frequency + 0.5)
+    )
+    normalized_length = (
+        field_length / average_field_length if average_field_length > 0 else 1.0
+    )
+    return inverse_document_frequency * (
+        term_frequency * (k1 + 1)
+        / (term_frequency + k1 * (1 - b + b * normalized_length))
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,43 +216,182 @@ class MCPToolCatalog:
         server_name: str | None = None,
         top_k: int = 5,
     ) -> list[MCPToolEntry]:
+        ranked = self._ranked_search(query, server_name=server_name)
+        return [entry for *_, entry in ranked[: max(1, top_k)]]
+
+    def search_many(
+        self,
+        queries: Iterable[str],
+        *,
+        server_name: str | None = None,
+        top_k: int = 5,
+    ) -> list[MCPToolEntry]:
+        """Merge independent keyword searches using each tool's best rank."""
+        normalized_queries: list[str] = []
+        seen_queries: set[str] = set()
+        for query in queries:
+            normalized_query = _normalize(query)
+            if not normalized_query or normalized_query in seen_queries:
+                continue
+            seen_queries.add(normalized_query)
+            normalized_queries.append(query)
+
+        best_by_tool: dict[
+            str,
+            tuple[int, float, int, int, str, MCPToolEntry],
+        ] = {}
+        for query_index, query in enumerate(normalized_queries):
+            for exact_priority, neg_relevance, neg_matched, tool_id, entry in (
+                self._ranked_search(query, server_name=server_name)
+            ):
+                candidate = (
+                    exact_priority,
+                    neg_relevance,
+                    neg_matched,
+                    query_index,
+                    tool_id,
+                    entry,
+                )
+                current = best_by_tool.get(tool_id)
+                if current is None or candidate[:4] < current[:4]:
+                    best_by_tool[tool_id] = candidate
+
+        ranked = sorted(best_by_tool.values(), key=lambda item: item[:5])
+        return [entry for *_, entry in ranked[: max(1, top_k)]]
+
+    def lookup_exact(
+        self,
+        tool_names: Iterable[str],
+        *,
+        server_name: str | None = None,
+    ) -> tuple[list[MCPToolEntry], list[str]]:
+        """Resolve exact catalog IDs, qualified names, or model/raw names."""
+        entries = [
+            entry
+            for entry in self.snapshot()
+            if server_name is None or entry.server_name == server_name
+        ]
+        resolved: list[MCPToolEntry] = []
+        resolved_ids: set[str] = set()
+        missing: list[str] = []
+        for requested_name in tool_names:
+            normalized_name = _normalize(requested_name)
+            if not normalized_name:
+                continue
+            matches = [
+                entry
+                for entry in entries
+                if normalized_name
+                in {
+                    _normalize(entry.tool_id),
+                    _normalize(f"{entry.server_name}/{entry.raw_tool_name}"),
+                    _normalize(f"{entry.server_name}:{entry.raw_tool_name}"),
+                    _normalize(entry.model_name),
+                    _normalize(entry.raw_tool_name),
+                }
+            ]
+            if not matches:
+                missing.append(requested_name)
+                continue
+            for entry in matches:
+                if entry.tool_id in resolved_ids:
+                    continue
+                resolved_ids.add(entry.tool_id)
+                resolved.append(entry)
+        return resolved, missing
+
+    def _ranked_search(
+        self,
+        query: str,
+        *,
+        server_name: str | None = None,
+    ) -> list[tuple[int, float, int, str, MCPToolEntry]]:
         normalized_query = _normalize(query)
-        if not normalized_query:
+        query_terms = tuple(dict.fromkeys(_tokenize(query)))
+        if not normalized_query or not query_terms:
             return []
-        ranked: list[tuple[int, str, MCPToolEntry]] = []
+        documents = []
         for entry in self.snapshot():
             if server_name and entry.server_name != server_name:
                 continue
-            normalized_name = _normalize(entry.model_name)
-            normalized_id = _normalize(entry.tool_id)
-            normalized_server_name = _normalize(
-                f"{entry.server_name} {entry.model_name}"
+            documents.append(
+                (
+                    entry,
+                    _normalize(entry.model_name),
+                    _normalize(entry.tool_id),
+                    _normalize(f"{entry.server_name} {entry.model_name}"),
+                    _tokenize(f"{entry.server_name} {entry.model_name} {entry.tool_id}"),
+                    _tokenize(entry.description),
+                )
             )
-            normalized_desc = _normalize(entry.description)
+        if not documents:
+            return []
+
+        average_name_length = sum(len(item[4]) for item in documents) / len(documents)
+        average_description_length = sum(len(item[5]) for item in documents) / len(
+            documents
+        )
+        document_frequencies = {
+            term: (
+                sum(_prefix_term_frequency(term, item[4]) > 0 for item in documents),
+                sum(_prefix_term_frequency(term, item[5]) > 0 for item in documents),
+            )
+            for term in query_terms
+        }
+
+        ranked: list[tuple[int, float, int, str, MCPToolEntry]] = []
+        for (
+            entry,
+            normalized_name,
+            normalized_id,
+            normalized_server_name,
+            name_terms,
+            description_terms,
+        ) in documents:
+            exact_priority = 3
             if normalized_query == normalized_name:
-                score = 0
+                exact_priority = 0
             elif normalized_query == normalized_id:
-                score = 1
-            elif normalized_query in normalized_server_name:
-                score = 2
+                exact_priority = 1
+            elif normalized_query == normalized_server_name:
+                exact_priority = 2
             elif len(normalized_name) >= 3 and normalized_name in normalized_query:
-                # A model may name several concrete tools in one discovery query.
-                # Treat each embedded exact name as a hit instead of requiring
-                # every query word to exist in one tool's metadata.
-                score = 2
-            elif normalized_query in normalized_name:
-                score = 3
-            elif normalized_query in normalized_desc:
-                score = 4
-            else:
-                words = normalized_query.split()
-                haystack = f"{normalized_server_name} {normalized_desc} {normalized_id}"
-                if not all(word in haystack for word in words):
-                    continue
-                score = 5
-            ranked.append((score, entry.tool_id, entry))
-        ranked.sort(key=lambda item: (item[0], item[1]))
-        return [entry for _, _, entry in ranked[: max(1, top_k)]]
+                # Preserve main's compound-query behavior: when the model names
+                # a concrete tool inside a longer request, rank that explicit
+                # selection ahead of fuzzy BM25 matches.
+                exact_priority = 2
+
+            relevance = 0.0
+            matched_terms = 0
+            for term in query_terms:
+                name_frequency = _prefix_term_frequency(term, name_terms)
+                description_frequency = _prefix_term_frequency(term, description_terms)
+                if name_frequency or description_frequency:
+                    matched_terms += 1
+                name_document_frequency, description_document_frequency = (
+                    document_frequencies[term]
+                )
+                relevance += 2.0 * _bm25_term_score(
+                    term_frequency=name_frequency,
+                    document_frequency=name_document_frequency,
+                    document_count=len(documents),
+                    field_length=len(name_terms),
+                    average_field_length=average_name_length,
+                )
+                relevance += _bm25_term_score(
+                    term_frequency=description_frequency,
+                    document_frequency=description_document_frequency,
+                    document_count=len(documents),
+                    field_length=len(description_terms),
+                    average_field_length=average_description_length,
+                )
+            if exact_priority == 3 and matched_terms == 0:
+                continue
+            ranked.append(
+                (exact_priority, -relevance, -matched_terms, entry.tool_id, entry)
+            )
+        ranked.sort(key=lambda item: item[:4])
+        return ranked
 
     def _rebuild_conflicts(self) -> None:
         counts: dict[str, int] = {}

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -56,9 +56,11 @@ class ToolSearchTool(Tool):
             "returned by this call is immediately activated for this session and "
             "only those activated hits are added to the next model step; other "
             "deferred catalog tools are not exposed, while alwaysLoad tools remain "
-            "visible without search. Prefer a short capability or one exact tool "
-            "name per search; when several concrete tools are needed, search each "
-            "name separately. Set top_k to however many matching tool "
+            "visible without search. Use query for one keyword search, queries for "
+            "independent bilingual or synonymous searches, or tool_names to activate "
+            "only exact catalog IDs or names. Prefer short capability, server, or tool "
+            "keywords; task-specific operands are tolerated but should be omitted "
+            "when possible. Set top_k to however many matching tool "
             "schemas the task actually needs, including ten or more when appropriate. "
             "This search activates tools but does not execute them."
         )
@@ -71,8 +73,29 @@ class ToolSearchTool(Tool):
                 "query": {
                     "type": "string",
                     "description": (
-                        "Capability, action, or tool name. Returned matches are all "
-                        "activated for this session."
+                        "One capability, action, server, or tool keyword query. Kept "
+                        "for compatibility; prefer queries for independent alternatives."
+                    ),
+                },
+                "queries": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": (
+                        "Independent keyword queries merged by each tool's best "
+                        "relevance. Use separate Chinese, English, synonym, or exact "
+                        "capability phrases. Prefix matches are supported and "
+                        "unmatched task operands are tolerated."
+                    ),
+                },
+                "tool_names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": (
+                        "Exact tool IDs or names to activate, such as "
+                        "mcp:server/tool or server/tool. No fuzzy fallback is used, "
+                        "and unlisted catalog tools remain hidden."
                     ),
                 },
                 "server_name": {
@@ -84,29 +107,67 @@ class ToolSearchTool(Tool):
                     "minimum": 1,
                     "default": 1,
                     "description": (
-                        "Exact maximum number of matches to return and activate. "
-                        "Choose any positive count required by the task; there is no "
-                        "small fixed cap. Unreturned catalog tools remain hidden."
+                        "Exact maximum number of query matches to return and activate; "
+                        "ignored for tool_names. Choose any positive count required by "
+                        "the task; there is no small fixed cap. Unreturned catalog "
+                        "tools remain hidden."
                     ),
                 },
             },
-            "required": ["query"],
+            "anyOf": [
+                {"required": ["query"]},
+                {"required": ["queries"]},
+                {"required": ["tool_names"]},
+            ],
             "additionalProperties": False,
         }
 
     async def execute(
         self,
-        query: str,
+        query: str | None = None,
+        queries: list[str] | None = None,
+        tool_names: list[str] | None = None,
         server_name: str | None = None,
         top_k: int = 1,
     ) -> ToolResult:
+        normalized_queries = [
+            item
+            for item in ([query] if query else []) + (queries or [])
+            if isinstance(item, str) and item.strip()
+        ]
+        normalized_tool_names = [
+            item
+            for item in tool_names or []
+            if isinstance(item, str) and item.strip()
+        ]
+        search_input = {
+            "query": query,
+            "queries": normalized_queries,
+            "tool_names": normalized_tool_names,
+        }
+        if not normalized_queries and not normalized_tool_names:
+            payload = {
+                "success": False,
+                **search_input,
+                "activated": [],
+                "conflicts": [],
+                "missing": [],
+                "notice": "Provide query, queries, or exact tool_names.",
+            }
+            return ToolResult(
+                success=False,
+                content=json.dumps(payload, ensure_ascii=False),
+                error="Tool search input is empty.",
+            )
+
         if not await self._catalog.wait_until_ready(self._readiness_timeout):
             payload = {
                 "success": False,
-                "query": query,
+                **search_input,
                 "state": "catalog_loading",
                 "activated": [],
                 "conflicts": [],
+                "missing": [],
                 "notice": (
                     "The MCP catalog is still loading. Retry tool_search after the "
                     "runtime readiness update; no empty-catalog conclusion was made."
@@ -118,7 +179,18 @@ class ToolSearchTool(Tool):
                 error="MCP catalog is still loading; retry tool_search shortly.",
             )
 
-        hits = self._catalog.search(query, server_name=server_name, top_k=top_k)
+        missing: list[str] = []
+        if normalized_tool_names:
+            hits, missing = self._catalog.lookup_exact(
+                normalized_tool_names,
+                server_name=server_name,
+            )
+        else:
+            hits = self._catalog.search_many(
+                normalized_queries,
+                server_name=server_name,
+                top_k=top_k,
+            )
         activated_results = []
         conflicts = []
         protected_names = (
@@ -168,9 +240,10 @@ class ToolSearchTool(Tool):
             )
         payload = {
             "success": not conflicts or bool(activated_results),
-            "query": query,
+            **search_input,
             "activated": activated_results,
             "conflicts": conflicts,
+            "missing": missing,
             "notice": (
                 f"Activated exactly {len(activated_results)} returned tool(s) for this "
                 "session. Only these hits (plus explicit eager tools) are callable by "
@@ -179,7 +252,11 @@ class ToolSearchTool(Tool):
                 else (
                     "Matching tools have conflicting model-facing names."
                     if conflicts
-                    else "No matching MCP tools found."
+                    else (
+                        "No exact MCP tools found for the requested tool_names."
+                        if normalized_tool_names
+                        else "No matching MCP tools found."
+                    )
                 )
             ),
         }

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -62,6 +62,9 @@ class ToolSearchTool(Tool):
             "keywords; task-specific operands are tolerated but should be omitted "
             "when possible. Set top_k to however many matching tool "
             "schemas the task actually needs, including ten or more when appropriate. "
+            "The response reports catalog_tool_count for the applied server scope, "
+            "matched_count after query limits, and activated_count after conflict "
+            "filtering; never infer the catalog total from top_k or matched_count. "
             "This search activates tools but does not execute them."
         )
 
@@ -144,11 +147,15 @@ class ToolSearchTool(Tool):
             "query": query,
             "queries": normalized_queries,
             "tool_names": normalized_tool_names,
+            "server_name": server_name,
         }
         if not normalized_queries and not normalized_tool_names:
             payload = {
                 "success": False,
                 **search_input,
+                "catalog_tool_count": None,
+                "matched_count": 0,
+                "activated_count": 0,
                 "activated": [],
                 "conflicts": [],
                 "missing": [],
@@ -165,6 +172,9 @@ class ToolSearchTool(Tool):
                 "success": False,
                 **search_input,
                 "state": "catalog_loading",
+                "catalog_tool_count": None,
+                "matched_count": 0,
+                "activated_count": 0,
                 "activated": [],
                 "conflicts": [],
                 "missing": [],
@@ -179,6 +189,11 @@ class ToolSearchTool(Tool):
                 error="MCP catalog is still loading; retry tool_search shortly.",
             )
 
+        catalog_tool_count = sum(
+            1
+            for entry in self._catalog.snapshot()
+            if server_name is None or entry.server_name == server_name
+        )
         missing: list[str] = []
         if normalized_tool_names:
             hits, missing = self._catalog.lookup_exact(
@@ -241,6 +256,9 @@ class ToolSearchTool(Tool):
         payload = {
             "success": not conflicts or bool(activated_results),
             **search_input,
+            "catalog_tool_count": catalog_tool_count,
+            "matched_count": len(hits),
+            "activated_count": len(activated_results),
             "activated": activated_results,
             "conflicts": conflicts,
             "missing": missing,

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -219,6 +219,63 @@ def test_catalog_search_uses_prefix_matching_and_name_boost() -> None:
     ]
 
 
+def test_catalog_search_weights_description_above_server_name() -> None:
+    catalog = MCPToolCatalog()
+    server_match = FakeMCPTool(
+        "lookup_company",
+        "financial",
+        "Look up a company profile",
+    )
+    description_match = FakeMCPTool(
+        "lookup_report",
+        "documents",
+        "Find a financial report",
+    )
+    catalog.replace_server("financial", [server_match])
+    catalog.replace_server("documents", [description_match])
+
+    hits = catalog.search("financial", top_k=2)
+
+    assert [entry.model_name for entry in hits] == [
+        "lookup_report",
+        "lookup_company",
+    ]
+
+
+def test_catalog_search_does_not_fuzzy_match_tool_id_prefix() -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "browser",
+        [FakeMCPTool("navigate", "browser", "Open a web page")],
+    )
+
+    assert catalog.search("mcp") == []
+    assert [
+        entry.model_name
+        for entry in catalog.search("mcp:browser/navigate")
+    ] == ["navigate"]
+
+
+def test_catalog_deduplicates_server_terms_already_present_in_model_name() -> None:
+    catalog = MCPToolCatalog()
+    duplicate = FakeMCPTool(
+        "search_alpha",
+        "zeta-search",
+        "Browse alpha documentation",
+    )
+    model_only = FakeMCPTool(
+        "search_beta",
+        "alpha",
+        "Browse beta documentation",
+    )
+    catalog.replace_server("zeta-search", [duplicate])
+    catalog.replace_server("alpha", [model_only])
+
+    hits = catalog.search("search", top_k=2)
+
+    assert [entry.model_name for entry in hits] == ["search_beta", "search_alpha"]
+
+
 def test_catalog_search_many_merges_independent_queries_without_duplicates() -> None:
     catalog = MCPToolCatalog()
     forecast = FakeMCPTool(

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -176,6 +176,164 @@ def test_catalog_retains_real_schema_without_putting_tool_in_candidates() -> Non
     assert MCPToolExposureManager(catalog, OrderedDict()).prepare_tools([]).tools == []
 
 
+def test_catalog_search_tolerates_unmatched_business_operands() -> None:
+    catalog = MCPToolCatalog()
+    financials = FakeMCPTool(
+        "get_global_stock_financials",
+        "hexin-ifind-ds-global-stock-mcp",
+        "Retrieve financial statements for global equities",
+    )
+    news = FakeMCPTool(
+        "search_company_news",
+        "hexin-ifind-ds-news-mcp",
+        "Search company news and announcements",
+    )
+    catalog.replace_server("hexin-ifind-ds-global-stock-mcp", [financials])
+    catalog.replace_server("hexin-ifind-ds-news-mcp", [news])
+
+    hits = catalog.search("ifind global stock financial 腾讯 财报", top_k=1)
+
+    assert [entry.model_name for entry in hits] == ["get_global_stock_financials"]
+
+
+def test_catalog_search_uses_prefix_matching_and_name_boost() -> None:
+    catalog = MCPToolCatalog()
+    name_match = FakeMCPTool(
+        "find_financial_report",
+        "finance",
+        "Look up a company report",
+    )
+    description_match = FakeMCPTool(
+        "company_lookup",
+        "crm",
+        "Find a financial report for a company",
+    )
+    catalog.replace_server("finance", [name_match])
+    catalog.replace_server("crm", [description_match])
+
+    hits = catalog.search("finan", top_k=2)
+
+    assert [entry.model_name for entry in hits] == [
+        "find_financial_report",
+        "company_lookup",
+    ]
+
+
+def test_catalog_search_many_merges_independent_queries_without_duplicates() -> None:
+    catalog = MCPToolCatalog()
+    forecast = FakeMCPTool(
+        "get_weather_forecast",
+        "weather-pro",
+        "Get an hourly weather forecast for a location",
+    )
+    news = FakeMCPTool(
+        "search_stock_news",
+        "market-data",
+        "Search stock market news and announcements",
+    )
+    catalog.replace_server("weather-pro", [forecast])
+    catalog.replace_server("market-data", [news])
+
+    hits = catalog.search_many(
+        ["weather forecast", "stock news", "weather forecast"],
+        top_k=2,
+    )
+
+    assert {entry.model_name for entry in hits} == {
+        "get_weather_forecast",
+        "search_stock_news",
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_accepts_workbuddy_style_independent_queries() -> None:
+    catalog = MCPToolCatalog()
+    forecast = FakeMCPTool(
+        "get_weather_forecast",
+        "weather-pro",
+        "Get an hourly weather forecast for a location",
+    )
+    news = FakeMCPTool(
+        "search_stock_news",
+        "market-data",
+        "Search stock market news and announcements",
+    )
+    catalog.replace_server("weather-pro", [forecast])
+    catalog.replace_server("market-data", [news])
+    activated = OrderedDict()
+    search = ToolSearchTool(catalog, activated)
+
+    result = await search.execute(
+        queries=["天气预报", "weather forecast", "stock news"],
+        top_k=2,
+    )
+    payload = json.loads(result.content)
+
+    assert result.success is True
+    assert {item["name"] for item in payload["activated"]} == {
+        "get_weather_forecast",
+        "search_stock_news",
+    }
+    assert payload["queries"] == ["天气预报", "weather forecast", "stock news"]
+    assert search.parameters["anyOf"] == [
+        {"required": ["query"]},
+        {"required": ["queries"]},
+        {"required": ["tool_names"]},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exact_tool_names_activate_only_explicit_selections() -> None:
+    catalog = MCPToolCatalog()
+    selected = FakeMCPTool("get_forecast", "weather", "Get a forecast")
+    also_selected = FakeMCPTool("get_air_quality", "weather", "Get air quality")
+    hidden = FakeMCPTool("get_weather_alerts", "weather", "Get weather alerts")
+    catalog.replace_server("weather", [selected, also_selected, hidden])
+    activated = OrderedDict()
+    search = ToolSearchTool(catalog, activated)
+
+    result = await search.execute(
+        tool_names=[
+            "mcp:weather/get_forecast",
+            "weather/get_air_quality",
+            "weather/get_missing_tool",
+        ],
+        top_k=1,
+    )
+    payload = json.loads(result.content)
+    exposure = MCPToolExposureManager(catalog, activated).prepare_tools([])
+
+    assert result.success is True
+    assert [item["name"] for item in payload["activated"]] == [
+        "get_forecast",
+        "get_air_quality",
+    ]
+    assert payload["missing"] == ["weather/get_missing_tool"]
+    assert exposure.offered_names == frozenset(
+        {"get_forecast", "get_air_quality"}
+    )
+    assert "get_weather_alerts" not in exposure.offered_names
+
+
+@pytest.mark.asyncio
+async def test_exact_tool_names_do_not_fall_back_to_fuzzy_activation() -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "weather",
+        [FakeMCPTool("get_forecast", "weather", "Get a forecast")],
+    )
+    activated = OrderedDict()
+
+    result = await ToolSearchTool(catalog, activated).execute(
+        tool_names=["weather/get_forecas"],
+    )
+    payload = json.loads(result.content)
+
+    assert payload["activated"] == []
+    assert payload["missing"] == ["weather/get_forecas"]
+    assert activated == OrderedDict()
+
+
 @pytest.mark.asyncio
 async def test_search_activates_exactly_requested_hits_without_small_cap() -> None:
     catalog = MCPToolCatalog()
@@ -213,7 +371,20 @@ async def test_search_finds_multiple_exact_tool_names_inside_compound_query() ->
         "playwright",
         "Capture the current page snapshot",
     )
-    catalog.replace_server("playwright", [navigate, snapshot])
+    page_content = FakeMCPTool(
+        "extract_page_content",
+        "playwright",
+        "Playwright browser get exact page text from URL",
+    )
+    page_reader = FakeMCPTool(
+        "read_rendered_page",
+        "playwright",
+        "Navigate URL and get exact page text",
+    )
+    catalog.replace_server(
+        "playwright",
+        [navigate, snapshot, page_content, page_reader],
+    )
     activated = OrderedDict()
 
     result = await ToolSearchTool(catalog, activated).execute(
@@ -222,7 +393,7 @@ async def test_search_finds_multiple_exact_tool_names_inside_compound_query() ->
             "get exact page text"
         ),
         server_name="playwright",
-        top_k=10,
+        top_k=2,
     )
     payload = json.loads(result.content)
 

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -274,6 +274,10 @@ async def test_search_accepts_workbuddy_style_independent_queries() -> None:
         "get_weather_forecast",
         "search_stock_news",
     }
+    assert payload["server_name"] is None
+    assert payload["catalog_tool_count"] == 2
+    assert payload["matched_count"] == 2
+    assert payload["activated_count"] == 2
     assert payload["queries"] == ["天气预报", "weather forecast", "stock news"]
     assert search.parameters["anyOf"] == [
         {"required": ["query"]},
@@ -309,6 +313,9 @@ async def test_exact_tool_names_activate_only_explicit_selections() -> None:
         "get_air_quality",
     ]
     assert payload["missing"] == ["weather/get_missing_tool"]
+    assert payload["catalog_tool_count"] == 3
+    assert payload["matched_count"] == 2
+    assert payload["activated_count"] == 2
     assert exposure.offered_names == frozenset(
         {"get_forecast", "get_air_quality"}
     )
@@ -352,6 +359,9 @@ async def test_search_activates_exactly_requested_hits_without_small_cap() -> No
 
     assert search.parameters["properties"]["top_k"]["default"] == 1
     assert "maximum" not in search.parameters["properties"]["top_k"]
+    assert payload["catalog_tool_count"] == 12
+    assert payload["matched_count"] == 10
+    assert payload["activated_count"] == 10
     assert [item["name"] for item in payload["activated"]] == names[:10]
     assert [tool.name for tool in exposed.tools] == names[:10]
     assert set(names[10:]).isdisjoint(exposed.offered_names)
@@ -385,6 +395,10 @@ async def test_search_finds_multiple_exact_tool_names_inside_compound_query() ->
         "playwright",
         [navigate, snapshot, page_content, page_reader],
     )
+    catalog.replace_server(
+        "unrelated",
+        [FakeMCPTool("search_docs", "unrelated", "Search documentation")],
+    )
     activated = OrderedDict()
 
     result = await ToolSearchTool(catalog, activated).execute(
@@ -398,6 +412,10 @@ async def test_search_finds_multiple_exact_tool_names_inside_compound_query() ->
     payload = json.loads(result.content)
 
     assert result.success is True
+    assert payload["server_name"] == "playwright"
+    assert payload["catalog_tool_count"] == 4
+    assert payload["matched_count"] == 2
+    assert payload["activated_count"] == 2
     assert {item["name"] for item in payload["activated"]} == {
         "browser_navigate",
         "browser_snapshot",
@@ -420,6 +438,9 @@ async def test_duplicate_model_names_are_reported_but_not_activated() -> None:
     payload = json.loads(result.content)
 
     assert result.success is False
+    assert payload["catalog_tool_count"] == 2
+    assert payload["matched_count"] == 2
+    assert payload["activated_count"] == 0
     assert len(payload["conflicts"]) == 2
     assert payload["activated"] == []
     assert activated == OrderedDict()
@@ -483,6 +504,9 @@ async def test_search_reports_loading_instead_of_false_empty_result() -> None:
 
     assert result.success is False
     assert payload["state"] == "catalog_loading"
+    assert payload["catalog_tool_count"] is None
+    assert payload["matched_count"] == 0
+    assert payload["activated_count"] == 0
     assert payload["activated"] == []
     catalog.mark_ready()
 


### PR DESCRIPTION
## Task
- improve deferred MCP tool discovery with independent queries, exact `tool_names` lookup, prefix-aware BM25 ranking, and explicit catalog/match/activation counts
- reduce ranking noise by weighting tool names above descriptions, lowering server-name influence, excluding `tool_id` from fuzzy scoring, and deduplicating repeated terms
- preserve exact `tool_id`, qualified-name lookup, server filtering, conflict protection, and session-scoped activation

## Proof
- `uv run pytest tests/test_mcp_tool_search.py -q` -> 29 passed on Python 3.10
- `uv run python -m compileall -q box_agent/tools/mcp_tool_catalog.py` -> passed
- `git diff --check` -> passed
- local Windows full CI command reached 2,387 passed / 25 skipped / 167 failed; failures are existing platform/environment assumptions outside the three changed files (Windows temp-file locking, path separators, local runtime/config state, and presentation assets)
- Python 3.11/3.12 local matrix setup was blocked before test collection by a Windows `uv` PE-resource update error; GitHub Actions runs the matrix on Ubuntu

## Risk
- fuzzy result ordering changes for queries that match generic server names or synthetic `mcp`/tool-id tokens
- exact lookup and execution contracts remain unchanged
- source-only change; no packaged runtime build, install, restart, or live Officev3 task was performed