### PR TITLE
fix: harden MCP auth recovery and artifact detection

### DIFF
--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -49,7 +49,11 @@ from box_agent.events import StopReason
 from box_agent.schema import LLMProvider, Message
 from box_agent.tools.base import Tool
 from box_agent.tools.jupyter_tool import JupyterSandboxTool, SandboxStatusTool
-from box_agent.tools.mcp_loader import cleanup_mcp_connections
+from box_agent.tools.mcp_loader import (
+    cleanup_mcp_connections,
+    get_all_mcp_tools,
+    reconnect_auth_failed_mcp_servers_if_token_changed,
+)
 from box_agent.tools.skill_preload import (
     build_auto_loaded_skills_prompt,
     turn_preload_skill_names,
@@ -2320,6 +2324,25 @@ async def run_agent(
             tool_limits=config.tool_limits,
         )
 
+    async def _refresh_mcp_after_auth_change() -> None:
+        results = await reconnect_auth_failed_mcp_servers_if_token_changed()
+        if not results:
+            return
+        if not config.tools.mcp.deferred_loading_enabled:
+            register_mcp_tools(agent.tools, get_all_mcp_tools())
+        for result in results:
+            name = result["name"]
+            if result.get("success"):
+                print(
+                    f"{Colors.GREEN}✅ Reconnected MCP server '{name}' "
+                    f"after login token refresh{Colors.RESET}"
+                )
+            else:
+                print(
+                    f"{Colors.YELLOW}⚠️  MCP reconnect failed for '{name}': "
+                    f"{result.get('error') or 'unknown error'}{Colors.RESET}"
+                )
+
     # 8. Display welcome information
     if not task:
         print_banner()
@@ -2334,6 +2357,7 @@ async def run_agent(
         loaded_mcp_tools = await await_mcp_tools(mcp_task)
         if not config.tools.mcp.deferred_loading_enabled:
             register_mcp_tools(agent.tools, loaded_mcp_tools)
+        await _refresh_mcp_after_auth_change()
         _apply_skill_filter(task)
         completion_gate = _build_cli_completion_gate(task)
         _apply_cli_auto_loaded_skills(completion_gate, task)
@@ -2670,6 +2694,7 @@ async def run_agent(
             loaded_mcp_tools = await await_mcp_tools(mcp_task)
             if not config.tools.mcp.deferred_loading_enabled:
                 register_mcp_tools(agent.tools, loaded_mcp_tools)
+            await _refresh_mcp_after_auth_change()
             mcp_task = None  # clear so we don't re-await the cached result each turn
 
             print(

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -14,6 +14,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import traceback
 from collections.abc import AsyncIterator
@@ -322,8 +323,16 @@ def empty_final_answer_retry_text(tool_call_count: int) -> str:
 _EMPTY_FINAL_ANSWER_ERROR = "工具已执行完成，但模型未生成最终答复，请重试。"
 
 
-# Regex to match file references like [foo.png] in tool output.
-_ARTIFACT_REF_RE = re.compile(r"\[([^\]\n]+\.\w{1,10})\]", re.IGNORECASE)
+# Regex to match file references like [foo.png] in tool output. Keep the
+# candidate bounded: structured tool payloads such as web_search commonly use
+# a top-level JSON array, and an unbounded match can otherwise consume the
+# entire payload and misclassify it as one enormous filename.
+_MAX_ARTIFACT_REF_CHARS = 512
+_MAX_ARTIFACT_COMPONENT_BYTES = 255
+_ARTIFACT_REF_RE = re.compile(
+    r"\[([^\]\n]{1,512}\.\w{1,10})\]",
+    re.IGNORECASE,
+)
 
 
 def _message_text(content: str | list[dict[str, Any]]) -> str:
@@ -967,26 +976,41 @@ def _detect_artifacts(
     if not workspace_dir or not content:
         return []
 
-    ws = Path(workspace_dir).resolve()
-    out = _artifact_scan_root(workspace_dir, artifact_root_dir)
+    try:
+        ws = Path(workspace_dir).resolve()
+        out = _artifact_scan_root(workspace_dir, artifact_root_dir)
+    except (OSError, RuntimeError, ValueError):
+        # Artifact discovery is best-effort and must never fail the tool call.
+        return []
     if out is None:
         return []
-    if not out.is_dir():
+    try:
+        if not out.is_dir():
+            return []
+    except OSError:
         return []
 
     artifacts: list[ArtifactEvent] = []
     seen_paths: set[Path] = set()
     for match in _ARTIFACT_REF_RE.finditer(content):
         filename = match.group(1)
-        candidate = (out / filename).resolve()
         try:
+            if len(filename) > _MAX_ARTIFACT_REF_CHARS or any(
+                len(os.fsencode(part)) > _MAX_ARTIFACT_COMPONENT_BYTES
+                for part in Path(filename).parts
+            ):
+                continue
+            candidate = (out / filename).resolve()
             candidate.relative_to(out)
-        except ValueError:
-            continue
-        if candidate in seen_paths or not candidate.is_file():
+            if candidate in seen_paths or not candidate.is_file():
+                continue
+            artifact = _make_artifact(tool_call_id, candidate, ws)
+        except (OSError, RuntimeError, UnicodeError, ValueError):
+            # Invalid, overlong, racy, or otherwise unresolvable references are
+            # ordinary false positives in arbitrary tool output.
             continue
         seen_paths.add(candidate)
-        artifacts.append(_make_artifact(tool_call_id, candidate, ws))
+        artifacts.append(artifact)
 
     return artifacts
 

--- a/box_agent/retry.py
+++ b/box_agent/retry.py
@@ -127,6 +127,7 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
             "incomplete read",
             "connection reset",
             "server disconnected",
+            "the model service could not complete this request",
         )
     )
 

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -1,6 +1,7 @@
 """MCP tool loader with real MCP client integration and timeout handling."""
 
 import asyncio
+import hashlib
 import inspect
 import json
 import os
@@ -776,6 +777,15 @@ _mcp_config_path: str | None = None
 # DynamicBearer / Authorization headers the cold-start path would build.
 _mcp_auth_file: str = ""
 _mcp_auth_token: str = ""
+_mcp_auth_fingerprint: str = ""
+
+
+def _current_mcp_auth_fingerprint() -> str:
+    """Return a non-reversible marker for the currently resolved login token."""
+    token = resolve_auth_token(_mcp_auth_token, _mcp_auth_file)
+    if not token:
+        return ""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
 def is_mcp_loading() -> bool:
@@ -920,7 +930,8 @@ async def load_mcp_tools_async(
     Returns:
         List of Tool objects representing MCP tools
     """
-    global _mcp_connections, _mcp_status, _mcp_loading, _mcp_config_path, _mcp_auth_file, _mcp_auth_token
+    global _mcp_connections, _mcp_status, _mcp_loading, _mcp_config_path
+    global _mcp_auth_file, _mcp_auth_token, _mcp_auth_fingerprint
     _mcp_loading = True
     catalog = get_mcp_tool_catalog()
     catalog.mark_loading()
@@ -928,6 +939,7 @@ async def load_mcp_tools_async(
     # dynamic bearer / Authorization headers it would have used on cold start.
     _mcp_auth_file = auth_file
     _mcp_auth_token = auth_token
+    _mcp_auth_fingerprint = _current_mcp_auth_fingerprint()
     try:
         config_file = _resolve_mcp_config_path(config_path)
         if config_file is not None:
@@ -1074,6 +1086,40 @@ async def reconnect_mcp_server(name: str) -> dict:
     lock = _mcp_reconnect_locks.setdefault(name, asyncio.Lock())
     async with lock:
         return await _reconnect_mcp_server_locked(name)
+
+
+async def reconnect_auth_failed_mcp_servers_if_token_changed() -> list[dict]:
+    """Reconnect 401-failed MCP servers after the product login token rotates.
+
+    Hosted MCP discovery happens once during CLI startup. If that initial
+    connection receives a 401, there is no persistent HTTP client on which the
+    dynamic bearer hook can observe a later desktop-login refresh. This helper
+    notices the auth-file change and retries only servers whose last failure was
+    an authentication failure. Connected servers do not need reconnecting:
+    ``DynamicBearerAuth`` already reads the latest token for every request.
+    """
+    global _mcp_auth_fingerprint
+
+    current_fingerprint = _current_mcp_auth_fingerprint()
+    if not current_fingerprint or current_fingerprint == _mcp_auth_fingerprint:
+        return []
+    _mcp_auth_fingerprint = current_fingerprint
+
+    failed_names = [
+        status.name
+        for status in _mcp_status.values()
+        if status.state == "failed"
+        and status.error
+        and (
+            "HTTP 401" in status.error
+            or "Authentication failed" in status.error
+        )
+    ]
+    results: list[dict] = []
+    for name in failed_names:
+        result = await reconnect_mcp_server(name)
+        results.append({"name": name, **result})
+    return results
 
 
 async def _reconnect_mcp_server_locked(name: str) -> dict:


### PR DESCRIPTION
## Summary

- reconnect hosted MCP servers after authentication refresh
- harden artifact filename detection for structured tool output
- prevent oversized or invalid path candidates from aborting a run