### PR TITLE
fix(acp): Restore MCP after auth refresh

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1117,6 +1117,57 @@ class BoxACPAgent:
         if injected:
             log.info("mcp/catalog_ready_injected", sessions=injected)
 
+    async def _refresh_mcp_after_auth_change(self) -> list[dict]:
+        """Reconnect auth-failed MCP servers after the host refreshes auth.json."""
+
+        if not self._mcp_loaded:
+            return []
+        from box_agent.tools.mcp_loader import (
+            get_all_mcp_tools,
+            get_mcp_tools_for_server,
+            reconnect_auth_failed_mcp_servers_if_token_changed,
+        )
+
+        results = await reconnect_auth_failed_mcp_servers_if_token_changed()
+        if not results:
+            return []
+
+        if not self._config.tools.mcp.deferred_loading_enabled:
+            all_mcp_tools = get_all_mcp_tools()
+            sync_mcp_tool_list(
+                self._base_tools,
+                all_mcp_tools,
+                self._base_mcp_fallback_tools,
+            )
+            for state in self._sessions.values():
+                sync_mcp_tools(
+                    state.agent.tools,
+                    all_mcp_tools,
+                    state.mcp_fallback_tools,
+                )
+
+        for result in results:
+            name = str(result.get("name") or "")
+            success = bool(result.get("success"))
+            tools = get_mcp_tools_for_server(name) if success else []
+            injected = self._inject_mcp_runtime_update(
+                name=name,
+                state="connected" if success else "failed",
+                tool_count=len(tools),
+                always_load_count=sum(
+                    bool(getattr(tool, "mcp_always_load", False))
+                    for tool in tools
+                ),
+            )
+            log.info(
+                "mcp/auth_refresh_reconnect",
+                server=name,
+                success=success,
+                error=result.get("error"),
+                context_injected_sessions=injected,
+            )
+        return results
+
     async def _ensure_skills_loaded(self) -> None:
         """Await the background skill-discovery task before it's needed.
 
@@ -1950,6 +2001,7 @@ class BoxACPAgent:
 
         # Ensure background-loaded MCP tools are available before running the turn
         await self._ensure_mcp_loaded()
+        await self._refresh_mcp_after_auth_change()
 
         # Skills should already be ready (newSession awaited them), but
         # short-circuit any edge case where a session was created before

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -414,6 +414,7 @@ class MCPServerConnection:
         self.always_load = always_load
         # Connection state
         self.last_error: str | None = None
+        self.last_auth_status: int | None = None
         self.session: ClientSession | None = None
         self.exit_stack: AsyncExitStack | None = None
         self.tools: list[MCPTool] = []
@@ -432,6 +433,7 @@ class MCPServerConnection:
 
     async def connect(self) -> bool:
         """Connect to the MCP server with timeout protection."""
+        self.last_auth_status = None
         connect_timeout = self._get_connect_timeout()
         started_at = time.monotonic()
         stage = "open-transport"
@@ -529,7 +531,8 @@ class MCPServerConnection:
         except TimeoutError as e:
             self.last_error = f"Connection timed out after {connect_timeout}s during {stage}"
             cleanup_error = await _close_exit_stack()
-            auth_failure = _is_mcp_authentication_error(cleanup_error)
+            self.last_auth_status = _mcp_auth_status(e, cleanup_error)
+            auth_failure = self.last_auth_status is not None
             if auth_failure:
                 self.last_error = _mcp_connection_error_message(e, cleanup_error)
                 _warn(
@@ -546,8 +549,9 @@ class MCPServerConnection:
 
         except asyncio.CancelledError as e:
             cleanup_error = await _close_exit_stack()
+            self.last_auth_status = _mcp_auth_status(e, cleanup_error)
             self.last_error = _mcp_connection_error_message(e, cleanup_error)
-            if _is_mcp_authentication_error(cleanup_error):
+            if self.last_auth_status is not None:
                 _warn(
                     f"[mcp] connect:failed server={self.name!r} stage={stage} "
                     f"elapsed_ms={elapsed_ms()} error={self.last_error}"
@@ -562,6 +566,7 @@ class MCPServerConnection:
 
         except Exception as e:
             cleanup_error = await _close_exit_stack()
+            self.last_auth_status = _mcp_auth_status(e, cleanup_error)
             self.last_error = _mcp_connection_error_message(e, cleanup_error)
             _warn(
                 f"[mcp] connect:failed server={self.name!r} stage={stage} "
@@ -767,6 +772,7 @@ class McpServerStatus:
     tool_count: int = 0
     tools: list = field(default_factory=list)
     error: str | None = None
+    auth_status: int | None = None
 
 
 _mcp_status: dict[str, McpServerStatus] = {}
@@ -831,10 +837,17 @@ def _record_status(
     tool_count: int = 0,
     tools: list | None = None,
     error: str | None = None,
+    auth_status: int | None = None,
 ) -> None:
+    if auth_status is None and error:
+        if "HTTP 401" in error or "Authentication failed" in error:
+            auth_status = 401
+        elif "HTTP 403" in error or "Authorization failed" in error:
+            auth_status = 403
     _mcp_status[name] = McpServerStatus(
         name=name, state=state, transport=transport,
         tool_count=tool_count, tools=tools or [], error=error,
+        auth_status=auth_status,
     )
 
 
@@ -847,6 +860,7 @@ def get_mcp_status() -> list[dict]:
             "toolCount": s.tool_count,
             "tools": s.tools,
             "error": s.error,
+            "authStatus": s.auth_status,
         }
         for s in _mcp_status.values()
     ]
@@ -1036,6 +1050,7 @@ async def load_mcp_tools_async(
                     conn.name, "failed",
                     transport=conn.url or conn.command or "",
                     error=str(success),
+                    auth_status=_mcp_auth_status(success),
                 )
                 continue
             if success:
@@ -1053,6 +1068,7 @@ async def load_mcp_tools_async(
                     conn.name, "failed",
                     transport=conn.url or conn.command or "",
                     error=conn.last_error or "connect() returned False",
+                    auth_status=conn.last_auth_status,
                 )
 
         _warn(f"Total MCP tools loaded: {len(all_tools)}")
@@ -1089,7 +1105,7 @@ async def reconnect_mcp_server(name: str) -> dict:
 
 
 async def reconnect_auth_failed_mcp_servers_if_token_changed() -> list[dict]:
-    """Reconnect 401-failed MCP servers after the product login token rotates.
+    """Reconnect auth-failed MCP servers after the product login token rotates.
 
     Hosted MCP discovery happens once during CLI startup. If that initial
     connection receives a 401, there is no persistent HTTP client on which the
@@ -1109,11 +1125,7 @@ async def reconnect_auth_failed_mcp_servers_if_token_changed() -> list[dict]:
         status.name
         for status in _mcp_status.values()
         if status.state == "failed"
-        and status.error
-        and (
-            "HTTP 401" in status.error
-            or "Authentication failed" in status.error
-        )
+        and status.auth_status in {401, 403}
     ]
     results: list[dict] = []
     for name in failed_names:
@@ -1203,7 +1215,13 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
         try:
             success = await conn.connect()
         except Exception as e:
-            _record_status(name, "failed", transport=transport_label, error=str(e))
+            _record_status(
+                name,
+                "failed",
+                transport=transport_label,
+                error=str(e),
+                auth_status=_mcp_auth_status(e),
+            )
             return {"success": False, "error": str(e), "configPath": _mcp_config_path}
 
         if success:
@@ -1217,7 +1235,13 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
             )
             return {"success": True, "toolCount": len(conn.tools), "tools": [t.name for t in conn.tools], "configPath": _mcp_config_path}
 
-        _record_status(name, "failed", transport=transport_label, error=conn.last_error)
+        _record_status(
+            name,
+            "failed",
+            transport=transport_label,
+            error=conn.last_error,
+            auth_status=conn.last_auth_status,
+        )
         return {"success": False, "error": conn.last_error or "connect() returned False", "configPath": _mcp_config_path}
     finally:
         catalog.mark_server_ready(name)

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1241,6 +1241,67 @@ async def test_mcp_reconnect_injects_hidden_deferred_state_into_active_turns_onl
 
 
 @pytest.mark.asyncio
+async def test_acp_auth_refresh_reconnects_and_injects_deferred_catalog_update(
+    tmp_path,
+    monkeypatch,
+):
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(
+            enable_sub_agent=False,
+            mcp=MCPConfig(deferred_loading_enabled=True),
+        ),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [], "system")
+    session = await agent.newSession(SimpleNamespace(cwd=str(tmp_path), field_meta={}))
+    state = agent._sessions[session.sessionId]
+    state.turn_active = True
+    runtime_tool = EchoTool()
+    runtime_tool.mcp_always_load = False
+
+    async def reconnect_changed():
+        return [{"name": "hosted", "success": True}]
+
+    monkeypatch.setattr(
+        "box_agent.tools.mcp_loader.reconnect_auth_failed_mcp_servers_if_token_changed",
+        reconnect_changed,
+    )
+    monkeypatch.setattr(
+        "box_agent.tools.mcp_loader.get_mcp_tools_for_server",
+        lambda _name: [runtime_tool],
+    )
+
+    result = await agent._refresh_mcp_after_auth_change()
+
+    assert result == [{"name": "hosted", "success": True}]
+    update = state.inject_queue.get_nowait()
+    assert update["source"] == "runtime"
+    assert "hosted" in update["content"]
+    assert "tool_search" in update["content"]
+
+
+@pytest.mark.asyncio
+async def test_acp_prompt_checks_for_mcp_auth_refresh(acp_agent, monkeypatch):
+    agent, _ = acp_agent
+    session = await agent.newSession(SimpleNamespace(cwd=None, field_meta={}))
+    calls = 0
+
+    async def refresh():
+        nonlocal calls
+        calls += 1
+        return []
+
+    monkeypatch.setattr(agent, "_refresh_mcp_after_auth_change", refresh)
+
+    await agent.prompt(
+        SimpleNamespace(sessionId=session.sessionId, prompt=[{"text": "hello"}])
+    )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
 async def test_initial_mcp_catalog_ready_is_injected_into_active_turn(tmp_path):
     config = Config(
         llm=LLMConfig(api_key="test-key"),

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -28,6 +28,8 @@ from box_agent.tools.mcp_loader import (
     cleanup_mcp_connections,
     get_mcp_timeout_config,
     load_mcp_tools_async,
+    McpServerStatus,
+    reconnect_auth_failed_mcp_servers_if_token_changed,
     set_mcp_timeout_config,
 )
 from box_agent.tools.setup import merge_mcp_tools, register_mcp_tools
@@ -37,6 +39,65 @@ from box_agent.tools.base import Tool, ToolResult
 def test_streamable_http_client_is_available():
     """The loader resolves the client exported by the installed MCP SDK."""
     assert callable(mcp_loader.streamable_http_client)
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_reconnects_structured_401_and_403_failures(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(mcp_loader, "_mcp_auth_token", "old-token")
+    monkeypatch.setattr(mcp_loader, "_mcp_auth_file", "")
+    monkeypatch.setattr(mcp_loader, "_mcp_auth_fingerprint", "old-fingerprint")
+    monkeypatch.setattr(
+        mcp_loader,
+        "_mcp_status",
+        {
+            "unauthenticated": McpServerStatus(
+                name="unauthenticated",
+                state="failed",
+                auth_status=401,
+            ),
+            "forbidden": McpServerStatus(
+                name="forbidden",
+                state="failed",
+                auth_status=403,
+            ),
+            "timeout": McpServerStatus(
+                name="timeout",
+                state="failed",
+                error="connection timeout",
+            ),
+        },
+    )
+    monkeypatch.setattr(mcp_loader, "resolve_auth_token", lambda *_args, **_kwargs: "new-token")
+
+    async def reconnect(name: str) -> dict:
+        calls.append(name)
+        return {"success": True}
+
+    monkeypatch.setattr(mcp_loader, "reconnect_mcp_server", reconnect)
+
+    result = await reconnect_auth_failed_mcp_servers_if_token_changed()
+
+    assert calls == ["unauthenticated", "forbidden"]
+    assert result == [
+        {"name": "unauthenticated", "success": True},
+        {"name": "forbidden", "success": True},
+    ]
+    assert await reconnect_auth_failed_mcp_servers_if_token_changed() == []
+
+
+def test_recorded_auth_status_is_exposed_without_parsing_at_retry_time(monkeypatch):
+    monkeypatch.setattr(mcp_loader, "_mcp_status", {})
+
+    mcp_loader._record_status(
+        "hosted",
+        "failed",
+        error="Authorization failed: Access denied (HTTP 403)",
+    )
+
+    status = mcp_loader.get_mcp_status()[0]
+    assert status["authStatus"] == 403
+    assert mcp_loader._mcp_status["hosted"].auth_status == 403
 
 
 def test_streamable_http_client_has_supported_signature():
@@ -768,6 +829,7 @@ class TestMCPServerConnectionTimeout:
 
         assert await conn.connect() is False
         assert conn.last_error == "Connection timed out after 0.02s during open-stdio-transport"
+        assert conn.last_auth_status is None
 
         stderr = capsys.readouterr().err
         assert "[mcp] connect:start server='slow-stdio' transport=stdio" in stderr
@@ -841,6 +903,7 @@ class TestMCPServerConnectionTimeout:
 
         assert await conn.connect() is False
         assert conn.last_error == expected_error
+        assert conn.last_auth_status == (401 if "401" in expected_error else 403)
         assert conn.exit_stack is None
         assert conn.session is None
 


### PR DESCRIPTION
## Task

- reconnect MCP servers that failed with structured HTTP 401 or 403 after the host token changes
- run the auth-refresh check on every ACP prompt after initial MCP loading
- refresh eager tool lists or notify active deferred-loading turns when reconnect results arrive
- expose additive `authStatus` in MCP status output

Out of scope: changing hosted MCP configuration or packaging the runtime into OfficeV3.

## Proof

- `uv run pytest tests/test_mcp.py tests/test_acp.py -q`: 159 passed, 3 skipped
- `uv run pytest tests/ -q`: 2599 passed, 17 skipped, 1 temp-path-sensitive PPT stdout threshold failure
- exact PPT failure rerun with `TMPDIR=/tmp`: 1 passed
- `git diff --check`: passed

## Risk

- MCP status gains an additive `authStatus` field.
- Reconnect attempts remain once per observed token fingerprint, avoiding repeated retries on every prompt.
- This is source-level validation only; an OfficeV3 runtime rebuild, install, restart, and fresh live task are still required before claiming deployed behavior.