### PR TITLE
fix todo problem

### DIFF
--- a/box_agent/tools/todo_tool.py
+++ b/box_agent/tools/todo_tool.py
@@ -61,6 +61,17 @@ def _todo_state_error(items: list[dict]) -> str | None:
     )
 
 
+def _activate_first_unfinished(items: list[dict]) -> bool:
+    """Activate the first unfinished item when no current item was supplied."""
+    unfinished = [item for item in items if item.get("status") != "completed"]
+    if not unfinished:
+        return False
+    if any(item.get("status") == "in_progress" for item in unfinished):
+        return False
+    unfinished[0]["status"] = "in_progress"
+    return True
+
+
 def _validate_todo_records(items: Any) -> None:
     """Validate todo record shapes without enforcing workflow state."""
     if not isinstance(items, list):
@@ -151,13 +162,12 @@ def _todo_next_instruction(items: list[dict]) -> str:
     if not has_pending:
         return (
             f"Continue only with todo #{current.get('id')}. After completing and verifying "
-            "it, use action='transition' without next_todo_id to complete the final "
-            "unfinished item."
+            "it, use action='transition' to complete the final unfinished item."
         )
     return (
         f"Continue only with todo #{current.get('id')}. After completing and verifying "
-        "it, use action='transition' to complete it and activate the next pending item "
-        "atomically. Use action='set' only to initialize or materially rebuild the list."
+        "it, use action='transition' to complete it and automatically activate the first "
+        "pending item. Use action='set' only to initialize or materially rebuild the list."
     )
 
 
@@ -358,12 +368,13 @@ class TodoStore:
                     or "pending"
                 )
             })
+        _activate_first_unfinished(candidate_state)
         state_error = _todo_state_error(candidate_state)
         if state_error:
             raise ValueError(state_error)
 
         items: list[dict] = []
-        for todo in todos:
+        for index, todo in enumerate(todos):
             supplied_id = todo.get("id")
             if supplied_id is None:
                 todo_id = self._next_id()
