### PR TITLE
fix(core): Harden session permissions and context recovery

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1293,7 +1293,12 @@ class BoxACPAgent:
         grant_store = GrantStore()
         effective_policy: CapabilityPolicy | None = None
         raw_permission_mode = meta.get("permission_mode") if isinstance(meta, dict) else None
-        permission_mode = raw_permission_mode if raw_permission_mode in {"default", "full_access"} else None
+        permission_mode = (
+            raw_permission_mode
+            if isinstance(raw_permission_mode, str)
+            and raw_permission_mode in {"default", "full_access"}
+            else None
+        )
         if raw_permission_mode is not None and permission_mode is None:
             log.warn(
                 "session/permissions",
@@ -1301,19 +1306,37 @@ class BoxACPAgent:
                 message=f"Invalid permission_mode={raw_permission_mode!r}; using default permissions",
             )
             permission_mode = "default"
-        session_allow_full_access = (
+        if (
             permission_mode == "full_access"
-            or (permission_mode is None and self._config.tools.allow_full_access)
+            and not self._config.tools.allow_full_access
+        ):
+            log.warn(
+                "session/permissions",
+                session_id=session_id,
+                message=(
+                    "Session requested full_access but the server disables "
+                    "tools.allow_full_access; using default permissions"
+                ),
+            )
+            permission_mode = "default"
+        session_allow_full_access = (
+            self._config.tools.allow_full_access
+            and permission_mode != "default"
         )
-        # Keep the managed Python/Jupyter runtime available in every ACP
-        # permission mode. Full access bypasses the host permission engine via
-        # session_allow_full_access/perm_engine; it must not require users to
-        # have a separate host Python installation.
-        session_sandbox_mode = True
+        # execute_code is a real Python process, not an OS filesystem sandbox.
+        # Expose it only when the server has explicitly enabled full access.
+        session_sandbox_mode = session_allow_full_access
 
-        if self._has_officev3_policy() and permission_mode != "full_access":
+        if (
+            permission_mode != "full_access"
+            and (self._has_officev3_policy() or permission_mode == "default")
+        ):
             try:
-                base_policy = CapabilityPolicy.from_config(self._config)
+                base_policy = (
+                    CapabilityPolicy.from_config(self._config)
+                    if self._has_officev3_policy()
+                    else CapabilityPolicy()
+                )
                 if permission_mode == "default":
                     # Explicit session-default mode must fail closed even when
                     # the host omits its filesystem context. Host-provided
@@ -1386,19 +1409,6 @@ class BoxACPAgent:
                 )
                 effective_policy = fallback_policy
                 perm_engine = PermissionEngine(fallback_policy, workspace, grant_store=grant_store)
