### PR TITLE
doc(auto-update)

### DIFF
--- a/docs/integration/host-progress-events.md
+++ b/docs/integration/host-progress-events.md
@@ -241,7 +241,11 @@ Host behavior:
 - Replace the current todo state with `items` for that session or message scope.
 - Treat every `todo_snapshot` as a complete snapshot, including results from filtered or single-item `todo_read` calls.
 - Use stable `items[].id` values as task identity. `set` preserves supplied existing IDs and allocates new IDs only for new tasks.
-- Every item in a non-empty `set` request must include `status`. While unfinished work remains, the complete list must contain exactly one `in_progress` item; empty or fully completed lists contain none.
+- Every item in a non-empty `set` request must include `status`. For unfinished work,
+  `todo_write` now allows no initial `in_progress` item; the tool will
+  automatically activate the first unfinished item in list order. After processing,
+  the complete snapshot therefore has exactly one `in_progress` item unless the
+  list is empty or fully completed.
 - `action: "transition"` may include an optional `transition` object with `completed_id` and `in_progress_id`; hosts do not need this field to consume the complete snapshot.
 - Do not classify `todo_write` as sub-agent work just because `rawInput.task` exists.
 - A `todo_read` result also includes `todo_snapshot`; it may omit `action` and `item`.


### PR DESCRIPTION
触发原始 PR/MR: https://github.com/Raccoon-Office/Box-Agent/pull/52
固定文档影响范围: `14e2c71c1e2d2d745a43eafc3502dd0bc82db0e2..ebeb53cd6fcfeb202741cc9407ab69f6cd5845cf`
文档更新摘要: 更新 `docs/integration/host-progress-events.md`，对齐 `todo` set 场景自动激活首个 `in_progress` 的行为；其他候选 `box_agent/config/system_prompt.md` 判定无需更新。
文档索引状态: `docs/README.md` 存在且无需修改。
子 Agent 验证: 已返回 UPDATED_AND_PUSHED，提交 subject `doc(auto-update)`，父提交为 `ebeb53cd6fcfeb202741cc9407ab69f6cd5845cf`，远端分支验证通过。