### PR TITLE
fix(acp): preserve session permission boundaries

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1301,8 +1301,18 @@ class BoxACPAgent:
                 message=f"Invalid permission_mode={raw_permission_mode!r}; using default permissions",
             )
             permission_mode = "default"
+        if permission_mode == "full_access" and not self._config.tools.allow_full_access:
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message=(
+                    "permission_mode='full_access' ignored because "
+                    "tools.allow_full_access=false; using default permissions"
+                ),
+            )
+            permission_mode = "default"
         session_allow_full_access = (
-            permission_mode == "full_access"
+            (permission_mode == "full_access" and self._config.tools.allow_full_access)
             or (permission_mode is None and self._config.tools.allow_full_access)
         )
         # Keep the managed Python/Jupyter runtime available in every ACP
@@ -1483,7 +1493,6 @@ class BoxACPAgent:
                 artifact_root_dir=output_dir,
                 env_context=env_context,
                 process_owner_id=session_id,
-                bypass_dangerous_command_approval=permission_mode == "full_access",
             )
             system_prompt = (
                 f"{system_prompt.rstrip()}\n\n"

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1292,9 +1292,38 @@ class BoxACPAgent:
         perm_engine = None
         grant_store = GrantStore()
         effective_policy: CapabilityPolicy | None = None
-        if self._has_officev3_policy():
+        raw_permission_mode = meta.get("permission_mode") if isinstance(meta, dict) else None
+        permission_mode = raw_permission_mode if raw_permission_mode in {"default", "full_access"} else None
+        if raw_permission_mode is not None and permission_mode is None:
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message=f"Invalid permission_mode={raw_permission_mode!r}; using default permissions",
+            )
+            permission_mode = "default"
+        session_allow_full_access = (
+            permission_mode == "full_access"
+            or (permission_mode is None and self._config.tools.allow_full_access)
+        )
+        # Keep the managed Python/Jupyter runtime available in every ACP
+        # permission mode. Full access bypasses the host permission engine via
+        # session_allow_full_access/perm_engine; it must not require users to
+        # have a separate host Python installation.
+        session_sandbox_mode = True
+
+        if self._has_officev3_policy() and permission_mode != "full_access":
             try:
                 base_policy = CapabilityPolicy.from_config(self._config)
+                if permission_mode == "default":
+                    # Explicit session-default mode must fail closed even when
+                    # the host omits its filesystem context. Host-provided
+                    # values below may narrow or extend this session baseline.
+                    base_policy = base_policy.with_filesystem_overrides(
+                        session_workspace_root=str(workspace),
+                        allowed_directories=[],
+                        filesystem_scope="session_workspace",
+                        replace_allowed_directories=True,
+                    )
 
                 # officev3_permissions_override is DEPRECATED — kept for parsing only.
                 # In-band permission/request negotiation handles escalation now.
@@ -1330,6 +1359,7 @@ class BoxACPAgent:
                         session_workspace_root=swr,
                         allowed_directories=extra_dirs,
                         filesystem_scope=fs_scope,
+                        replace_allowed_directories=permission_mode == "default",
                     )
                     log.info(
                         "session/permissions",
@@ -1356,9 +1386,28 @@ class BoxACPAgent:
                 )
                 effective_policy = fallback_policy
                 perm_engine = PermissionEngine(fallback_policy, workspace, grant_store=grant_store)
+        elif permission_mode == "default":
+            fallback_policy = CapabilityPolicy(
+                filesystem_scope="session_workspace",
+                session_workspace_root=str(workspace),
+            )
+            effective_policy = fallback_policy
+            perm_engine = PermissionEngine(fallback_policy, workspace, grant_store=grant_store)
+            session_allow_full_access = False
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message="No officev3 policy configured; using restrictive session policy",
+            )
+        elif permission_mode == "full_access":
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message="Full access enabled for this session; permission checks are bypassed",
+            )
 
         skill_runtime_context = build_skill_runtime_context(
-            sandbox_mode=True,
+            sandbox_mode=session_sandbox_mode,
             env_context=env_context,
         )
         session_skill_loader = self._skill_loader
@@ -1421,8 +1470,8 @@ class BoxACPAgent:
                 tools,
                 self._config,
                 workspace,