-        elif permission_mode == "default":
-            fallback_policy = CapabilityPolicy(
-                filesystem_scope="session_workspace",
-                session_workspace_root=str(workspace),
-            )
-            effective_policy = fallback_policy
-            perm_engine = PermissionEngine(fallback_policy, workspace, grant_store=grant_store)
-            session_allow_full_access = False
-            log.warn(
-                "session/permissions",
-                session_id=session_id,
-                message="No officev3 policy configured; using restrictive session policy",
-            )
         elif permission_mode == "full_access":
             log.warn(
                 "session/permissions",
@@ -1483,7 +1493,6 @@ class BoxACPAgent:
                 artifact_root_dir=output_dir,
                 env_context=env_context,
                 process_owner_id=session_id,
-                bypass_dangerous_command_approval=permission_mode == "full_access",
             )
             system_prompt = (
                 f"{system_prompt.rstrip()}\n\n"

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -283,6 +283,9 @@ class _GoalReadTool(Tool):
     def parameters(self) -> dict:
         return {"type": "object", "properties": {}}
 
+    def compaction_state(self) -> tuple[str, str]:
+        return "Goal", json.dumps(_goal_snapshot(self._agent), ensure_ascii=False)
+
     async def execute(self) -> ToolResult:
         goal = self._agent.goal
         if goal is None:

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -340,7 +340,7 @@ def _message_text(content: str | list[dict[str, Any]]) -> str:
 
 def _latest_user_text(messages: list[Message]) -> str:
     for msg in reversed(messages):
-        if msg.role == "user":
+        if msg.role == "user" and not _is_compaction_metadata(msg):
             return _message_text(msg.content)
     return ""
 
@@ -1357,15 +1357,21 @@ def _fallback_context_estimate(
     """Estimate a complete request as characters / 4 when usage is absent."""
 
     chars = sum(_message_chars(message) for message in messages)
+    serialized_parts = [
+        _summary_message_text(message)
+        for message in messages
+    ]
     if tools:
-        chars += len(
+        serialized_parts.append(
             json.dumps(
                 [tool.to_openai_schema() for tool in tools.values()],
                 ensure_ascii=False,
                 default=str,
             )
         )
-    return max(1, chars // 4)
+        chars += len(serialized_parts[-1])
+    utf8_bytes = sum(len(part.encode("utf-8")) for part in serialized_parts)
+    return max(1, chars // 4, utf8_bytes // 3)
 
 
 def _estimate_context_from_latest_response(
@@ -1381,8 +1387,17 @@ def _estimate_context_from_latest_response(
         usage = messages[index].usage
         if messages[index].role != "assistant" or usage is None:
             continue
-        added_chars = sum(_message_chars(message) for message in messages[index + 1 :])
-        return usage.context_tokens + added_chars // 4, "usage"
+        added_messages = messages[index + 1 :]
+        added_tokens = (
+            _fallback_context_estimate(added_messages, None)
+            if added_messages
+            else 0
+        )
+        usage_estimate = usage.context_tokens + added_tokens
+        # Deferred MCP activation can change the next request's tool schemas
+        # after the provider usage boundary. Compare with the complete current
+        # request estimate so newly exposed schemas are never omitted.
+        return max(usage_estimate, _fallback_context_estimate(messages, tools)), "usage"
 
     # Backward-compatible low-level callers may still provide a usage total
     # without response metadata attached to a Message. There is no safe delta
@@ -1452,41 +1467,27 @@ def _select_recent_messages(
 
 
 async def _restore_runtime_state(
-    messages: list[Message],
+    _messages: list[Message],
     tools: dict[str, Tool] | None,
 ) -> Message | None:
-    """Render current todo, plan, and invoked-skill state as one user message."""
+    """Render trusted read-only tool state without executing a tool call."""
 
     sections: list[str] = []
     if tools:
-        for tool_name, label in (("todo_read", "Todo"), ("plan_read", "Plan")):
-            tool = tools.get(tool_name)
-            if tool is None:
-                continue
+        for tool in tools.values():
             try:
-                result = await tool.invoke({})
+                state = tool.compaction_state()
             except Exception as exc:
-                _log.warning("post-compact %s restore failed: %s", tool_name, exc)
+                _log.warning(
+                    "post-compact state restore failed for %s: %s",
+                    getattr(tool, "name", type(tool).__name__),
+                    exc,
+                )
                 continue
-            if result.success and result.content:
-                sections.append(f"## {label}\n{result.content[:12_000]}")
-
-    skill_names: list[str] = []
-    for message in messages:
-        if message.role != "assistant" or not message.tool_calls:
-            continue
-        for call in message.tool_calls:
-            if call.function.name != "get_skill":
-                continue
-            name = call.function.arguments.get("skill_name")
-            if isinstance(name, str) and name and name not in skill_names:
-                skill_names.append(name)
-    if skill_names:
-        sections.append(
-            "## Active Skills\n"
-            + ", ".join(skill_names)
-            + "\nFull active skill instructions remain pinned in the system message."
-        )
+            if state is not None:
+                label, content = state
+                if content:
+                    sections.append(f"## {label}\n{content[:12_000]}")
     if not sections:
         return None
     return Message(
@@ -4986,7 +4987,7 @@ async def run_agent_loop(
                 tool=tools.get(fn_name),
                 session_id=session_id,
                 persistence_content=(
-                    result.persistence_content if result.success else None
+                    result.persistence_content
                 ),
                 content_already_processed=(
                     result.success
@@ -5621,7 +5622,7 @@ async def run_agent_loop(
                     tool=tools.get(fn_name),
                     session_id=session_id,
                     persistence_content=(
-                        result.persistence_content if result.success else None
+                        result.persistence_content
                     ),
                     content_already_processed=(
                         result.success

--- a/box_agent/tool_result_storage.py
+++ b/box_agent/tool_result_storage.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import math
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
+from uuid import uuid4
 
 from .schema import Message
 from .tools.base import Tool
@@ -62,15 +64,15 @@ def build_persisted_output(
 ) -> str:
     """Build the stable preview shown to the model for a persisted result."""
 
-    label = preview_label or f"Preview (first {_format_size(PREVIEW_SIZE_CHARS)})"
     message = (
         f"{PERSISTED_OUTPUT_TAG}\n"
         f"Output too large ({_format_size(result.original_size)}). "
-        f"Full output saved to: {result.path}\n\n"
-        f"{label}:\n"
-        f"{result.preview}"
+        f"Full output saved to: {result.path}\n"
     )
-    message += "\n...\n" if result.has_more else "\n"
+    if result.preview:
+        label = preview_label or f"Preview (first {_format_size(PREVIEW_SIZE_CHARS)})"
+        message += f"\n{label}:\n{result.preview}"
+        message += "\n...\n" if result.has_more else "\n"
     return message + PERSISTED_OUTPUT_CLOSING_TAG
 
 
@@ -141,6 +143,7 @@ class ToolResultStorage:
         self.root_dir = Path(root_dir)
         self.default_result_limit = default_result_limit
         self.aggregate_budget = aggregate_budget
+        self._default_session_id = f"local-{uuid4().hex}"
         self._seen_ids: set[str] = set()
         self._replacements: dict[str, str] = {}
         self._initialized = False
@@ -273,12 +276,16 @@ class ToolResultStorage:
                 message.content,
                 message.tool_call_id or "tool-result",
                 session_id=session_id,
+                include_preview=False,
             )
             if replacement is None:
                 continue
+            replacement_size = len(replacement)
+            if replacement_size >= size:
+                continue
             self._replacements[message.tool_call_id or ""] = replacement
             messages[index] = message.model_copy(update={"content": replacement})
-            remaining_chars -= size
+            remaining_chars += replacement_size - size
             persisted_count += 1
 
         return ToolResultBudgetOutcome(
@@ -295,12 +302,14 @@ class ToolResultStorage:
         *,
         session_id: str,
         model_content: str | list[dict[str, Any]] | None = None,
+        include_preview: bool = True,
     ) -> str | None:
         serialized = _content_text(content)
         if serialized is None:
             return None
         content_text, is_json = serialized
-        session = _safe_path_segment(session_id, "default")
+        effective_session_id = session_id or self._default_session_id
+        session = _safe_path_segment(effective_session_id, "local")
         identifier = _safe_path_segment(tool_use_id, "tool-result")
         path = self.root_dir / session / "tool-results" / (
             f"{identifier}.json" if is_json else f"{identifier}.txt"
@@ -311,11 +320,28 @@ class ToolResultStorage:
                 with path.open("x", encoding="utf-8") as stream:
                     stream.write(content_text)
             except FileExistsError:
-                pass
+                try:
+                    existing = path.read_text(encoding="utf-8")
+                except OSError:
+                    return None
+                if existing != content_text:
+                    digest = hashlib.sha256(content_text.encode("utf-8")).hexdigest()[:12]
+                    path = path.with_name(f"{path.stem}-{digest}{path.suffix}")
+                    try:
+                        with path.open("x", encoding="utf-8") as stream:
+                            stream.write(content_text)
+                    except FileExistsError:
+                        try:
+                            if path.read_text(encoding="utf-8") != content_text:
+                                return None
+                        except OSError:
+                            return None
         except OSError:
             return None
         preview_label = None
-        if model_content is None:
+        if not include_preview:
+            preview, has_more = "", True
+        elif model_content is None:
             preview, has_more = generate_preview(content_text)
         else:
             serialized_model_content = _content_text(model_content)

--- a/box_agent/tools/base.py
+++ b/box_agent/tools/base.py
@@ -49,6 +49,11 @@ class Tool:
     # through ``ToolResult.persistence_content``.
     max_result_size_chars: float = 50_000
 
+    def compaction_state(self) -> tuple[str, str] | None:
+        """Return trusted read-only runtime state for history compaction."""
+
+        return None
+
     @property
     def name(self) -> str:
         """Tool name."""

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -781,7 +781,6 @@ class BashTool(Tool):
         permission_engine: PermissionEngine | None = None,
         runtime_env: dict[str, str] | None = None,
         process_owner_id: str | None = None,
-        bypass_dangerous_command_approval: bool = False,
     ):
         """Initialize BashTool with OS-specific shell detection.
 
@@ -798,8 +797,6 @@ class BashTool(Tool):
                                so subprocess commands use the sandbox Python.
             permission_engine: If provided, use capability-based permission checks.
             runtime_env: Extra runtime environment variables exposed to commands.
-            bypass_dangerous_command_approval: If True, skip approval for dangerous
-                                                commands in an explicitly trusted session.
         """
         self.is_windows = platform.system() == "Windows"
         self.shell_name = "PowerShell" if self.is_windows else "bash"
@@ -856,7 +853,6 @@ class BashTool(Tool):
         self.non_interactive = non_interactive
         self._perm = permission_engine
         self.process_owner_id = process_owner_id
-        self.bypass_dangerous_command_approval = bypass_dangerous_command_approval
         self._approved_safety_commands: set[str] = set()
         self._subprocess_env = None
         self._use_login_shell = True
@@ -1309,10 +1305,10 @@ Examples:
                     exit_code=1,
                 )
 
-            # 1. Dangerous command approval is bypassed only for an explicitly
-            # trusted full-access session. Hard product blocks above still apply.
+            # 1. Dangerous command approval remains independent from filesystem
+            # scope. Full access must not silently authorize destructive actions.
             danger_reason = detect_dangerous_command(command)
-            if danger_reason and not self.bypass_dangerous_command_approval:
+            if danger_reason:
                 if not self._consume_safety_approval(command, danger_reason):
                     return BashOutputResult(
                         success=False,

--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -1184,6 +1184,7 @@ class JupyterSandboxTool(Tool):
         runtime_env: Mapping[str, str] | None = None,
         use_output_dir: bool = True,
         output_dir: str | None = None,
+        process_owner_id: str | None = None,
     ):
         """Initialize sandbox tool.
 
@@ -1192,11 +1193,14 @@ class JupyterSandboxTool(Tool):
             runtime_env: Host runtime environment exported by env_context.
             use_output_dir: Chdir kernels into {workspace}/output when True.
             output_dir: Optional explicit artifact output directory.
+            process_owner_id: Trusted host session identity used to namespace
+                persistent kernels. Model-provided session IDs never cross it.
         """
         self.workspace_dir = workspace_dir
         self.runtime_env = dict(runtime_env or {})
         self.use_output_dir = use_output_dir
         self.output_dir = output_dir
+        self.process_owner_id = (process_owner_id or "").strip()
         self._session_id: Optional[str] = None
 
     @property
@@ -1223,7 +1227,11 @@ class JupyterSandboxTool(Tool):
         """Get current sandbox status."""
         env = self._get_sandbox_env()
         sessions_info = []
-        for sid, session in self._sessions.items():
+        prefix = f"{self.process_owner_id}::" if self.process_owner_id else ""
+        for internal_id, session in self._sessions.items():
+            if prefix and not internal_id.startswith(prefix):
+                continue
+            sid = internal_id[len(prefix) :] if prefix else internal_id
             sessions_info.append({
                 "session_id": sid,
                 "is_alive": session.is_alive(),
@@ -1233,7 +1241,7 @@ class JupyterSandboxTool(Tool):
         status: dict[str, Any] = {
             "current_session_id": self._session_id,
             "sessions": sessions_info,
-            "total_sessions": len(self._sessions),
+            "total_sessions": len(sessions_info),
             "frozen": IS_FROZEN,
         }
         if not IS_FROZEN:
@@ -1252,7 +1260,7 @@ class JupyterSandboxTool(Tool):
         session forces a fresh kernel to be built next time. Best-effort —
         never raises.
         """
-        session = self._sessions.pop(session_id, None)
+        session = self._sessions.pop(self._session_key(session_id), None)
         if session is None:
             return
         try:
@@ -1261,6 +1269,13 @@ class JupyterSandboxTool(Tool):
             # Cleanup is best-effort; the session is already removed from the
             # map so it will be rebuilt regardless.
             pass
+
+    def _session_key(self, session_id: str) -> str:
+        """Bind a model-facing kernel ID to this trusted host session."""
+
+        if not self.process_owner_id:
+            return session_id
+        return f"{self.process_owner_id}::{session_id}"
 
     def _create_session(
         self, session_id: str, workspace: Path, env: SandboxEnvironment
@@ -1442,19 +1457,21 @@ Output formats:
         if session_id is None:
             session_id = self._session_id or str(uuid.uuid4())[:8]
         self._session_id = session_id
+        session_key = self._session_key(session_id)
 
         # Check kernel health if session already exists
-        existing_session = self._sessions.get(self._session_id)
+        existing_session = self._sessions.get(session_key)
         if existing_session and not existing_session.is_alive():
             old_session_id = self._session_id
-            del self._sessions[self._session_id]
+            del self._sessions[session_key]
             existing_session = None
             session_id = str(uuid.uuid4())[:8]
             self._session_id = session_id
-            workspace = self._get_workspace(session_id)
-            session = self._create_session(session_id, workspace, env)
+            session_key = self._session_key(session_id)
+            workspace = self._get_workspace(session_key)
+            session = self._create_session(session_key, workspace, env)
             await session.start()
-            self._sessions[session_id] = session
+            self._sessions[session_key] = session
             return ToolResult(
                 success=False,
                 content="",
@@ -1462,9 +1479,9 @@ Output formats:
             )
 
         # Get or create kernel session
-        if session_id not in self._sessions:
-            workspace = self._get_workspace(session_id)
-            session = self._create_session(session_id, workspace, env)
+        if session_key not in self._sessions:
+            workspace = self._get_workspace(session_key)
+            session = self._create_session(session_key, workspace, env)
             try:
                 await session.start()
             except RuntimeError as e:
@@ -1473,9 +1490,9 @@ Output formats:
                     content="",
                     error=f"KERNEL_START_FAILED: {e}",
                 )
-            self._sessions[session_id] = session
+            self._sessions[session_key] = session
 
-        session = self._sessions[session_id]
+        session = self._sessions[session_key]
 
         # Snapshot files in workspace BEFORE execution to detect new ones
         workspace = session.workspace
@@ -1740,6 +1757,9 @@ class SandboxStatusTool(Tool):
 
     _sandbox_tool: Optional[JupyterSandboxTool] = None
 
+    def __init__(self, sandbox_tool: JupyterSandboxTool | None = None) -> None:
+        self._bound_sandbox_tool = sandbox_tool
+
     @classmethod
     def set_sandbox_tool(cls, tool: JupyterSandboxTool):
         """Set the sandbox tool to query status from."""
@@ -1766,10 +1786,11 @@ and sandbox venv status.
 
     async def execute(self) -> ToolResult:
         """Get sandbox status."""
-        if self._sandbox_tool is None:
+        sandbox_tool = self._bound_sandbox_tool or self._sandbox_tool
+        if sandbox_tool is None:
             return ToolResult(success=False, content="", error="Sandbox not initialized")
 
-        status = self._sandbox_tool.get_status()
+        status = sandbox_tool.get_status()
 
         lines = [
             f"Mode: {'in-process (frozen)' if status.get('frozen') else 'subprocess + venv'}",

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -133,6 +133,11 @@ class ToolSearchTool(Tool):
         server_name: str | None = None,
         top_k: int = 1,
     ) -> ToolResult:
+        normalized_server_name = (
+            server_name.strip()
+            if isinstance(server_name, str) and server_name.strip()
+            else None
+        )
         normalized_queries = [
             item
             for item in ([query] if query else []) + (queries or [])
@@ -147,7 +152,7 @@ class ToolSearchTool(Tool):
             "query": query,
             "queries": normalized_queries,
             "tool_names": normalized_tool_names,
-            "server_name": server_name,
+            "server_name": normalized_server_name,
         }
         if not normalized_queries and not normalized_tool_names:
             payload = {
@@ -192,18 +197,19 @@ class ToolSearchTool(Tool):
         catalog_tool_count = sum(
             1
             for entry in self._catalog.snapshot()
-            if server_name is None or entry.server_name == server_name
+            if normalized_server_name is None
+            or entry.server_name == normalized_server_name
         )
         missing: list[str] = []
         if normalized_tool_names:
             hits, missing = self._catalog.lookup_exact(
                 normalized_tool_names,
-                server_name=server_name,
+                server_name=normalized_server_name,
             )
         else:
             hits = self._catalog.search_many(
                 normalized_queries,
-                server_name=server_name,
+                server_name=normalized_server_name,
                 top_k=top_k,
             )
         activated_results = []

--- a/box_agent/tools/plan_tool.py
+++ b/box_agent/tools/plan_tool.py
@@ -295,6 +295,10 @@ class PlanReadTool(Tool):
     def parameters(self) -> dict[str, Any]:
         return {"type": "object", "properties": {}}
 
+    def compaction_state(self) -> tuple[str, str]:
+        plan = self._store.get()
+        return "Plan", self._format_plan(plan) if plan is not None else "No current plan."
+
     async def execute(self) -> ToolResult:
         plan = self._store.get()
         if plan is None:

--- a/box_agent/tools/runtime.py
+++ b/box_agent/tools/runtime.py
@@ -43,6 +43,7 @@ class SkillRuntime:
 @dataclass(frozen=True)
 class SkillRuntimeContext:
     runtimes: dict[RuntimeKind, SkillRuntime]
+    sandbox_mode: bool = False
 
     def get(self, kind: RuntimeKind) -> SkillRuntime:
         return self.runtimes[kind]
@@ -66,6 +67,7 @@ def build_skill_runtime_context(
     """Discover runtimes available to skills for this session."""
     host_runtimes = _env_context_runtimes(env_context)
     return SkillRuntimeContext(
+        sandbox_mode=sandbox_mode,
         runtimes={
             "python": _build_python_runtime(
                 sandbox_mode,
@@ -110,8 +112,10 @@ def build_skill_runtime_prompt(ctx: SkillRuntimeContext) -> str:
             f"- Python: {python.provider}，标准 `python`/`python3` 已指向受管运行时"
             "（也可用 `$BOX_AGENT_PYTHON`）"
         )
-    else:
+    elif ctx.sandbox_mode:
         py_line = "- Python: 仅 `execute_code` 沙箱可用，无 shell python"
+    else:
+        py_line = "- Python: 本 session 不可用；不要调用 `execute_code` 或 shell python"
     if python.notes:
         py_line += f" — {'; '.join(python.notes)}"
     lines.append(py_line)

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -528,8 +528,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         use_output_dir: bool = True,
                         artifact_root_dir: str | Path | None = None,
                         env_context=None,
-                        process_owner_id: str | None = None,
-                        bypass_dangerous_command_approval: bool = False):
+                        process_owner_id: str | None = None):
     """Add workspace-dependent tools
 
     These tools need to know the workspace directory.
@@ -589,7 +588,6 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             permission_engine=permission_engine,
             runtime_env=runtime_env,
             process_owner_id=process_owner_id,
-            bypass_dangerous_command_approval=bypass_dangerous_command_approval,
         )
         tools.append(bash_tool)
         if process_owner_id is not None:
@@ -683,11 +681,11 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             runtime_env=runtime_context.env(),
             use_output_dir=use_output_dir,
             output_dir=str(artifact_root) if artifact_root else None,
+            process_owner_id=process_owner_id,
         )
         tools.append(sandbox_tool)
         # Also add sandbox status tool
-        status_tool = SandboxStatusTool()
-        SandboxStatusTool.set_sandbox_tool(sandbox_tool)
+        status_tool = SandboxStatusTool(sandbox_tool)
         tools.append(status_tool)
         _out(f"{Colors.GREEN}✅ Loaded Jupyter sandbox tool (execute_code){Colors.RESET}")
         _out(f"{Colors.GREEN}✅ Loaded sandbox status tool{Colors.RESET}")

--- a/box_agent/tools/todo_tool.py
+++ b/box_agent/tools/todo_tool.py
@@ -766,6 +766,11 @@ class TodoReadTool(Tool):
             },
         }
 
+    def compaction_state(self) -> tuple[str, str]:
+        items = self._store.list()
+        content = self._format_items(items) if items else "No todo items."
+        return "Todo", content
+
     async def execute(self, todo_id: str | None = None, status: str | None = None) -> ToolResult:
         all_items = self._store.list()
         snapshot = _todo_snapshot(all_items)

--- a/docs/CONTEXT_COMPRESSION.md
+++ b/docs/CONTEXT_COMPRESSION.md
@@ -47,7 +47,7 @@ The original result is preserved when it is below the limit, contains an image o
 
 Each `tool_use_id` receives one decision. A persisted replacement is cached and reused in later loop iterations, so the result is not written repeatedly. Results already present when a session is resumed are frozen and are not retroactively externalized.
 
-Tools may still bound their own output for operational reasons. When they do, they pass the complete persistable text through `ToolResult.persistence_content`; only `ToolResultStorage` writes it. Bash uses this path: the complete output is saved, while the model keeps the tool-generated head/tail plus the saved path instead of receiving a second generic 2,000-character head preview. Semantic `model_context` projections remain a separate tool concern; once selected, neither the immediate check nor the fresh aggregate budget processes them again.
+Tools may still bound their own output for operational reasons. When they do, they pass the complete persistable text through `ToolResult.persistence_content`; only `ToolResultStorage` writes it. Bash uses this path for both successful and failed commands: the complete output is saved, while the model keeps the tool-generated head/tail plus the saved path instead of receiving a second generic 2,000-character head preview. Semantic `model_context` projections remain a separate tool concern; once selected, neither the immediate check nor the fresh aggregate budget processes them again.
 
 ### Preview format
 
@@ -78,7 +78,8 @@ Before every LLM request, results first seen during the current conversation are
 1. Considers only fresh `tool_use_id` values.
 2. Excludes selected `model_context` projections and self-processed tools whose declaration is infinity.
 3. Sorts eligible results from largest to smallest.
-4. Persists and replaces the largest results until the remaining fresh content is at or below the budget.
+4. Uses a path-only persisted wrapper for this aggregate pass and counts the wrapper's actual model-facing length.
+5. Persists and replaces the largest results until the actual remaining fresh content is at or below the budget.
 
 Unsupported blocks and persistence failures remain unchanged. Since IDs are marked seen during the pass, later requests do not reconsider the same results. This handles a batch of parallel tool calls whose individual results are below the per-result limit but are too large together.
 
@@ -107,7 +108,7 @@ input_tokens
 + output_tokens
 ```
 
-It then adds `characters / 4` for messages appended after that response. If no message has real API usage, the entire pending request—including tool schemas—is estimated with `characters / 4`.
+It then estimates messages appended after that response conservatively. If no message has real API usage, the entire pending request—including tool schemas—is estimated with the larger of `characters / 4` and UTF-8 bytes `/ 3`. This avoids severe under-counting for CJK and other multibyte text.
 
 ### Compacted message layout
 
@@ -133,11 +134,11 @@ bounded recent messages
 runtime-state user message
 ```
 
-Recent selection applies to user, assistant, and tool messages. Assistant tool calls stay grouped with their contiguous tool results. Selection keeps at most 3 messages and 12,000 total characters. A user message inside that recent suffix is retained verbatim; an older user message is not copied into rebuilt history. There is no second per-tool-result size limit here: recent tool results reuse the output already produced by the shared result processor. At least the newest complete protocol group is retained even if that one group exceeds a cap; the rebuilt-request estimate then marks the result blocked if it still cannot fit.
+Recent selection applies to user, assistant, and tool messages. Assistant tool calls stay grouped with their contiguous tool results. Selection keeps at most 5 messages and 20,000 total characters. A user message inside that recent suffix is retained verbatim; an older user message is not copied into rebuilt history. There is no second per-tool-result size limit here: recent tool results reuse the output already produced by the shared result processor. At least the newest complete protocol group is retained even if that one group exceeds a cap; the rebuilt-request estimate then marks the result blocked if it still cannot fit.
 
 Compaction does not discover, reread, or replay recent files.
 
-Current todo and plan state are re-read through their original tools. Requested skill names are appended to the same synthetic runtime-state `user` message; full skill instructions remain pinned in the system message.
+Current goal, todo, and plan state are read through their explicit, side-effect-free `compaction_state` contract; compaction never invokes a normal tool call. Full active skill instructions remain pinned in the system message and are not reconstructed by replaying historical `get_skill` calls. Internal summary/runtime-state messages are excluded whenever control policy asks for the latest real user text.
 
 If the rebuilt request still exceeds the safe limit, the outcome is marked blocked instead of silently sending a known-oversized request.
 

--- a/docs/CONTEXT_COMPRESSION_CN.md
+++ b/docs/CONTEXT_COMPRESSION_CN.md
@@ -47,7 +47,7 @@ Box-Agent 在两个边界控制上下文增长：
 
 每个 `tool_use_id` 只做一次决策。成功落盘后的替换文本会被缓存，后续循环直接复用，不会重复写文件。恢复会话时已经存在的结果会被冻结，不会被追溯外置。
 
-工具仍可自行保留有界输出；此时通过 `ToolResult.persistence_content` 把完整可落盘文本交给统一边界，真正的写入仍只由 `ToolResultStorage` 完成。Bash 使用的就是这条路径：完整输出保存到磁盘，模型继续看到工具已经生成的 head/tail，并额外得到完整输出路径，不会再被替换成通用的 2,000 字符 head 预览。工具提供的语义化 `model_context` 属于另一层职责，一旦采用也不会被即时检查或 fresh 总预算重复处理。
+工具仍可自行保留有界输出；此时通过 `ToolResult.persistence_content` 把完整可落盘文本交给统一边界，真正的写入仍只由 `ToolResultStorage` 完成。Bash 的成功和失败命令都使用这条路径：完整输出保存到磁盘，模型继续看到工具已经生成的 head/tail，并额外得到完整输出路径，不会再被替换成通用的 2,000 字符 head 预览。工具提供的语义化 `model_context` 属于另一层职责，一旦采用也不会被即时检查或 fresh 总预算重复处理。
 
 ### 预览策略
 
@@ -76,7 +76,8 @@ Preview (first 2.0KB):
 1. 只处理 fresh `tool_use_id`；
 2. 排除已经采用 `model_context` 的结果和声明为 Infinity 的自处理工具；
 3. 按可落盘结果大小从大到小排序；
-4. 依次持久化并替换最大结果，直到剩余 fresh 内容不超过预算。
+4. 总预算路径使用只含恢复路径的包装，并按包装后的模型侧实际长度记账；
+5. 依次持久化并替换最大结果，直到实际剩余 fresh 内容不超过预算。
 
 不支持的 block 和落盘失败结果保持不变。检查时 ID 会被标记为已见，因此后续请求不会反复处理。这条路径专门覆盖并行工具调用：单个结果都没有超限，但合计内容过大。
 
@@ -101,7 +102,7 @@ input_tokens
 + output_tokens
 ```
 
-然后对这条响应之后新增的消息追加 `字符数 / 4` 估算。若没有真实 API usage，则对整个待发送请求（包括工具 schema）使用 `字符数 / 4`。
+然后对这条响应之后新增的消息做保守估算。若没有真实 API usage，则对整个待发送请求（包括工具 schema）取 `字符数 / 4` 与 UTF-8 字节数 `/ 3` 中较大者，避免中文及其他多字节文本被严重低估。
 
 ### 压缩后的消息组织
 
@@ -127,11 +128,11 @@ system message
 运行状态 user message
 ```
 
-recent 选择统一覆盖 user、assistant 和 tool message；assistant 工具调用与连续 tool results 按组保留。上限为 3 条消息、合计 12,000 字符。位于 recent 后缀内的 user message 原样保留，更早的 user message 不再复制到重建历史。这里不再设置第二个“单条 tool result”上限：近期结果直接复用通用 result processor 已经处理过的模型侧内容。即使最新完整协议组本身超过数量或字符上限，也至少完整保留这一组；若重建后仍放不下，由最终估算明确标记为 blocked。
+recent 选择统一覆盖 user、assistant 和 tool message；assistant 工具调用与连续 tool results 按组保留。上限为 5 条消息、合计 20,000 字符。位于 recent 后缀内的 user message 原样保留，更早的 user message 不再复制到重建历史。这里不再设置第二个“单条 tool result”上限：近期结果直接复用通用 result processor 已经处理过的模型侧内容。即使最新完整协议组本身超过数量或字符上限，也至少完整保留这一组；若重建后仍放不下，由最终估算明确标记为 blocked。
 
 上下文压缩不再发现、重新读取或重放近期文件。
 
-Todo 和 Plan 通过各自原始读取工具恢复；已请求的 skill 名称与它们一起写入合成的运行状态 `user` message，完整 skill 指令仍固定在 system message 中。
+Goal、Todo 和 Plan 通过显式、无副作用的 `compaction_state` 契约读取；压缩不会执行普通工具调用。完整 active skill 指令继续固定在 system message 中，不再通过回放历史 `get_skill` 调用重建。控制策略查询“最新用户文本”时会排除内部摘要与运行状态消息。
 
 若重建后的请求仍超过安全阈值，结果会标记为 blocked，不会静默发送一个已知超限的请求。
 

--- a/docs/FILESYSTEM_POLICY_PROTOCOL.md
+++ b/docs/FILESYSTEM_POLICY_PROTOCOL.md
@@ -40,6 +40,7 @@ Box-Agent 的权限引擎是**能力（capability）模型**：每个文件读/�
     "cwd": "/Users/me/work/my-project",
     "_meta": {
       "session_mode": "data_analysis",
+      "permission_mode": "default",
       "filesystem_policy": {
         "session_workspace_root": "/Users/me/work/my-project",
         "allowed_directories": [
@@ -53,23 +54,33 @@ Box-Agent 的权限引擎是**能力（capability）模型**：每个文件读/�
 }
 ```
 
-### 2.2 字段定义
+### 2.2 会话权限模式
+
+`session/new._meta.permission_mode` 可取：
+
+- `default`：显式受限会话。以当前 workspace 为基线，使用本次 session 的 `filesystem_policy`；不会继承全局 `allowed_directories`，也不会暴露可绕过文件权限的 `execute_code`。
+- `full_access`：请求完全文件/命令范围，但它只是请求，不是 authority。只有服务端同时配置 `tools.allow_full_access: true` 才生效；否则 fail closed 到 `default`。
+- 不传：兼容旧客户端，继续遵循服务端配置和原有 officev3 policy。
+
+非字符串或未知值按 `default` 处理。`full_access` 不会关闭危险命令的一次性审批，也不会跳过删除前恢复保护。
+
+### 2.3 字段定义
 
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
 | `session_workspace_root` | string | 否 | session 的主工作区绝对路径。覆盖 `config.yaml` 中的同名字段。空字符串等价于不传。 |
-| `allowed_directories` | string[] | 否 | 额外白名单。**与 config.yaml 中的同名字段合并**（去重），不会替换。 |
+| `allowed_directories` | string[] | 否 | 额外白名单。显式 `default` 模式下替换全局目录；兼容模式下追加合并。 |
 | `filesystem_scope` | string | 否 | 覆盖默认 scope，取值 `session_workspace` / `user_home` / `custom`。默认 `session_workspace`。 |
 
-### 2.3 合并语义
+### 2.4 合并语义
 
 | 字段 | 来源 | 合并方式 |
 |---|---|---|
 | `session_workspace_root` | config.yaml `officev3.paths.session_workspace_root` | 宿主提供则**覆盖**；否则继承配置 |
-| `allowed_directories` | config.yaml `officev3.permissions.filesystem.allowed_directories` | 宿主提供则**追加合并并去重**；否则继承配置 |
+| `allowed_directories` | config.yaml `officev3.permissions.filesystem.allowed_directories` | `permission_mode=default` 时宿主提供值**替换并去重**，未提供则为空；兼容模式下追加合并 |
 | `filesystem_scope` | config.yaml `officev3.permissions.filesystem.scope` | 宿主提供则**覆盖**；否则继承配置 |
 
-### 2.4 输入校验
+### 2.5 输入校验
 
 后端把 `filesystem_policy` 当作"可信但可能含有宿主开发者失误"的输入：
 
@@ -79,7 +90,7 @@ Box-Agent 的权限引擎是**能力（capability）模型**：每个文件读/�
 - `filesystem_scope` 必须是字符串；不在已知 scope 列表中的值会被引擎在请求时按 "未知 scope，fail closed" 处理（与 config.yaml 同等待遇）。
 - 路径不会 `expanduser()` / `resolve()`，由 `PermissionEngine` 在 check 时延迟解析（与 config.yaml 行为一致）。
 
-### 2.5 不需要传的字段
+### 2.6 不需要传的字段
 
 请**不要**通过 `_meta.filesystem_policy` 传：
 
@@ -96,7 +107,9 @@ session/new
     ↓
 解析 _meta.filesystem_policy（dict 校验）
     ↓
-base_policy = CapabilityPolicy.from_config(config)
+server_cap = config.tools.allow_full_access
+permission_mode = validate_and_cap(_meta.permission_mode, server_cap)
+base_policy = CapabilityPolicy.from_config(config) or restrictive_workspace_policy
     ↓
 base_policy.with_filesystem_overrides(
     session_workspace_root=..., allowed_directories=..., filesystem_scope=...
@@ -109,7 +122,9 @@ PermissionEngine(effective_policy, workspace, grant_store)
   session/permissions session_id=... PermissionEngine created: scope=..., swr=..., allowed_dirs=[...]
 ```
 
-`with_filesystem_overrides` 是**不可变变换**——返回新 `CapabilityPolicy` 实例，原对象不变。`allowed_directories` 走**合并去重**而非替换，所以宿主追加目录不会丢失全局配置。
+`with_filesystem_overrides` 是**不可变变换**——返回新 `CapabilityPolicy` 实例，原对象不变。`allowed_directories` 的合并方式由 `permission_mode` 决定：显式 `default` 替换，旧客户端兼容模式追加。
+
+显式受限会话不会注册 `execute_code` / `sandbox_status`，因为 Jupyter venv + `chdir` 不是 OS 文件系统沙箱。若宿主也没有提供可执行 Python runtime，skill runtime prompt 会明确声明该 session 不可使用 Python，而不会继续宣传 `execute_code`。允许完全访问时，kernel 标识还会绑定内部 ACP session identity；模型提供的同名 `session_id` 不能跨会话共享状态或从 status 中枚举其他会话。
 
 ---
 
@@ -205,7 +220,8 @@ PermissionEngine.check FILESYSTEM_WRITE → allowed=False, escalation=user_home
 
 `tests/test_permissions.py`：
 
-- `TestFilesystemOverrides`：3 个用例，覆盖 `session_workspace_root` 覆盖、`allowed_directories` 合并去重、空参数返回 self。
+- `TestFilesystemOverrides`：覆盖 `session_workspace_root` 覆盖、`allowed_directories` 合并/替换去重、空参数返回 self。
+- ACP 权限用例覆盖无全局 officev3 配置时的 session 目录、非法 `permission_mode`、服务端 full-access 上限和受限会话不暴露 `execute_code`。
 - `TestExtractAbsolutePaths::test_bare_root_dropped` / `test_bare_system_root_dropped` / `test_subpath_under_system_root_kept`：3 个用例，回归裸系统根丢弃。
 
 ---
@@ -217,6 +233,9 @@ PermissionEngine.check FILESYSTEM_WRITE → allowed=False, escalation=user_home
 | 宿主不传 `_meta.filesystem_policy` | 完全沿用 `config.yaml` —— 0.8.26 及之前的行为 |
 | 宿主传空对象 `{}` | 等价于不传 |
 | 宿主只传 `session_workspace_root` | 仅覆盖该字段，`allowed_directories` 与 `filesystem_scope` 沿用配置 |
+| `permission_mode=default` | workspace + 本 session policy；全局 allowed directories 不继承；无 policy 时仅 workspace |
+| `permission_mode=full_access` 且服务端禁止 | fail closed 到 `default` |
+| `permission_mode=full_access` 且服务端允许 | 完全文件范围；危险命令仍逐次审批；Jupyter kernel 按 ACP session 隔离 |
 | 宿主同时还传 deprecated `officev3_permissions_override` | 旧字段会被 WARNING 但忽略；新字段照常生效 |
 
-无破坏性变更。
+受限 session 不再暴露 `execute_code`，这是为关闭真实 Python 进程绕过文件权限所必需的安全收紧。

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -18,6 +18,7 @@ wire 格式，但底层共享 core/tool 行为仍可能一致。
 | **Memory Proposal**   | 双向        | `session/memory_proposal` + extension methods | [MEMORY_PROPOSAL_PROTOCOL.md](./MEMORY_PROPOSAL_PROTOCOL.md) | 记忆晋升提案的 push、list、apply 流程 |
 | **Env Context**       | 前端 → 后端 | `session/new._meta.env_context`       | [ENV_CONTEXT_PROTOCOL.md](./ENV_CONTEXT_PROTOCOL.md)             | 宿主把 CLI 路径 / 平台 / 浏览器工具状态等已知事实喂给模型，避免它否认已可用的工具 |
 | **Filesystem Policy** | 前端 → 后端 | `session/new._meta.filesystem_policy` | [FILESYSTEM_POLICY_PROTOCOL.md](./FILESYSTEM_POLICY_PROTOCOL.md) | 宿主声明 session 工作区根 + 额外允许目录，避免反复触发 `permission/request` 协商  |
+| **Permission Mode**   | 前端 → 后端 | `session/new._meta.permission_mode`   | [FILESYSTEM_POLICY_PROTOCOL.md](./FILESYSTEM_POLICY_PROTOCOL.md) | `default` 显式受限；`full_access` 仅在服务端 `tools.allow_full_access` 已启用时生效 |
 | **Artifact**          | 后端 → 前端 | `update_tool_call.rawOutput`          | [ARTIFACT_PROTOCOL.md](./ARTIFACT_PROTOCOL.md)                   | 宿主收集、解析并渲染 Agent 生成的文件产物                                          |
 | **Host Progress**     | 后端 → 前端 | `update_tool_call.rawOutput`          | [integration/host-progress-events.md](./integration/host-progress-events.md) | 宿主分组渲染 sub-agent、plan、todo、goal、turn usage 等结构化执行状态 |
 | **User Decision**     | 双向        | `update_tool_call.rawOutput` + `session/prompt._meta` | [USER_DECISION_PROTOCOL_CN.md](./USER_DECISION_PROTOCOL_CN.md) | Skill/模型发起结构化执行决策，宿主选择或按运行时批准的默认项超时续跑 |

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -325,7 +325,7 @@ async def test_acp_session_update_send_times_out(tmp_path):
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=1, workspace_dir=str(tmp_path)),
-        tools=ToolsConfig(),
+        tools=ToolsConfig(allow_full_access=True),
     )
     agent = BoxACPAgent(HangingConn(), config, DummyLLM(), [], "system")
     agent._SESSION_UPDATE_TIMEOUT_SECONDS = 0.01
@@ -2299,7 +2299,7 @@ async def test_acp_uses_host_artifact_root_dir_for_output_mode(tmp_path):
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=1, workspace_dir=str(tmp_path)),
-        tools=ToolsConfig(),
+        tools=ToolsConfig(allow_full_access=True),
     )
     conn = DummyConn()
     agent = BoxACPAgent(conn, config, DoneLLM(), [], "system")
@@ -3886,6 +3886,7 @@ async def test_acp_default_permission_mode_replaces_global_allowed_directories(t
     assert bash_tool._perm is not None
     assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
     assert bash_tool._perm.policy.allowed_directories == (str(session_allowed),)
+    assert "execute_code" not in agent._sessions[session.sessionId].agent.tools
 
 
 @pytest.mark.asyncio
@@ -3921,15 +3922,72 @@ async def test_acp_default_permission_mode_without_filesystem_policy_fails_close
     bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
 
     assert bash_tool.allow_full_access is False
-    assert bash_tool.bypass_dangerous_command_approval is False
     assert bash_tool._perm is not None
     assert bash_tool._perm.policy.filesystem_scope == "session_workspace"
     assert bash_tool._perm.policy.session_workspace_root == str(workspace)
     assert bash_tool._perm.policy.allowed_directories == ()
+    assert "execute_code" not in agent._sessions[session.sessionId].agent.tools
 
 
 @pytest.mark.asyncio
-async def test_acp_full_access_mode_bypasses_permission_engine(tmp_path):
+async def test_acp_default_mode_applies_session_directories_without_global_policy(tmp_path):
+    workspace = tmp_path / "workspace"
+    allowed = tmp_path / "session-allowed"
+    allowed.mkdir()
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={
+                "permission_mode": "default",
+                "filesystem_policy": {
+                    "filesystem_scope": "session_workspace",
+                    "session_workspace_root": str(workspace),
+                    "allowed_directories": [str(allowed)],
+                },
+            },
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+
+    assert bash_tool._perm is not None
+    assert bash_tool._perm.policy.allowed_directories == (str(allowed),)
+    assert "execute_code" not in agent._sessions[session.sessionId].agent.tools
+    assert "仅 `execute_code` 沙箱可用" not in agent._sessions[session.sessionId].agent.system_prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_mode", [[], {}, 1])
+async def test_acp_non_string_permission_mode_fails_closed(tmp_path, invalid_mode):
+    workspace = tmp_path / "workspace"
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=True),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={"permission_mode": invalid_mode},
+        )
+    )
+    tools = agent._sessions[session.sessionId].agent.tools
+
+    assert tools["bash"].allow_full_access is False
+    assert tools["bash"]._perm is not None
+    assert "execute_code" not in tools
+
+
+@pytest.mark.asyncio
+async def test_acp_full_access_request_respects_server_cap(tmp_path):
     workspace = tmp_path / "workspace"
     config = Config(
         llm=LLMConfig(api_key="test-key"),
@@ -3947,8 +4005,32 @@ async def test_acp_full_access_mode_bypasses_permission_engine(tmp_path):
     bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
     session_tools = agent._sessions[session.sessionId].agent.tools
 
+    assert bash_tool.allow_full_access is False
+    assert bash_tool._perm is not None
+    assert "execute_code" not in session_tools
+    assert "sandbox_status" not in session_tools
+
+
+@pytest.mark.asyncio
+async def test_acp_full_access_mode_requires_server_opt_in(tmp_path):
+    workspace = tmp_path / "workspace"
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
+        tools=ToolsConfig(allow_full_access=True),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
+
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(workspace),
+            field_meta={"permission_mode": "full_access"},
+        )
+    )
+    bash_tool = agent._sessions[session.sessionId].agent.tools["bash"]
+    session_tools = agent._sessions[session.sessionId].agent.tools
+
     assert bash_tool.allow_full_access is True
-    assert bash_tool.bypass_dangerous_command_approval is True
     assert bash_tool._perm is None
     assert "execute_code" in session_tools
     assert "sandbox_status" in session_tools
@@ -3978,7 +4060,7 @@ async def test_acp_prompt_includes_skill_runtime_context(tmp_path, monkeypatch):
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
-        tools=ToolsConfig(),
+        tools=ToolsConfig(allow_full_access=True),
     )
     agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
 
@@ -4029,7 +4111,7 @@ async def test_acp_prompt_and_bash_env_include_self_managed_node_runtime(tmp_pat
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
-        tools=ToolsConfig(),
+        tools=ToolsConfig(allow_full_access=True),
     )
     agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
 
@@ -4117,7 +4199,7 @@ async def test_acp_host_env_context_feeds_bash_and_execute_code_runtime_env(tmp_
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=3, workspace_dir=str(workspace)),
-        tools=ToolsConfig(),
+        tools=ToolsConfig(allow_full_access=True),
     )
     agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [EchoTool()], "system")
 

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -849,6 +849,8 @@ async def test_foreground_large_stderr_failure_is_bounded_without_error_duplicat
     assert result.raw_output is not None
     assert result.raw_output["dropped_chars"] > 0
     assert result.raw_output["original_stderr_chars"] >= 60_000
+    assert result.persistence_content is not None
+    assert len(result.persistence_content) > MAX_BASH_OUTPUT_CHARS
 
 
 @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4671,6 +4671,69 @@ async def test_parallel_fresh_results_apply_aggregate_budget_before_next_llm_cal
 
 
 @pytest.mark.asyncio
+async def test_failed_tool_persistence_content_is_saved_before_next_llm_call(tmp_path):
+    from box_agent.tool_result_storage import ToolResultStorage
+
+    class FailedLargeTool(Tool):
+        @property
+        def name(self):
+            return "failed_large"
+
+        @property
+        def description(self):
+            return "Return bounded failure output with a complete persisted payload."
+
+        @property
+        def parameters(self):
+            return {"type": "object", "properties": {}}
+
+        async def execute(self):
+            return ToolResult(
+                success=False,
+                content="bounded failure",
+                error="command failed",
+                persistence_content="complete failure output\n" + "e" * 60_000,
+            )
+
+    llm = CapturingStreamLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="failed-large-1",
+                        type="function",
+                        function=FunctionCall(name="failed_large", arguments={}),
+                    )
+                ],
+                finish_reason="tool",
+            ),
+            LLMResponse(content="done", finish_reason="stop"),
+        ]
+    )
+    storage = ToolResultStorage(tmp_path)
+
+    await collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={"failed_large": FailedLargeTool()},
+            max_steps=5,
+            tool_result_storage=storage,
+            session_id="failed-result",
+        )
+    )
+
+    saved = tmp_path / "failed-result" / "tool-results" / "failed-large-1.txt"
+    assert saved.read_text(encoding="utf-8").startswith("complete failure output")
+    tool_message = next(
+        message for message in llm.message_calls[1] if message.role == "tool"
+    )
+    assert "<persisted-output>" in str(tool_message.content)
+    assert str(saved) in str(tool_message.content)
+
+
+@pytest.mark.asyncio
 async def test_no_progress_breaker_injects_wrapup_and_stops():
     """After no_progress_limit consecutive failing steps, the breaker injects a
     synthesis nudge so the agent stops flailing instead of running to max_steps."""