@@ -377,9 +388,7 @@ class TodoStore:
                 "id": todo_id,
                 "task": str(todo["task"]).strip(),
                 "status": str(
-                    todo.get("status")
-                    or (existing or {}).get("status")
-                    or "pending"
+                    candidate_state[index]["status"]
                 ),
                 "priority": str(
                     todo.get("priority")
@@ -430,7 +439,12 @@ class TodoStore:
         current["status"] = "completed"
 
         next_item = None
-        if next_todo_id is not None:
+        if next_todo_id is None:
+            next_item = next(
+                (item for item in items if item["status"] == "pending"),
+                None,
+            )
+        else:
             next_item = next(
                 (item for item in items if item["id"] == next_todo_id),
                 None,
@@ -439,6 +453,7 @@ class TodoStore:
                 raise ValueError(f"Todo #{next_todo_id} not found.")
             if next_item["status"] != "pending":
                 raise ValueError(f"Todo #{next_todo_id} is not pending.")
+        if next_item is not None:
             next_item["status"] = "in_progress"
 
         self._commit(items)
@@ -458,7 +473,7 @@ class TodoStore:
 # ── Tools ───────────────────────────────────────────────────
 
 class TodoWriteTool(Tool):
-    """Create, replace, transition, update, or delete todo items."""
+    """Initialize or transition todo items."""
 
     def __init__(self, store: TodoStore):
         self._store = store
@@ -498,14 +513,16 @@ class TodoWriteTool(Tool):
     def description(self) -> str:
         return (
             "Manage a todo list for tracking multi-step tasks. "
-            "Actions: 'set' the full current list in one call, 'create' a new item, "
-            "'transition' atomically completes the active item and starts the next, "
-            "'update' changes an existing item, and 'delete' removes an item. "
+            "Actions: 'set' initializes or substantially revises the full current "
+            "list in one call, and 'transition' atomically completes the active item "
+            "and starts the next. "
             "Use 'set' only for new or substantially revised multi-step work. Preserve "
             "the id of unchanged existing items in the complete ordered todos array. "
             "Status-only changes to the same ordered list are rejected; use "
             "'transition' for progress. Existing tasks submitted without their canonical "
             "ids are also rejected; call todo_read first if the ids are unavailable. "
+            "If a set payload has unfinished work but no in_progress item, the first "
+            "unfinished item is activated automatically. "
             "When initializing an empty todo list, omit ids; any supplied ids are "
             "ignored and canonical todo ids are assigned automatically. "
             "Use 'transition' for normal progress instead of rebuilding the whole list. "
@@ -529,7 +546,7 @@ class TodoWriteTool(Tool):
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["set", "create", "transition", "update", "delete"],
+                    "enum": ["set", "transition"],
                     "description": "Operation to perform.",
                 },
                 "todos": {
@@ -537,9 +554,10 @@ class TodoWriteTool(Tool):
                     "description": (
                         "Complete ordered todo list for action='set'. This replaces the "
                         "current list. Each item requires task and status, with optional "
-                        "priority. When unfinished work remains, the complete list must "
-                        "contain exactly one in_progress item; an empty or fully completed "
-                        "list must contain none."
+                        "priority. When unfinished work remains, zero in_progress items "
+                        "activates the first unfinished item automatically; more than one "
+                        "in_progress item is invalid. An empty or fully completed list "
+                        "must contain none."
                     ),
                     "items": {
                         "type": "object",
@@ -557,8 +575,9 @@ class TodoWriteTool(Tool):
                                 "type": "string",
                                 "enum": list(_VALID_STATUSES),
                                 "description": (
-                                    "Required task status. Across the complete set payload, "
-                                    "unfinished work requires exactly one in_progress item."
+                                    "Required task status. If no unfinished item is marked "
+                                    "in_progress, the first unfinished item is activated "
+                                    "automatically."
                                 ),
                             },
                             "priority": {
@@ -570,36 +589,17 @@ class TodoWriteTool(Tool):
                         "required": ["task", "status"],
                     },
                 },
-                "task": {
-                    "type": "string",
-                    "description": "Task description (required for 'create', optional for 'update').",
-                },
                 "todo_id": {
                     "type": "string",
-                    "description": (
-                        "ID of the todo item (required for 'transition', 'update', "
-                        "and 'delete')."
-                    ),
+                    "description": "ID of the active todo item for action='transition'.",
                 },
                 "next_todo_id": {
                     "type": "string",
                     "description": (
-                        "Pending todo to activate for action='transition'. Omit only "
-                        "when completing the final unfinished todo."
+                        "Pending todo to activate for action='transition'. Omit to "
+                        "activate the first pending item in list order automatically, "
+                        "or when completing the final unfinished todo."
                     ),
-                },
-                "status": {
-                    "type": "string",
-                    "enum": list(_VALID_STATUSES),
-                    "description": (
-                        "Status to set for 'create' or 'update'. One of: pending, "
-                        "in_progress, completed."
-                    ),
-                },
-                "priority": {
-                    "type": "string",
-                    "enum": list(_VALID_PRIORITIES),
-                    "description": "Priority level (for 'create'). Default: medium.",
                 },
             },
             "required": ["action"],

--- a/tests/test_todo_tool.py
+++ b/tests/test_todo_tool.py
@@ -323,24 +323,34 @@ async def test_set_requires_valid_todos(writer):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "todos, active_count",
-    [
-        ([{"task": "Pending only", "status": "pending"}], 0),
-        (
-            [
-                {"task": "Active A", "status": "in_progress"},
-                {"task": "Active B", "status": "in_progress"},
-            ],
-            2,
-        ),
-    ],
-)
-async def test_set_rejects_invalid_active_item_count(writer, todos, active_count):
-    result = await writer.execute(action="set", todos=todos)
+async def test_set_activates_first_unfinished_when_all_items_are_pending(writer):
+    result = await writer.execute(
+        action="set",
+        todos=[
+            {"task": "First", "status": "pending"},
+            {"task": "Second", "status": "pending"},
+        ],
+    )
+
+    assert result.success
+    assert [item["status"] for item in result.raw_output["items"]] == [
+        "in_progress",
+        "pending",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_rejects_multiple_active_items(writer):
+    result = await writer.execute(
+        action="set",
+        todos=[
+            {"task": "Active A", "status": "in_progress"},
+            {"task": "Active B", "status": "in_progress"},
+        ],
+    )
 
     assert not result.success
-    assert f"found {active_count}" in result.error
+    assert "found 2" in result.error
 
 
 @pytest.mark.asyncio
@@ -368,7 +378,8 @@ async def test_failed_set_does_not_consume_ids_or_change_existing_state(writer):
     failed = await writer.execute(
         action="set",
         todos=[
-            {"task": "Invalid pending", "status": "pending"},
+            {"task": "Invalid active A", "status": "in_progress"},
+            {"task": "Invalid active B", "status": "in_progress"},
         ],
     )
 
@@ -451,7 +462,7 @@ async def test_transition_atomically_advances_to_next_todo(writer):
     assert "Inspect implementation" in result.model_context
     assert "Run verification" in result.model_context
     assert "action='transition'" in result.model_context
-    assert "without next_todo_id" in result.model_context
+    assert "complete the final unfinished item" in result.model_context
     assert "complete current todo list" not in result.model_context
 
 
@@ -473,16 +484,21 @@ async def test_transition_completes_final_todo_without_next_id(writer):
 
 
 @pytest.mark.asyncio
-async def test_transition_requires_next_id_when_pending_work_remains(writer):
+async def test_transition_activates_first_pending_when_next_id_is_omitted(writer):
     await writer.execute(action="create", task="Current")
     await writer.execute(action="create", task="Next")
 
     result = await writer.execute(action="transition", todo_id="1")
 
-    assert not result.success
-    assert "found 0" in result.error
-    items = writer._store.list()
-    assert [item["status"] for item in items] == ["in_progress", "pending"]
+    assert result.success
+    assert result.raw_output["transition"] == {
+        "completed_id": "1",
+        "in_progress_id": "2",
+    }
+    assert [item["status"] for item in result.raw_output["items"]] == [
+        "completed",
+        "in_progress",
+    ]
 
 
 @pytest.mark.asyncio
@@ -821,14 +837,17 @@ def test_anthropic_schema(writer, reader):
     schema = writer.to_schema()
     assert schema["name"] == "todo_write"
     assert "input_schema" in schema
-    assert "set" in schema["input_schema"]["properties"]["action"]["enum"]
-    assert "transition" in schema["input_schema"]["properties"]["action"]["enum"]
-    assert "todos" in schema["input_schema"]["properties"]
-    assert "id" in schema["input_schema"]["properties"]["todos"]["items"]["properties"]
-    todo_items_schema = schema["input_schema"]["properties"]["todos"]["items"]
+    properties = schema["input_schema"]["properties"]
+    assert properties["action"]["enum"] == ["set", "transition"]
+    assert "todos" in properties
+    assert "id" in properties["todos"]["items"]["properties"]
+    assert "task" not in properties
+    assert "status" not in properties
+    assert "priority" not in properties
+    todo_items_schema = properties["todos"]["items"]
     assert todo_items_schema["required"] == ["task", "status"]
-    assert "exactly one in_progress" in schema["input_schema"]["properties"]["todos"]["description"]
-    assert "next_todo_id" in schema["input_schema"]["properties"]
+    assert "activates the first unfinished item automatically" in properties["todos"]["description"]
+    assert "next_todo_id" in properties
 
     schema = reader.to_schema()
     assert schema["name"] == "todo_read"
@@ -857,3 +876,6 @@ def test_todo_write_description_keeps_todo_as_progress_tracker(writer):
     assert "Use 'set' only" in description
     assert "Use 'transition' for normal progress" in description
     assert "Preserve the id" in description
+    assert "'create'" not in description
+    assert "'update'" not in description
+    assert "'delete'" not in description


### PR DESCRIPTION
set 全部 pending 时自动激活第一项。
transition 省略 next_todo_id 时自动激活第一个 pending。
多个 in_progress 仍然拒绝。
模型仍只看到 set/transition

## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

### Design and architecture impact

- Affected layers and owners:
- Contract, schema, or protocol impact:
- Documentation updated:

### Target branch consistency

- Base branch and reviewed Head SHA:
- Relevant target-branch changes considered:
- Rebase, compatibility, or historical-fix risk:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [ ] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [ ] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` passed for the current Head SHA, or the missing status is explained.