-                sandbox_mode=True,
-                allow_full_access=self._config.tools.allow_full_access,
+                sandbox_mode=session_sandbox_mode,
+                allow_full_access=session_allow_full_access,
                 non_interactive=True,  # ACP cannot do interactive terminal prompts
                 output=lambda msg: sys.stderr.write(msg + "\n"),
                 llm=session_llm,
@@ -1434,6 +1483,7 @@ class BoxACPAgent:
                 artifact_root_dir=output_dir,
                 env_context=env_context,
                 process_owner_id=session_id,
+                bypass_dangerous_command_approval=permission_mode == "full_access",
             )
             system_prompt = (
                 f"{system_prompt.rstrip()}\n\n"

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -781,7 +781,6 @@ class BashTool(Tool):
         permission_engine: PermissionEngine | None = None,
         runtime_env: dict[str, str] | None = None,
         process_owner_id: str | None = None,
-        bypass_dangerous_command_approval: bool = False,
     ):
         """Initialize BashTool with OS-specific shell detection.
 
@@ -798,8 +797,6 @@ class BashTool(Tool):
                                so subprocess commands use the sandbox Python.
             permission_engine: If provided, use capability-based permission checks.
             runtime_env: Extra runtime environment variables exposed to commands.
-            bypass_dangerous_command_approval: If True, skip approval for dangerous
-                                                commands in an explicitly trusted session.
         """
         self.is_windows = platform.system() == "Windows"
         self.shell_name = "PowerShell" if self.is_windows else "bash"
@@ -856,7 +853,6 @@ class BashTool(Tool):
         self.non_interactive = non_interactive
         self._perm = permission_engine
         self.process_owner_id = process_owner_id
-        self.bypass_dangerous_command_approval = bypass_dangerous_command_approval
         self._approved_safety_commands: set[str] = set()
         self._subprocess_env = None
         self._use_login_shell = True
@@ -1309,10 +1305,9 @@ Examples:
                     exit_code=1,
                 )
 
-            # 1. Dangerous command approval is bypassed only for an explicitly
-            # trusted full-access session. Hard product blocks above still apply.
+            # 1. Dangerous command detection (always active)
             danger_reason = detect_dangerous_command(command)
-            if danger_reason and not self.bypass_dangerous_command_approval:
+            if danger_reason:
                 if not self._consume_safety_approval(command, danger_reason):
                     return BashOutputResult(
                         success=False,

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -781,6 +781,7 @@ class BashTool(Tool):
         permission_engine: PermissionEngine | None = None,
         runtime_env: dict[str, str] | None = None,
         process_owner_id: str | None = None,
+        bypass_dangerous_command_approval: bool = False,
     ):
         """Initialize BashTool with OS-specific shell detection.
 
@@ -797,6 +798,8 @@ class BashTool(Tool):
                                so subprocess commands use the sandbox Python.
             permission_engine: If provided, use capability-based permission checks.
             runtime_env: Extra runtime environment variables exposed to commands.
+            bypass_dangerous_command_approval: If True, skip approval for dangerous
+                                                commands in an explicitly trusted session.
         """
         self.is_windows = platform.system() == "Windows"
         self.shell_name = "PowerShell" if self.is_windows else "bash"
@@ -853,6 +856,7 @@ class BashTool(Tool):
         self.non_interactive = non_interactive
         self._perm = permission_engine
         self.process_owner_id = process_owner_id
+        self.bypass_dangerous_command_approval = bypass_dangerous_command_approval
         self._approved_safety_commands: set[str] = set()
         self._subprocess_env = None
         self._use_login_shell = True
@@ -1305,9 +1309,10 @@ Examples:
                     exit_code=1,
                 )
 
-            # 1. Dangerous command detection (always active)
+            # 1. Dangerous command approval is bypassed only for an explicitly
+            # trusted full-access session. Hard product blocks above still apply.
             danger_reason = detect_dangerous_command(command)