@@ -6110,7 +6173,10 @@ async def test_summary_cooldown_uses_local_fallback_without_provider_call():
 
 
 def test_context_pressure_uses_latest_response_usage_plus_new_messages():
-    from box_agent.core import _estimate_context_from_latest_response, _message_chars
+    from box_agent.core import (
+        _estimate_context_from_latest_response,
+        _fallback_context_estimate,
+    )
 
     response = Message(
         role="assistant",
@@ -6129,17 +6195,42 @@ def test_context_pressure_uses_latest_response_usage_plus_new_messages():
         None,
     )
 
-    assert estimated == 160 + _message_chars(added) // 4
+    assert estimated == 160 + _fallback_context_estimate([added], None)
     assert source == "usage"
 
 
+def test_context_pressure_includes_tools_activated_after_latest_usage():
+    from box_agent.core import _estimate_context_from_latest_response
+
+    class _LargeActivatedTool:
+        def to_openai_schema(self):
+            return {"description": "new deferred schema " * 5_000}
+
+    response = Message(
+        role="assistant",
+        content="tool search complete",
+        usage=TokenUsage(input_tokens=100, output_tokens=10),
+    )
+
+    estimated, source = _estimate_context_from_latest_response(
+        [Message(role="system", content="sys"), response],
+        {"activated": _LargeActivatedTool()},
+    )
+
+    assert source == "usage"
+    assert estimated > 10_000
+
+
 def test_context_pressure_without_usage_falls_back_to_characters_over_four():
-    from box_agent.core import _estimate_context_from_latest_response, _message_chars
+    from box_agent.core import (
+        _estimate_context_from_latest_response,
+        _fallback_context_estimate,
+    )
 
     message = Message(role="system", content="x" * 400)
     estimated, source = _estimate_context_from_latest_response([message], None)
 
-    assert estimated == _message_chars(message) // 4
+    assert estimated == _fallback_context_estimate([message], None)
     assert source == "fallback"
 
 
@@ -6160,8 +6251,11 @@ class _PostCompactStateTool(Tool):
     def parameters(self):
         return {"type": "object", "properties": {}}
 
+    def compaction_state(self):
+        return self._name.removesuffix("_read").title(), self._content
+
     async def execute(self):
-        return ToolResult(success=True, content=self._content)
+        raise AssertionError("compaction must not execute runtime-state tools")
 
 
 class _PostCompactFileTool(Tool):
@@ -6262,7 +6356,41 @@ async def test_compaction_restores_runtime_state_without_replaying_files():
     assert runtime_state.role == "user"
     assert "◑ implement compaction" in rendered
     assert "Plan #1: context compaction" in rendered
-    assert "codebase-design" in rendered
+    assert "codebase-design" not in rendered
+
+
+def test_latest_user_text_ignores_post_compaction_runtime_state():
+    from box_agent.core import _latest_user_text
+
+    messages = [
+        Message(role="system", content="system"),
+        Message(role="user", content="继续"),
+        Message(
+            role="user",
+            content="[Post-Compaction Runtime State]\n\n## Todo\nactive",
+        ),
+    ]
+
+    assert _latest_user_text(messages) == "继续"
+
+
+def test_goal_read_exposes_side_effect_free_compaction_state(tmp_path):
+    from box_agent.agent import Agent
+
+    agent = Agent(
+        llm_client=object(),
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+    )
+    agent.set_goal("Finish the repair", progress=["tests added"])
+
+    label, content = agent.tools["goal_read"].compaction_state()
+
+    assert label == "Goal"
+    assert "Finish the repair" in content
+    assert "tests added" in content
 
 
 def test_fallback_context_estimate_includes_tool_schemas():