-            if danger_reason:
+            if danger_reason and not self.bypass_dangerous_command_approval:
                 if not self._consume_safety_approval(command, danger_reason):
                     return BashOutputResult(
                         success=False,

--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -1184,6 +1184,7 @@ class JupyterSandboxTool(Tool):
         runtime_env: Mapping[str, str] | None = None,
         use_output_dir: bool = True,
         output_dir: str | None = None,
+        fixed_session_id: str | None = None,
     ):
         """Initialize sandbox tool.
 
@@ -1192,11 +1193,14 @@ class JupyterSandboxTool(Tool):
             runtime_env: Host runtime environment exported by env_context.
             use_output_dir: Chdir kernels into {workspace}/output when True.
             output_dir: Optional explicit artifact output directory.
+            fixed_session_id: Optional tool-owned session id. When set, callers
+                cannot switch kernels by passing a different session_id.
         """
         self.workspace_dir = workspace_dir
         self.runtime_env = dict(runtime_env or {})
         self.use_output_dir = use_output_dir
         self.output_dir = output_dir
+        self._fixed_session_id = fixed_session_id.strip() if fixed_session_id else None
         self._session_id: Optional[str] = None
 
     @property
@@ -1331,37 +1335,42 @@ Output formats:
 
     @property
     def parameters(self) -> dict[str, Any]:
+        properties: dict[str, Any] = {
+            "code": {
+                "type": "string",
+                "maxLength": MAX_EXECUTE_CODE_CHARS,
+                "description": (
+                    "Python code to execute. Keep this under "
+                    f"{MAX_EXECUTE_CODE_CHARS_DISPLAY} characters. For large "
+                    "generated static content such as HTML/CSS/JS, shared "
+                    "styles, JSON manifests, templates, base64, or file "
+                    "bodies, do not inline the body in execute_code; use "
+                    "ordered write_file chunks using chunk_index/final unless "
+                    "Python processing is actually required. "
+                    "Reads may use allowed input paths, but durable writes "
+                    "are confined to the active project/artifact root. "
+                    "Variables and functions from previous calls in the same "
+                    "session are available. Use %pip install <pkg> to install "
+                    "packages."
+                ),
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Execution timeout in seconds (default: 60, max: 300)",
+                "default": 60,
+            },
+        }
+        if self._fixed_session_id is None:
+            properties["session_id"] = {
+                "type": "string",
+                "description": (
+                    "Session ID for persistent kernel. Same session_id shares all state. "
+                    "Auto-generated if not provided."
+                ),
+            }
         return {
             "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string",
-                    "maxLength": MAX_EXECUTE_CODE_CHARS,
-                    "description": (
-                        "Python code to execute. Keep this under "
-                        f"{MAX_EXECUTE_CODE_CHARS_DISPLAY} characters. For large "
-                        "generated static content such as HTML/CSS/JS, shared "
-                        "styles, JSON manifests, templates, base64, or file "
-                        "bodies, do not inline the body in execute_code; use "
-                        "ordered write_file chunks using chunk_index/final unless "
-                        "Python processing is actually required. "
-                        "Reads may use allowed input paths, but durable writes "
-                        "are confined to the active project/artifact root. "
-                        "Variables and functions from previous calls in the same "
-                        "session are available. Use %pip install <pkg> to install "
-                        "packages."
-                    ),
-                },
-                "session_id": {
-                    "type": "string",
-                    "description": "Session ID for persistent kernel. Same session_id shares all state. Auto-generated if not provided.",
-                },
-                "timeout": {
-                    "type": "integer",
-                    "description": "Execution timeout in seconds (default: 60, max: 300)",
-                    "default": 60,
-                },
-            },
+            "properties": properties,
             "required": ["code"],
         }
 
@@ -1439,9 +1448,13 @@ Output formats:
             )
 
         # Create or get session
-        if session_id is None:
-            session_id = self._session_id or str(uuid.uuid4())[:8]
-        self._session_id = session_id
+        active_session_id = (
+            self._fixed_session_id
+            or session_id
+            or self._session_id
+            or str(uuid.uuid4())[:8]
+        )
+        self._session_id = active_session_id
 
         # Check kernel health if session already exists
         existing_session = self._sessions.get(self._session_id)
@@ -1449,22 +1462,32 @@ Output formats:
             old_session_id = self._session_id
             del self._sessions[self._session_id]
             existing_session = None
-            session_id = str(uuid.uuid4())[:8]
-            self._session_id = session_id
-            workspace = self._get_workspace(session_id)
-            session = self._create_session(session_id, workspace, env)
+            replacement_session_id = self._fixed_session_id or str(uuid.uuid4())[:8]
+            self._session_id = replacement_session_id
+            workspace = self._get_workspace(replacement_session_id)
+            session = self._create_session(replacement_session_id, workspace, env)
             await session.start()
-            self._sessions[session_id] = session
+            self._sessions[replacement_session_id] = session
+            if replacement_session_id == old_session_id:
+                restart_note = (
+                    "Sandbox kernel died. Auto-restarted this session; please retry your code."
+                )
+            else:
+                restart_note = (
+                    "Sandbox kernel died "
+                    f"(old session={old_session_id}). Auto-restarted with new session="
+                    f"{replacement_session_id}. Please retry your code."
+                )
             return ToolResult(
                 success=False,
                 content="",
-                error=f"KERNEL_DIED: Sandbox kernel died (old session={old_session_id}). Auto-restarted with new session={session_id}. Please retry your code.",
+                error=f"KERNEL_DIED: {restart_note}",
             )
 
         # Get or create kernel session
-        if session_id not in self._sessions:
-            workspace = self._get_workspace(session_id)
-            session = self._create_session(session_id, workspace, env)
+        if active_session_id not in self._sessions:
+            workspace = self._get_workspace(active_session_id)
+            session = self._create_session(active_session_id, workspace, env)
             try:
                 await session.start()
             except RuntimeError as e:
@@ -1473,9 +1496,9 @@ Output formats:
                     content="",
                     error=f"KERNEL_START_FAILED: {e}",
                 )
-            self._sessions[session_id] = session
+            self._sessions[active_session_id] = session
 
-        session = self._sessions[session_id]
+        session = self._sessions[active_session_id]
 
         # Snapshot files in workspace BEFORE execution to detect new ones
         workspace = session.workspace
@@ -1522,7 +1545,7 @@ Output formats:
             # session (it would corrupt the next call's output if reused) and
             # surface a timeout, mirroring the outer wait_for timeout branch.
             if error == KERNEL_EXEC_TIMEOUT:
-                await self._discard_session(session_id)
+                await self._discard_session(active_session_id)
                 return ToolResult(
                     success=False,
                     content="",
@@ -1567,7 +1590,7 @@ Output formats:
             # worker we cannot cancel. Discard the session so it is NOT reused
             # (a busy kernel would interleave IOPub output on the next call);
             # stopping it also unblocks the orphaned worker thread.
-            await self._discard_session(session_id)
+            await self._discard_session(active_session_id)
             return ToolResult(
                 success=False,
                 content="",

--- a/box_agent/tools/permissions.py
+++ b/box_agent/tools/permissions.py
@@ -90,6 +90,7 @@ class CapabilityPolicy(BaseModel):
         session_workspace_root: str | None = None,
         allowed_directories: tuple[str, ...] | list[str] | None = None,
         filesystem_scope: str | None = None,
+        replace_allowed_directories: bool = False,
     ) -> CapabilityPolicy:
         """Apply per-session filesystem context from a trusted host.
 
@@ -105,12 +106,15 @@ class CapabilityPolicy(BaseModel):
         if session_workspace_root is not None:
             updates["session_workspace_root"] = session_workspace_root
         if allowed_directories is not None:
-            # Merge with existing rather than replace, so host injection adds
-            # to whatever is configured globally.
-            merged = list(self.allowed_directories) + [
-                d for d in allowed_directories if d not in self.allowed_directories
-            ]
-            updates["allowed_directories"] = tuple(merged)
+            if replace_allowed_directories:
+                updates["allowed_directories"] = tuple(dict.fromkeys(allowed_directories))
+            else:
+                # Legacy host context remains additive for clients that have
+                # not opted into the session permission protocol.
+                merged = list(self.allowed_directories) + [
+                    d for d in allowed_directories if d not in self.allowed_directories
+                ]
+                updates["allowed_directories"] = tuple(merged)
         if filesystem_scope is not None:
             updates["filesystem_scope"] = filesystem_scope
         if not updates:

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -528,7 +528,8 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         use_output_dir: bool = True,
                         artifact_root_dir: str | Path | None = None,
                         env_context=None,
-                        process_owner_id: str | None = None):
+                        process_owner_id: str | None = None,
+                        bypass_dangerous_command_approval: bool = False):
     """Add workspace-dependent tools
 
     These tools need to know the workspace directory.
@@ -588,6 +589,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             permission_engine=permission_engine,
             runtime_env=runtime_env,
             process_owner_id=process_owner_id,
+            bypass_dangerous_command_approval=bypass_dangerous_command_approval,
         )
         tools.append(bash_tool)
         if process_owner_id is not None:

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -528,8 +528,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         use_output_dir: bool = True,
                         artifact_root_dir: str | Path | None = None,
                         env_context=None,