@@ -6276,6 +6404,15 @@ def test_fallback_context_estimate_includes_tool_schemas():
     message_tokens = _fallback_context_estimate(msgs, None)
     request_tokens = _fallback_context_estimate(msgs, {"large": _SchemaTool()})
     assert request_tokens > message_tokens + 1_000
+
+
+def test_fallback_context_estimate_is_conservative_for_multibyte_text():
+    from box_agent.core import _fallback_context_estimate
+
+    content = "测试" * 1_000
+    messages = [Message(role="system", content="sys"), Message(role="user", content=content)]
+
+    assert _fallback_context_estimate(messages, None) >= len(content.encode("utf-8")) // 3
 
 
 def test_generic_tool_result_reaches_storage_seam_without_loss():

--- a/tests/test_jupyter_timeout_session.py
+++ b/tests/test_jupyter_timeout_session.py
@@ -19,6 +19,7 @@ from box_agent.tools.jupyter_tool import (
     KERNEL_EXEC_TIMEOUT,
     JupyterKernelSession,
     JupyterSandboxTool,
+    SandboxStatusTool,
 )
 
 
@@ -66,6 +67,14 @@ def _bare_session(tmp_path: Path) -> JupyterKernelSession:
     return JupyterKernelSession("s", tmp_path / "ws", sandbox_env=object())
 
 
+class _OwnedSession:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+
+    def is_alive(self) -> bool:
+        return True
+
+
 def test_low_level_execute_returns_timeout_sentinel_when_kernel_stays_busy(tmp_path):
     """The actual JupyterKernelSession.execute() must surface a hard-timeout
     sentinel (not silently succeed) when the idle status never arrives."""
@@ -77,6 +86,41 @@ def test_low_level_execute_returns_timeout_sentinel_when_kernel_stays_busy(tmp_p
     assert error == KERNEL_EXEC_TIMEOUT
     assert stdout == ""
     assert images == []
+
+
+@pytest.mark.asyncio
+async def test_kernel_and_status_state_are_namespaced_by_host_session(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(JupyterSandboxTool, "_sessions", {})
+    first = JupyterSandboxTool(
+        workspace_dir=str(tmp_path / "first"),
+        process_owner_id="acp-first",
+    )
+    second = JupyterSandboxTool(
+        workspace_dir=str(tmp_path / "second"),
+        process_owner_id="acp-second",
+    )
+    first._sessions[first._session_key("first-kernel")] = _OwnedSession(tmp_path / "first")
+    second._sessions[second._session_key("second-kernel")] = _OwnedSession(tmp_path / "second")
+    first._session_id = "first-kernel"
+    second._session_id = "second-kernel"
+
+    assert first._session_key("shared") != second._session_key("shared")
+    assert [item["session_id"] for item in first.get_status()["sessions"]] == ["first-kernel"]
+    assert [item["workspace"] for item in first.get_status()["sessions"]] == [
+        str(tmp_path / "first")
+    ]
+    assert [item["workspace"] for item in second.get_status()["sessions"]] == [
+        str(tmp_path / "second")
+    ]
+
+    first_status = await SandboxStatusTool(first).execute()
+    second_status = await SandboxStatusTool(second).execute()
+    assert "first-kernel" in first_status.content
+    assert "second-kernel" not in first_status.content
+    assert "second-kernel" in second_status.content
+    assert "first-kernel" not in second_status.content
 
 
 def test_low_level_execute_happy_path_still_succeeds(tmp_path):

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -480,6 +480,34 @@ async def test_search_finds_multiple_exact_tool_names_inside_compound_query() ->
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("server_name", "expected_server"),
+    [(" weather ", "weather"), ("", None), ("   ", None)],
+)
+async def test_search_normalizes_blank_and_padded_server_filters(
+    server_name, expected_server
+) -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "weather",
+        [FakeMCPTool("get_forecast", "weather", "Get weather forecast")],
+    )
+    activated = OrderedDict()
+
+    result = await ToolSearchTool(catalog, activated).execute(
+        query="forecast",
+        server_name=server_name,
+    )
+    payload = json.loads(result.content)
+
+    assert result.success is True
+    assert payload["server_name"] == expected_server
+    assert payload["catalog_tool_count"] == 1
+    assert payload["matched_count"] == 1
+    assert payload["activated_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_duplicate_model_names_are_reported_but_not_activated() -> None:
     catalog = MCPToolCatalog()
     first = FakeMCPTool("lookup", "crm", "CRM lookup")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -813,7 +813,7 @@ class TestBashPermissionPhase1:
         )
         return await tool.execute(command)
 