-                        process_owner_id: str | None = None,
-                        bypass_dangerous_command_approval: bool = False):
+                        process_owner_id: str | None = None):
     """Add workspace-dependent tools
 
     These tools need to know the workspace directory.
@@ -589,7 +588,6 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             permission_engine=permission_engine,
             runtime_env=runtime_env,
             process_owner_id=process_owner_id,
-            bypass_dangerous_command_approval=bypass_dangerous_command_approval,
         )
         tools.append(bash_tool)
         if process_owner_id is not None:
@@ -683,6 +681,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             runtime_env=runtime_context.env(),
             use_output_dir=use_output_dir,
             output_dir=str(artifact_root) if artifact_root else None,
+            fixed_session_id=process_owner_id,
         )
         tools.append(sandbox_tool)
         # Also add sandbox status tool

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -3921,7 +3921,6 @@ async def test_acp_default_permission_mode_without_filesystem_policy_fails_close
     bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
 
     assert bash_tool.allow_full_access is False
-    assert bash_tool.bypass_dangerous_command_approval is False
     assert bash_tool._perm is not None
     assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
     assert bash_tool._perm.policy.session_workspace_root == str(workspace)
@@ -3929,7 +3928,7 @@ async def test_acp_default_permission_mode_without_filesystem_policy_fails_close
 
 
 @pytest.mark.asyncio
-async def test_acp_full_access_mode_bypasses_permission_engine(tmp_path):
+async def test_acp_full_access_mode_respects_server_allow_full_access(tmp_path):
     workspace = tmp_path / "workspace"
     config = Config(
         llm=LLMConfig(api_key="test-key"),
@@ -3947,9 +3946,10 @@ async def test_acp_full_access_mode_bypasses_permission_engine(tmp_path):
     bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
     session_tools = agent._sessions[session.sessionId].agent.tools
 
-    assert bash_tool.allow_full_access is True
-    assert bash_tool.bypass_dangerous_command_approval is True
-    assert bash_tool._perm is None
+    assert bash_tool.allow_full_access is False
+    assert bash_tool._perm is not None
+    assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
+    assert bash_tool._perm.policy.session_workspace_root == str(workspace)
     assert "execute_code" in session_tools
     assert "sandbox_status" in session_tools
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -3842,6 +3842,119 @@ async def test_acp_prompt_lists_officev3_allowed_directories(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_acp_default_permission_mode_replaces_global_allowed_directories(tmp_path):
+    global_allowed = tmp_path / "global"
+    session_allowed = tmp_path / "session-allowed"
+    workspace = tmp_path / "workspace"
+    global_allowed.mkdir()
+    session_allowed.mkdir()
+
+    officev3 = Officev3Config(
+        permissions=Officev3Permissions(
+            filesystem=FilesystemPermissions(
+                scope="user_home",
+                allowed_directories=[str(global_allowed)],
+            )
+        ),
+        paths=Officev3Paths(session_workspace_root=str(tmp_path / "legacy-root")),
+    )
+    officev3._present = True
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=True),
+        officev3=officev3,
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={
+                "permission_mode": "default",
+                "filesystem_policy": {
+                    "filesystem_scope": "session_workspace",
+                    "session_workspace_root": str(workspace),
+                    "allowed_directories": [str(session_allowed)],
+                },
+            },
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+
+    assert bash_tool.allow_full_access is False
+    assert bash_tool._perm is not None
+    assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
+    assert bash_tool._perm.policy.allowed_directories == (str(session_allowed),)
+
+
+@pytest.mark.asyncio
+async def test_acp_default_permission_mode_without_filesystem_policy_fails_closed(tmp_path):
+    global_allowed = tmp_path / "global"
+    workspace = tmp_path / "workspace"
+    global_allowed.mkdir()
+
+    officev3 = Officev3Config(
+        permissions=Officev3Permissions(
+            filesystem=FilesystemPermissions(
+                scope="user_home",
+                allowed_directories=[str(global_allowed)],
+            )
+        ),
+        paths=Officev3Paths(session_workspace_root=str(tmp_path / "legacy-root")),
+    )
+    officev3._present = True
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=True),
+        officev3=officev3,
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={"permission_mode": "default"},
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+
+    assert bash_tool.allow_full_access is False
+    assert bash_tool.bypass_dangerous_command_approval is False
+    assert bash_tool._perm is not None
+    assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
+    assert bash_tool._perm.policy.session_workspace_root == str(workspace)
+    assert bash_tool._perm.policy.allowed_directories == ()
+
+
+@pytest.mark.asyncio
+async def test_acp_full_access_mode_bypasses_permission_engine(tmp_path):
+    workspace = tmp_path / "workspace"
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={"permission_mode": "full_access"},
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+    session_tools = agent._sessions[session.sessionId].agent.tools
+
+    assert bash_tool.allow_full_access is True
+    assert bash_tool.bypass_dangerous_command_approval is True
+    assert bash_tool._perm is None
+    assert "execute_code" in session_tools
+    assert "sandbox_status" in session_tools
+
+
+@pytest.mark.asyncio
 async def test_acp_prompt_includes_skill_runtime_context(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     sandbox_base = tmp_path / "sandbox-runtime"

--- a/tests/test_jupyter_runtime_python.py
+++ b/tests/test_jupyter_runtime_python.py
@@ -112,6 +112,15 @@ def test_sandbox_tool_accepts_runtime_env_python_without_process_env(
     assert env._bundled_override is True
 
 
+def test_fixed_session_id_hides_session_parameter(tmp_path: Path) -> None:
+    tool = JupyterSandboxTool(
+        workspace_dir=str(tmp_path / "workspace"),
+        fixed_session_id="acp-session-1",
+    )
+
+    assert "session_id" not in tool.parameters["properties"]
+
+
 def test_sandbox_subprocess_env_includes_host_runtime_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -265,6 +274,49 @@ async def test_execute_code_runs_with_runtime_env_python(
 
     assert result.success is True
     assert "external-python-ok" in result.content
+
+
+@pytest.mark.asyncio
+async def test_fixed_session_id_ignores_caller_supplied_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_python_runtime_env(monkeypatch)
+    monkeypatch.setattr(jupyter_tool, "SANDBOX_BASE_DIR", tmp_path / "sandbox")
+    monkeypatch.setattr(jupyter_tool, "RUNTIME_PACKAGES_DIR", tmp_path / "runtime-packages")
+    monkeypatch.setattr(SandboxEnvironment, "_REQUIRED_MODULES", {"ipykernel": "ipykernel"})
+    await JupyterSandboxTool.shutdown_all()
+    JupyterSandboxTool._sandbox_env = None
+    JupyterSandboxTool._sandbox_env_key = None
+    tool_a = JupyterSandboxTool(
+        workspace_dir=str(tmp_path / "workspace-a"),
+        runtime_env={"BOX_AGENT_SANDBOX_PYTHON": sys.executable},
+        fixed_session_id="acp-session-a",
+    )
+    tool_b = JupyterSandboxTool(
+        workspace_dir=str(tmp_path / "workspace-b"),
+        runtime_env={"BOX_AGENT_SANDBOX_PYTHON": sys.executable},
+        fixed_session_id="acp-session-b",
+    )
+
+    try:
+        result_a = await tool_a.execute("secret = 41\nprint(secret)", session_id="shared-kernel")
+        result_b = await tool_b.execute(
+            "print(globals().get('secret', 'missing'))",
+            session_id="shared-kernel",
+        )
+        result_a_again = await tool_a.execute("print(secret)", session_id="other-kernel")
+    finally:
+        await JupyterSandboxTool.shutdown_all()
+        JupyterSandboxTool._sandbox_env = None
+        JupyterSandboxTool._sandbox_env_key = None
+
+    assert result_a.success is True
+    assert "41" in result_a.content
+    assert result_b.success is True
+    assert "missing" in result_b.content
+    assert result_a_again.success is True
+    assert "41" in result_a_again.content
 
 
 def test_frozen_without_host_python_keeps_in_process_fallback(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -583,6 +583,16 @@ class TestFilesystemOverrides:
         # No duplicate
         assert list(new.allowed_directories).count("/a") == 1
 
+    def test_allowed_directories_replaced_for_session_policy(self):
+        base = CapabilityPolicy(allowed_directories=("/global",))
+        new = base.with_filesystem_overrides(
+            allowed_directories=["/session", "/session"],
+            replace_allowed_directories=True,
+        )
+
+        assert new.allowed_directories == ("/session",)
+        assert base.allowed_directories == ("/global",)
+
     def test_no_args_returns_self(self):
         base = CapabilityPolicy(session_workspace_root="/r")
         new = base.with_filesystem_overrides()
@@ -802,6 +812,21 @@ class TestBashPermissionPhase1:
             permission_engine=perm_engine,
         )
         return await tool.execute(command)
+
+    async def test_full_access_bypasses_dangerous_command_approval(self, workspace: Path):
+        from box_agent.tools.bash_tool import BashTool
+
+        tool = BashTool(
+            workspace_dir=str(workspace),
+            allow_full_access=True,
+            non_interactive=True,
+            permission_engine=None,
+            bypass_dangerous_command_approval=True,
+        )
+        result = await tool.execute(f'rm -rf "{workspace / "missing-target"}"')
+
+        assert result.permission_request is None
+        assert "Approval required" not in (result.stderr or "")
 
     def _make_engine(self, workspace: Path) -> PermissionEngine:
         policy = CapabilityPolicy()  # session_workspace scope

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -813,7 +813,7 @@ class TestBashPermissionPhase1:
         )
         return await tool.execute(command)
 
-    async def test_full_access_bypasses_dangerous_command_approval(self, workspace: Path):
+    async def test_full_access_still_requires_dangerous_command_approval(self, workspace: Path):
         from box_agent.tools.bash_tool import BashTool
 
         tool = BashTool(
@@ -821,12 +821,11 @@ class TestBashPermissionPhase1:
             allow_full_access=True,
             non_interactive=True,
             permission_engine=None,
-            bypass_dangerous_command_approval=True,
         )
         result = await tool.execute(f'rm -rf "{workspace / "missing-target"}"')
 
-        assert result.permission_request is None
-        assert "Approval required" not in (result.stderr or "")
+        assert result.permission_request is not None
+        assert "Approval required" in (result.stderr or "")
 
     def _make_engine(self, workspace: Path) -> PermissionEngine:
         policy = CapabilityPolicy()  # session_workspace scope


### PR DESCRIPTION
## Task
- preserve the session-scoped permission work from PR #36 while closing the remaining service-side escapes
- keep `permission_mode=default` fail-closed behavior and session filesystem replacement semantics
- bind ACP `execute_code` kernels to the ACP session instead of a model-supplied `session_id`
- keep dangerous-command approval active and require the server `tools.allow_full_access` gate before any session can enter `full_access`

## Proof
- `uv run pytest tests/test_acp.py -q -k "default_permission_mode or full_access_mode_respects_server_allow_full_access"`
- `uv run pytest tests/test_permissions.py -q -k "full_access_still_requires_dangerous_command_approval or allowed_directories_replaced_for_session_policy"`
- `uv run pytest tests/test_jupyter_runtime_python.py -q -k "fixed_session_id or execute_code_runs_with_runtime_env_python"`
- `uv run python -m compileall -q box_agent/acp/__init__.py box_agent/tools/bash_tool.py box_agent/tools/jupyter_tool.py box_agent/tools/setup.py tests/test_acp.py tests/test_permissions.py tests/test_jupyter_runtime_python.py`
- `git diff --check`

## Risk
- source-only validation; no packaged runtime build/install/restart/live Officev3 probe was run
- ACP `execute_code` no longer accepts caller-selected `session_id`; CLI behavior is unchanged because only ACP-owned tools pass a fixed session id
- this supersedes the unsafe merge path from PR #36 because that fork branch could not be updated from this environment