-    async def test_full_access_bypasses_dangerous_command_approval(self, workspace: Path):
+    async def test_full_access_still_requires_dangerous_command_approval(self, workspace: Path):
         from box_agent.tools.bash_tool import BashTool
 
         tool = BashTool(
@@ -821,12 +821,13 @@ class TestBashPermissionPhase1:
             allow_full_access=True,
             non_interactive=True,
             permission_engine=None,
-            bypass_dangerous_command_approval=True,
         )
         result = await tool.execute(f'rm -rf "{workspace / "missing-target"}"')
 
-        assert result.permission_request is None
-        assert "Approval required" not in (result.stderr or "")
+        assert result.permission_request is not None
+        assert result.permission_request["scope"] == "safety"
+        assert result.permission_request["persistent_supported"] is False
+        assert "Approval required" in (result.stderr or "")
 
     def _make_engine(self, workspace: Path) -> PermissionEngine:
         policy = CapabilityPolicy()  # session_workspace scope

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -829,6 +829,20 @@ def test_runtime_prompt_mentions_python_node_and_npm_rules(tmp_path: Path) -> No
     assert "禁止 `sudo`" in out
 
 
+def test_runtime_prompt_does_not_advertise_execute_code_when_sandbox_is_disabled(
+    tmp_path: Path,
+) -> None:
+    ctx = build_skill_runtime_context(
+        sandbox_mode=False,
+        node_runtime_root=tmp_path / "missing-node",
+    )
+
+    out = build_skill_runtime_prompt(ctx)
+
+    assert "本 session 不可用" in out
+    assert "仅 `execute_code` 沙箱可用" not in out
+
+
 def test_runtime_prompt_mentions_available_self_managed_node(tmp_path: Path) -> None:
     root = tmp_path / "node-runtime"
     node = root / "versions" / "node" / "bin" / "node"

--- a/tests/test_tool_result_storage.py
+++ b/tests/test_tool_result_storage.py
@@ -155,27 +155,81 @@ def test_fresh_aggregate_budget_persists_largest_then_freezes_ids(tmp_path: Path
     storage = ToolResultStorage(
         tmp_path,
         default_result_limit=1_000,
-        aggregate_budget=100,
+        aggregate_budget=1_000,
     )
     messages = [
-        _message("a" * 80, "a"),
-        _message("b" * 60, "b"),
-        _message("c" * 40, "c"),
+        _message("a" * 600, "a"),
+        _message("b" * 500, "b"),
+        _message("c" * 400, "c"),
     ]
     tools = {"bash": _Tool()}
 
     first = storage.enforce_fresh_budget(messages, tools=tools, session_id="s")
     assert first.fresh_count == 3
-    assert first.persisted_count == 1
-    assert first.remaining_chars == 100
+    assert first.persisted_count == 2
+    assert first.remaining_chars == sum(len(str(message.content)) for message in messages)
+    assert first.remaining_chars <= storage.aggregate_budget
     assert "<persisted-output>" in messages[0].content
-    assert messages[1].content == "b" * 60
+    assert "<persisted-output>" in messages[1].content
 
-    messages[1] = _message("b" * 500, "b")
+    messages[2] = _message("c" * 900, "c")
     second = storage.enforce_fresh_budget(messages, tools=tools, session_id="s")
     assert second.fresh_count == 0
     assert second.persisted_count == 0
-    assert messages[1].content == "b" * 500
+    assert messages[2].content == "c" * 900
+
+
+def test_default_aggregate_budget_counts_actual_persisted_wrappers(tmp_path: Path) -> None:
+    storage = ToolResultStorage(tmp_path)
+    messages = [
+        _message("x" * 1_000, f"call-{index}")
+        for index in range(100)
+    ]
+
+    outcome = storage.enforce_fresh_budget(
+        messages,
+        tools={"bash": _Tool()},
+        session_id="batch",
+    )
+
+    actual_chars = sum(len(str(message.content)) for message in messages)
+    assert outcome.remaining_chars == actual_chars
+    assert actual_chars <= DEFAULT_TOOL_RESULTS_BUDGET_CHARS
+    assert outcome.persisted_count > 0
+
+
+def test_empty_session_ids_use_isolated_storage_namespaces(tmp_path: Path) -> None:
+    first_storage = ToolResultStorage(tmp_path, default_result_limit=5)
+    second_storage = ToolResultStorage(tmp_path, default_result_limit=5)
+
+    first = first_storage.process_message(_message("first payload"), tool=_Tool())
+    second = second_storage.process_message(_message("second payload"), tool=_Tool())
+
+    first_path = Path(str(first.content).split("Full output saved to: ", 1)[1].splitlines()[0])
+    second_path = Path(str(second.content).split("Full output saved to: ", 1)[1].splitlines()[0])
+    assert first_path != second_path
+    assert first_path.read_text(encoding="utf-8") == "first payload"
+    assert second_path.read_text(encoding="utf-8") == "second payload"
+
+
+def test_explicit_session_collision_never_points_at_stale_content(tmp_path: Path) -> None:
+    first_storage = ToolResultStorage(tmp_path, default_result_limit=5)
+    second_storage = ToolResultStorage(tmp_path, default_result_limit=5)
+    first_storage.process_message(
+        _message("first payload"),
+        tool=_Tool(),
+        session_id="shared",
+    )
+
+    second = second_storage.process_message(
+        _message("second payload"),
+        tool=_Tool(),
+        session_id="shared",
+    )
+
+    second_path = Path(str(second.content).split("Full output saved to: ", 1)[1].splitlines()[0])
+    assert second_path.name.startswith("call-1-")
+    assert second_path.read_text(encoding="utf-8") == "second payload"
 
 
 def test_aggregate_budget_never_persists_read_results(tmp_path: Path) -> None:


### PR DESCRIPTION
## Task

Harden the three recently merged areas without duplicating policy in CLI/ACP adapters:

- enforce the server-side `tools.allow_full_access` cap for ACP session requests;
- keep dangerous Bash approval independent from filesystem scope;
- apply session filesystem policy without a global OfficeV3 block;
- remove `execute_code` from restricted sessions and namespace full-access Jupyter kernels by trusted ACP session;
- make tool-result aggregate accounting use actual model-facing wrapper sizes and persist failed Bash output;
- exclude compaction metadata from latest-user policy, restore durable state without invoking tools, and conservatively count multibyte text plus newly activated MCP schemas;
- normalize blank and padded deferred-MCP server filters;
- synchronize the English/Chinese protocol documentation.

Out of scope: no runtime package build, OfficeV3 install, restart, or live desktop task.

## Proof

- `uv run pytest tests/test_tool_result_storage.py tests/test_bash_tool.py tests/test_core.py tests/test_mcp_tool_search.py tests/test_permissions.py tests/test_acp.py tests/test_jupyter_timeout_session.py tests/test_jupyter_runtime_python.py -q`
  - `497 passed, 1 skipped`
- `uv run pytest -q`
  - `2596 passed, 17 skipped, 2 warnings`
- `uv run python -m compileall -q box_agent`
- `git diff --check`
- independent code review: APPROVE
- independent architecture review: CLEAR

## Risk

- Restricted ACP sessions no longer expose `execute_code`; hosts that require managed Python execution must explicitly enable the server cap and request `permission_mode: full_access`.
- `full_access` no longer bypasses one-shot dangerous-command approval.
- Tool-result aggregate persistence uses path-only wrappers during the batch budget pass; immediate oversized results retain their normal preview.
- Source is validated, but packaged OfficeV3 behavior still requires a runtime rebuild/install/restart/live-task cycle.
