### PR TITLE
feat(roadmap): add structured editable HTML roadmap support

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -73,7 +73,6 @@ from box_agent.agent import (
 from box_agent.tools.setup import (
     add_workspace_tools,
     await_mcp_tools,
-    await_skill_discovery,
     build_file_delivery_prompt,
     build_image_generation_prompt,
     build_sandbox_info_prompt,
@@ -178,6 +177,7 @@ from box_agent.acp.project_context import build_project_startup_context_prompt
 from box_agent.experts import ExpertSessionContext
 from box_agent.memory import MemoryManager
 from box_agent.retry import RetryConfig as RetryConfigBase
+from box_agent.runtime_capabilities import runtime_capabilities
 from box_agent.schema import LLMProvider, Message
 from box_agent.tools.permissions import CapabilityPolicy, GrantStore, PermissionEngine
 from box_agent.tools.runtime import (
@@ -201,6 +201,9 @@ from .debug_logger import acp_logger as log
 # Keep stdlib logger for backward compat with existing log calls
 logger = logging.getLogger(__name__)
 _DEFAULT_AGENT_TITLE = "Box-Agent"
+_SKILL_DISCOVERY_WAIT_SECONDS = 5.0
+_RUNTIME_CAPABILITIES_UPDATE_METHOD = "box-agent/runtime-capabilities-update"
+_RUNTIME_CAPABILITIES_UPDATE_CONTRACT = "box-agent.runtime-capabilities-update"
 
 try:
     class InitializeRequestPatch(InitializeRequest):
@@ -250,6 +253,8 @@ def _artifact_envelope(
     }
     if output_dir:
         payload["output_dir"] = output_dir
+    if art.layout_id:
+        payload["layout_id"] = art.layout_id
     if session_id:
         payload["session_id"] = session_id
         payload["sessionId"] = session_id
@@ -873,6 +878,7 @@ class SessionState:
     skill_runtime_context: "SkillRuntimeContext | None" = None
     skill_loader: Any | None = None  # session-local loader for expert-only recommended skills
     skill_selector: Any | None = None  # SkillSelector — filters skill metadata per turn
+    runtime_capabilities: dict[str, Any] | None = None
     expert_context: ExpertSessionContext | None = None
     upstream_session_id: str = ""  # caller-owned session id from _meta.session_id
     current_task_id: str = ""
@@ -1323,7 +1329,7 @@ class BoxACPAgent:
             )
         return results
 
-    async def _ensure_skills_loaded(self) -> None:
+    async def _ensure_skills_loaded(self) -> bool:
         """Await the background skill-discovery task before it's needed.
 
         SkillSelector runs at newSession + first-turn boundary; both call
@@ -1334,22 +1340,37 @@ class BoxACPAgent:
         alternative is an empty ``## Available Skills`` block on turn 1.
         """
         if self._skills_loaded:
-            return
-        try:
-            await await_skill_discovery(self._skill_task)
-        finally:
-            # Flip regardless of outcome — discovery failures are logged
-            # inside the task; retrying on every turn would just repeat them.
+            return True
+        if self._skill_task is None:
             self._skills_loaded = True
+            return True
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._skill_task),
+                timeout=_SKILL_DISCOVERY_WAIT_SECONDS,
+            )
+        except TimeoutError:
+            log.warn(
+                "skills/discovery_timeout",
+                message=(
+                    "Skill discovery is still pending after "
+                    f"{_SKILL_DISCOVERY_WAIT_SECONDS:g}s; continuing conservatively"
+                ),
+            )
+            return False
+        except Exception:
+            # Discovery logs its own failure. Treat a completed failed task as
+            # final so sessions can continue with the partial/empty catalog.
+            pass
+        self._skills_loaded = True
+        return True
 
     def _skills_meta(self) -> list[dict] | None:
         """Return current skills metadata for ACP _meta payload, reloading if changed.
 
         Returns ``None`` (rather than an empty list) while background
-        discovery is still running so the initialize RPC never blocks on
-        skill parsing. Hosts that need the catalog can read
-        ``session/new._meta.skills`` — by newSession time the task has been
-        awaited via ``_ensure_skills_loaded``.
+        discovery is still running. ``initialize`` reports that conservative
+        pending state; ``session/new`` waits for and publishes the final catalog.
         """
         if not self._skill_loader:
             return None
@@ -1362,6 +1383,82 @@ class BoxACPAgent:
             log.warn("skills/meta_error", message=f"Failed to build skills metadata: {exc}")
             return None
 
+    def _runtime_capabilities_meta(
+        self,
+        *,
+        node_available: bool | None = None,
+        roadmap_skill_available: bool | None = None,
+    ) -> dict[str, Any]:
+        if roadmap_skill_available is None:
+            roadmap_skill_available = self._roadmap_skill_available()
+        kwargs: dict[str, Any] = {
+            "skills_enabled": self._config.tools.enable_skills,
+            "roadmap_skill_available": roadmap_skill_available,
+        }
+        if node_available is not None:
+            kwargs["node_available"] = node_available
+        return runtime_capabilities(**kwargs)
+
+    def _roadmap_skill_available(self, loader: Any | None = None) -> bool:
+        if not self._skills_loaded or not self._config.tools.enable_skills:
+            return False
+        skill_loader = loader or self._skill_loader
+        if skill_loader is None:
+            return False
+        try:
+            return skill_loader.get_skill("roadmap") is not None
+        except Exception as exc:
+            log.warn(
+                "skills/roadmap_availability_error",
+                message=f"Failed to resolve Roadmap skill availability: {exc}",
+            )
+            return False
+
+    async def _publish_runtime_capabilities_if_changed(
+        self,
+        session_id: str,
+        state: SessionState,
+    ) -> None:
+        runtime_context = state.skill_runtime_context
+        current = self._runtime_capabilities_meta(
+            node_available=(
+                runtime_context.get("node").available
+                if runtime_context is not None
+                else None
+            ),
+            roadmap_skill_available=self._roadmap_skill_available(state.skill_loader),
+        )
+        if current == state.runtime_capabilities:
+            return
+
+        notify = getattr(self._conn, "extNotification", None)
+        if not callable(notify):
+            state.runtime_capabilities = current
+            return
+        try:
+            await asyncio.wait_for(
+                notify(
+                    _RUNTIME_CAPABILITIES_UPDATE_METHOD,
+                    {
+                        "contract": _RUNTIME_CAPABILITIES_UPDATE_CONTRACT,
+                        "contractVersion": 1,
+                        "sessionId": session_id,
+                        "runtime_capabilities": current,
+                    },
+                ),
+                timeout=self._SESSION_UPDATE_TIMEOUT_SECONDS,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log.warn(
+                "runtime_capabilities/update_error",
+                session_id=session_id,
+                message=str(exc),
+            )
+            return
+        state.runtime_capabilities = current
+
     async def initialize(self, params: InitializeRequest) -> InitializeResponse:
         log.info("initialize", message="ACP initialize request received")
         meta = getattr(params, "field_meta", None) or {}
@@ -1373,9 +1470,13 @@ class BoxACPAgent:
             agentInfo=Implementation(name="box-agent", title="Box-Agent", version=__version__),
         )
         skills = self._skills_meta()
+        response_meta: dict[str, Any] = {
+            "runtime_capabilities": self._runtime_capabilities_meta(),
+        }
         if skills is not None:
-            # Pydantic alias: _meta ↔ field_meta
-            kwargs["field_meta"] = {"skills": skills}
+            response_meta["skills"] = skills
+        # Pydantic alias: _meta ↔ field_meta
+        kwargs["field_meta"] = response_meta
         resp = InitializeResponse(**kwargs)
         log.info("initialize", message=f"Initialized box-agent v{__version__}, skills={len(skills) if skills else 0}")
         return resp
@@ -1386,7 +1487,7 @@ class BoxACPAgent:
         # prompt (SkillSelector.bind reads the sentinel; the metadata block
         # is populated on the first turn). This is a no-op after the first
         # session — the task caches its result.
-        await self._ensure_skills_loaded()
+        skills_ready = await self._ensure_skills_loaded()
         session_id = f"sess-{len(self._sessions)}-{uuid4().hex[:8]}"
         workspace = Path(params.cwd or self._config.agent.workspace_dir).expanduser()
         if not workspace.is_absolute():
@@ -1797,6 +1898,13 @@ class BoxACPAgent:
             session_id=upstream_session_id or session_id,
             acp_session_id=session_id,
         )
+        session_runtime_capabilities = self._runtime_capabilities_meta(
+            node_available=skill_runtime_context.get("node").available,
+            roadmap_skill_available=(
+                skills_ready
+                and self._roadmap_skill_available(session_skill_loader)
+            ),
+        )
         self._sessions[session_id] = SessionState(
             agent=agent, session_llm=session_llm,
             summary_llm=summary_llm,
@@ -1811,6 +1919,7 @@ class BoxACPAgent:
             env_context=env_context,
             skill_runtime_context=skill_runtime_context,
             skill_loader=session_skill_loader,
+            runtime_capabilities=session_runtime_capabilities,
             expert_context=expert_context,
             upstream_session_id=upstream_session_id,
             current_task_id=initial_task_id,
@@ -1859,10 +1968,12 @@ class BoxACPAgent:
         log.info("session/new", session_id=session_id, message=f"Session ready, {len(tools)} tools: {', '.join(tool_names)}")
 
         kwargs: dict[str, Any] = {"sessionId": session_id}
-        response_meta: dict[str, Any] = {}
+        response_meta: dict[str, Any] = {
+            "runtime_capabilities": session_runtime_capabilities,
+        }
         skills = (
             session_skill_loader.list_skills_metadata()
-            if session_skill_loader is not None
+            if skills_ready and session_skill_loader is not None
             else self._skills_meta()
         )
         if skills is not None:
@@ -2399,17 +2510,19 @@ class BoxACPAgent:
         # short-circuit any edge case where a session was created before
         # the task finished (e.g. host called newSession within the same
         # event-loop iteration as run_acp_server's setup).
-        await self._ensure_skills_loaded()
+        skills_ready = await self._ensure_skills_loaded()
 
         # Refresh skills so officev3-authored skills are available mid-session
-        if state.skill_loader:
+        if skills_ready and state.skill_loader:
             try:
                 state.skill_loader.maybe_reload()
             except Exception as exc:
                 log.warn("skills/reload_error", session_id=session_id, message=str(exc))
+        if skills_ready:
+            await self._publish_runtime_capabilities_if_changed(session_id, state)
 
         # Per-turn skill metadata filter.
-        if state.skill_selector is not None:
+        if skills_ready and state.skill_selector is not None:
             try:
                 from box_agent.tools.skill_loader import SKILL_SLOT_SENTINEL
                 current_system = state.agent.messages[0].content
@@ -2429,21 +2542,22 @@ class BoxACPAgent:
             except Exception as exc:
                 log.warn("skills/filter_error", session_id=session_id, message=str(exc))
 
+        turn_skill_loader = state.skill_loader if skills_ready else None
         matched_skill_names = (
             state.skill_selector.matched_skill_names
-            if state.skill_selector is not None
+            if skills_ready and state.skill_selector is not None
             else ()
         )
         current_skill_names = (
             tuple(
                 skill.name
-                for skill in state.skill_loader.filter_by_query(plan_detection_text)
+                for skill in turn_skill_loader.filter_by_query(plan_detection_text)
             )
-            if state.skill_loader is not None and plan_detection_text.strip()
+            if turn_skill_loader is not None and plan_detection_text.strip()
             else ()
         )
         explicit_skill = resolve_explicit_skill_invocation(
-            state.skill_loader,
+            turn_skill_loader,
             plan_detection_text,
         )
         explicit_skill_uses_controlled_workflow = (
@@ -2471,7 +2585,7 @@ class BoxACPAgent:
             host_presentation_config = None
         presentation_provider = (
             resolve_presentation_skill_provider(
-                state.skill_loader,
+                turn_skill_loader,
                 current_skill_names,
                 preferred_skill=(
                     host_presentation_config.preferred_skill
@@ -2480,7 +2594,7 @@ class BoxACPAgent:
                 ),
                 query=plan_detection_text,
             )
-            if state.skill_loader is not None
+            if turn_skill_loader is not None
             else None
         )
         if host_presentation_config is not None:
@@ -2511,8 +2625,8 @@ class BoxACPAgent:
             and presentation_provider.uses_controlled_workflow
         )
         presentation_provider_skill = (
-            state.skill_loader.get_skill(presentation_provider.skill_name)
-            if state.skill_loader is not None
+            turn_skill_loader.get_skill(presentation_provider.skill_name)
+            if turn_skill_loader is not None
             and presentation_provider is not None
             else None
         )
@@ -2720,7 +2834,7 @@ class BoxACPAgent:
                 source=completion_gate_source,
             )
 
-        if state.skill_selector is not None:
+        if skills_ready and state.skill_selector is not None:
             preload_names = self._turn_preload_skill_names(
                 state.skill_selector.matched_skill_names,
                 completion_gate,

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -208,6 +208,7 @@ _DEFAULT_AGENT_TITLE = "Box-Agent"
 _SKILL_DISCOVERY_WAIT_SECONDS = 5.0
 _RUNTIME_CAPABILITIES_UPDATE_METHOD = "box-agent/runtime-capabilities-update"
 _RUNTIME_CAPABILITIES_UPDATE_CONTRACT = "box-agent.runtime-capabilities-update"
+_RUNTIME_CAPABILITIES_QUERY_CONTRACT = "box-agent.runtime-capabilities-query"
 
 try:
     class InitializeRequestPatch(InitializeRequest):
@@ -3338,6 +3339,16 @@ class BoxACPAgent:
 
     async def extMethod(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Handle custom ACP extension methods (called as ``_<method>``)."""
+        if method == "runtime/capabilities":
+            skills_ready = await self._ensure_skills_loaded()
+            return {
+                "contract": _RUNTIME_CAPABILITIES_QUERY_CONTRACT,
+                "contractVersion": 1,
+                "ready": skills_ready,
+                "_meta": {
+                    "runtime_capabilities": self._runtime_capabilities_meta(),
+                },
+            }
         if method == "inject":
             session_id = params.get("sessionId", "")
             text = params.get("text", "")

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -82,6 +82,10 @@ from box_agent.tools.setup import (
 )
 from box_agent.tools.bash_tool import BashTool
 from box_agent.tools.file_tools import WriteTool
+from box_agent.tools.skill_scratch import (
+    SkillScratchDirectory,
+    cleanup_skill_scratch_dir,
+)
 from box_agent.tools.browser_runtime_scope import (
     release_browser_runtime,
     reset_browser_runtime_owner,
@@ -863,6 +867,7 @@ class SessionState:
     summary_llm: SessionBoundLLM | None = None
     cancelled: bool = False
     output_dir: str | None = None  # ``{workspace}/output/`` — the canonical artifact root
+    skill_scratch_dir: SkillScratchDirectory | None = None
     artifact_mode: str = "output"
     session_mode: str | None = None  # e.g. "data_analysis" for /analysis pages
     llm_binding: dict[str, Any] | None = None  # host-owned model binding for this ACP session
@@ -1779,6 +1784,7 @@ class BoxACPAgent:
                 log.info("session/memory", session_id=session_id, message="Memory context injected")
 
         preloaded_skill_hashes: dict[str, str] = {}
+        skill_scratch_dir = None
         if utility:
             # Pure text transform: no base tools, no workspace/sandbox tools.
             tools: list = []
@@ -1815,7 +1821,7 @@ class BoxACPAgent:
                     message=message,
                 )
             # Enable sandbox mode and restrict to workspace for ACP sessions
-            add_workspace_tools(
+            skill_scratch_dir = add_workspace_tools(
                 tools,
                 self._config,
                 workspace,
@@ -1910,6 +1916,7 @@ class BoxACPAgent:
             summary_llm=summary_llm,
             trace_writer=trace_writer,
             output_dir=output_dir, session_mode=session_mode,
+            skill_scratch_dir=skill_scratch_dir,
             llm_binding=llm_binding,
             artifact_mode=artifact_mode,
             permission_engine=perm_engine, grant_store=grant_store,
@@ -3010,6 +3017,25 @@ class BoxACPAgent:
                 except Exception as cleanup_error:
                     log.error(
                         "write_file/session_cleanup_failed",
+                        session_id=session_id,
+                        turn_id=turn_id,
+                        error=str(cleanup_error),
+                    )
+            if state.skill_scratch_dir is not None:
+                try:
+                    removed_scratch_paths = cleanup_skill_scratch_dir(
+                        state.skill_scratch_dir
+                    )
+                    if removed_scratch_paths:
+                        log.info(
+                            "skill_scratch/session_cleanup",
+                            session_id=session_id,
+                            turn_id=turn_id,
+                            count=len(removed_scratch_paths),
+                        )
+                except Exception as cleanup_error:
+                    log.error(
+                        "skill_scratch/session_cleanup_failed",
                         session_id=session_id,
                         turn_id=turn_id,
                         error=str(cleanup_error),

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1349,7 +1349,7 @@ class BoxACPAgent:
                 asyncio.shield(self._skill_task),
                 timeout=_SKILL_DISCOVERY_WAIT_SECONDS,
             )
-        except TimeoutError:
+        except asyncio.TimeoutError:
             log.warn(
                 "skills/discovery_timeout",
                 message=(

--- a/box_agent/artifacts.py
+++ b/box_agent/artifacts.py
@@ -8,11 +8,16 @@ without importing ``box_agent.core``.
 from __future__ import annotations
 
 import hashlib
+import json
 import mimetypes
 import re
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Final
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
 
 from .events import ArtifactEvent
 
@@ -127,6 +132,182 @@ _EXT_MIME_OVERRIDES = {
     ".key": "application/vnd.apple.keynote",
 }
 _SAFE_NAME_RE = re.compile(r"[^a-z0-9._-]+")
+_HTML_ARTIFACT_METADATA_LIMIT = 16 * 1024 * 1024
+_ROADMAP_LAYOUT_ID = "roadmap-swimlane-v1"
+_ROADMAP_GENERATOR = "Box Agent Roadmap Artifact v1"
+_ROADMAP_JSON_SCRIPT_IDS = frozenset(
+    {
+        "deck-document",
+        "roadmap-geometry",
+        "roadmap-diagnostics",
+        "roadmap-pending-questions",
+        "roadmap-palette",
+        "roadmap-editor-metadata",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _roadmap_spec_validator() -> Draft202012Validator:
+    references = Path(__file__).resolve().parent / "skills" / "roadmap" / "references"
+    draft_schema = json.loads(
+        (references / "roadmap-draft.schema.json").read_text(encoding="utf-8")
+    )
+    spec_schema = json.loads(
+        (references / "roadmap-spec.schema.json").read_text(encoding="utf-8")
+    )
+    registry = Registry().with_resource(
+        draft_schema["$id"], Resource.from_contents(draft_schema)
+    )
+    return Draft202012Validator(spec_schema, registry=registry)
+
+
+def _safe_inline_script(value: str) -> str:
+    return re.sub(r"</script", r"<\\/script", value, flags=re.IGNORECASE)
+
+
+def _runtime_module(source: str, name: str, require_body: str) -> str:
+    return "\n".join(
+        (
+            f"(function(){{const module={{exports:{{}}}};const exports=module.exports;{require_body}",
+            _safe_inline_script(source),
+            f";window.{name}=module.exports;}})();",
+        )
+    )
+
+
+@lru_cache(maxsize=1)
+def _trusted_roadmap_runtime_surface() -> tuple[dict[str, str], str]:
+    skill_root = Path(__file__).resolve().parent / "skills" / "roadmap"
+    scripts = skill_root / "scripts"
+    contract_source = (scripts / "roadmap_contract_core.js").read_text(encoding="utf-8")
+    geometry_source = (scripts / "roadmap_geometry_core.js").read_text(encoding="utf-8")
+    editor_source = (skill_root / "runtime" / "roadmap-editor.js").read_text(
+        encoding="utf-8"
+    )
+    contract_require = (
+        'const require=(request)=>{if(request==="crypto")return '
+        '{createHash:()=>{throw new Error("crypto hashing is unavailable in the Roadmap '
+        'editor runtime")}};throw new Error(`Unsupported runtime module: ${request}`);};'
+    )
+    geometry_require = (
+        'const require=(request)=>{if(request==="./roadmap_contract_core.js")return '
+        'window.__roadmapContractCore;throw new Error(`Unsupported runtime module: '
+        '${request}`);};'
+    )
+    return (
+        {
+            "contract-core": _runtime_module(
+                contract_source, "__roadmapContractCore", contract_require
+            ),
+            "geometry-core": _runtime_module(
+                geometry_source, "__roadmapGeometryCore", geometry_require
+            ),
+            "editor": _safe_inline_script(editor_source).strip(),
+        },
+        (skill_root / "runtime" / "roadmap.css").read_text(encoding="utf-8"),
+    )
+
+
+def _has_trusted_roadmap_runtime_surface(content: str) -> bool:
+    markup = re.sub(
+        r"<(?:script|style)\b[^>]*>[\s\S]*?</(?:script|style)\s*>",
+        "",
+        content,
+        flags=re.IGNORECASE,
+    )
+    if re.search(r"\son[a-z0-9_-]+\s*=", markup, re.IGNORECASE):
+        return False
+    if re.search(
+        r"<(?:a|form|iframe|object|embed|base|link|img|video|audio|svg|math)\b",
+        markup,
+        re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"\s(?:href|src|srcset|action|formaction)\s*=", markup, re.IGNORECASE
+    ):
+        return False
+    if re.search(r"<meta\b[^>]*\bhttp-equiv\s*=", markup, re.IGNORECASE):
+        return False
+
+    expected_scripts, expected_css = _trusted_roadmap_runtime_surface()
+    actual_scripts: dict[str, str] = {}
+    json_script_ids: set[str] = set()
+    for match in re.finditer(
+        r"<script\b([^>]*)>([\s\S]*?)</script\s*>", content, re.IGNORECASE
+    ):
+        attrs, source = match.groups()
+
+        def attr(name: str) -> str:
+            value = re.search(
+                rf"\b{re.escape(name)}\s*=\s*([\"'])(.*?)\1",
+                attrs,
+                re.IGNORECASE,
+            )
+            return value.group(2) if value else ""
+
+        if attr("src"):
+            return False
+        if attr("type").lower() == "application/json":
+            script_id = attr("id")
+            if script_id not in _ROADMAP_JSON_SCRIPT_IDS or script_id in json_script_ids:
+                return False
+            json_script_ids.add(script_id)
+            continue
+        runtime_id = attr("data-roadmap-runtime")
+        if runtime_id not in expected_scripts or runtime_id in actual_scripts:
+            return False
+        actual_scripts[runtime_id] = source.strip()
+
+    if json_script_ids != _ROADMAP_JSON_SCRIPT_IDS or actual_scripts != expected_scripts:
+        return False
+    styles = re.findall(r"<style\b[^>]*>([\s\S]*?)</style\s*>", content, re.IGNORECASE)
+    return len(styles) == 1 and styles[0].strip() == expected_css.strip()
+
+
+def _html_artifact_layout_id(abs_file: Path, size: int) -> str:
+    if abs_file.suffix.lower() not in {".html", ".htm"}:
+        return ""
+    if size < 0 or size > _HTML_ARTIFACT_METADATA_LIMIT:
+        return ""
+    try:
+        content = abs_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+    def meta(name: str) -> str:
+        pattern = re.compile(
+            rf"<meta\b(?=[^>]*\bname=[\"']{re.escape(name)}[\"'])(?=[^>]*\bcontent=[\"']([^\"']*)[\"'])[^>]*>",
+            re.IGNORECASE,
+        )
+        match = pattern.search(content)
+        return match.group(1).strip() if match else ""
+
+    layout_id = meta("box-agent-artifact-layout-id")
+    if layout_id != _ROADMAP_LAYOUT_ID or len(layout_id) > 128:
+        return ""
+    if meta("generator") != _ROADMAP_GENERATOR:
+        return ""
+    try:
+        if not _has_trusted_roadmap_runtime_surface(content):
+            return ""
+    except (OSError, UnicodeError):
+        return ""
+    sources = re.findall(
+        r"<script\b(?=[^>]*\bid=[\"']deck-document[\"'])"
+        r"(?=[^>]*\btype=[\"']application/json[\"'])[^>]*>"
+        r"([\s\S]*?)</script\s*>",
+        content,
+        re.IGNORECASE,
+    )
+    if len(sources) != 1:
+        return ""
+    try:
+        _roadmap_spec_validator().validate(json.loads(sources[0]))
+    except Exception:
+        return ""
+    return layout_id
 
 
 def _classify_kind(filename: str, mime: str | None) -> str:
@@ -214,6 +395,8 @@ def make_artifact(
     except OSError:
         pass
 
+    layout_id = _html_artifact_layout_id(abs_resolved, size)
+
     return ArtifactEvent(
         tool_call_id=tool_call_id,
         kind=_classify_kind(abs_resolved.name, mime),
@@ -225,4 +408,5 @@ def make_artifact(
         size=size,
         sha256=digest,
         produced_at=datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        layout_id=layout_id,
     )

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -76,6 +76,7 @@ from box_agent.tools.runtime import (
     resolve_cli_shell_python,
 )
 from box_agent.tools.skill_execution_env import build_skill_execution_env
+from box_agent.tools.skill_scratch import cleanup_skill_scratch_dir
 from box_agent.utils import calculate_display_width
 from box_agent.acp.project_context import build_project_startup_context_prompt
 from box_agent.workspace_registry import WorkspaceRegistry, WorkspaceRegistryError
@@ -2075,7 +2076,7 @@ async def run_agent(
         shell_python_path=resolve_cli_shell_python(),
     )
 
-    add_workspace_tools(
+    skill_scratch_dir = add_workspace_tools(
         tools, config, workspace_dir,
         sandbox_mode=sandbox_mode,
         allow_full_access=allow_full_access,
@@ -2443,6 +2444,15 @@ async def run_agent(
                     f"{auto_no_progress_turns} continuation(s) without recorded goal progress.{Colors.RESET}"
                 )
             _save_goal_state(workspace_dir, agent.goal)
+            if skill_scratch_dir is not None:
+                try:
+                    cleanup_skill_scratch_dir(skill_scratch_dir)
+                except Exception as cleanup_error:
+                    print(
+                        f"{Colors.YELLOW}⚠️  Failed to clean Skill scratch: "
+                        f"{cleanup_error}{Colors.RESET}",
+                        file=sys.stderr,
+                    )
             print_stats(agent, session_start)
             if json_summary:
                 paused = agent.last_stop_reason == StopReason.CHECKPOINT_PAUSED.value
@@ -2788,6 +2798,15 @@ async def run_agent(
                 esc_listener_stop.set()
                 esc_thread.join(timeout=0.2)
                 _save_goal_state(workspace_dir, agent.goal)
+                if skill_scratch_dir is not None:
+                    try:
+                        cleanup_skill_scratch_dir(skill_scratch_dir)
+                    except Exception as cleanup_error:
+                        print(
+                            f"{Colors.YELLOW}⚠️  Failed to clean Skill scratch: "
+                            f"{cleanup_error}{Colors.RESET}",
+                            file=sys.stderr,
+                        )
 
             # Visual separation
             print(f"\n{Colors.DIM}{'─' * 60}{Colors.RESET}\n")

--- a/box_agent/events.py
+++ b/box_agent/events.py
@@ -202,6 +202,7 @@ class ArtifactEvent:
         sha256: First 16 hex chars of the SHA-256 digest, used as a stable
             cache/dedup key. Empty if the file could not be hashed.
         produced_at: ISO 8601 timestamp of detection (with tz offset).
+        layout_id: Optional controlled artifact layout identifier.
     """
 
     tool_call_id: str
@@ -214,6 +215,7 @@ class ArtifactEvent:
     size: int = -1
     sha256: str = ""
     produced_at: str = ""
+    layout_id: str = ""
 
 
 # ── Summarization ───────────────────────────────────────────────

--- a/box_agent/runtime_capabilities.py
+++ b/box_agent/runtime_capabilities.py
@@ -1,0 +1,151 @@
+"""Versioned capabilities exposed by the Box-Agent runtime.
+
+Keep this manifest conservative: a capability is advertised only after its
+runtime implementation is present. Host applications can use the versioned
+values to negotiate data contracts without inferring support from source files.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+_RUNTIME_CAPABILITIES_PATH = (
+    Path(__file__).resolve().parent
+    / "skills"
+    / "roadmap"
+    / "references"
+    / "runtime-capabilities-v1.json"
+)
+_ROADMAP_SKILL_ROOT = _RUNTIME_CAPABILITIES_PATH.parents[1]
+_BUILTIN_SKILLS_MANIFEST_PATH = _ROADMAP_SKILL_ROOT.parent / "_manifest.json"
+_RUNTIME_CAPABILITIES_SCHEMA_PATH = (
+    _ROADMAP_SKILL_ROOT / "references" / "runtime-capabilities-v1.schema.json"
+)
+_REQUIRED_ROADMAP_RESOURCES = (
+    "SKILL.md",
+    "scripts/build_roadmap_artifact.js",
+    "scripts/extract_roadmap_spec.js",
+    "scripts/migrate_roadmap_spec.js",
+    "scripts/roadmap_contract_core.js",
+    "scripts/roadmap_geometry_core.js",
+    "scripts/roadmap_html_core.js",
+    "scripts/roadmap_io.js",
+    "runtime/registry.json",
+    "runtime/roadmap.css",
+    "runtime/roadmap-editor.js",
+    "references/roadmap-draft.schema.json",
+    "references/roadmap-spec.schema.json",
+)
+
+
+def _disabled_capabilities() -> dict[str, Any]:
+    return {
+        "contract": "box-agent.runtime-capabilities",
+        "contractVersion": 1,
+        "deckProtocolVersion": 1,
+        "roadmap": {
+            "schemaVersion": 1,
+            "geometryVersion": 1,
+            "rendererVersion": None,
+            "capabilities": [],
+        },
+    }
+
+
+def _node_runtime_available() -> bool:
+    try:
+        from box_agent.tools.runtime import build_skill_runtime_context
+
+        return build_skill_runtime_context(sandbox_mode=False).get("node").available
+    except Exception:
+        return False
+
+
+def _roadmap_resources_available(skill_root: Path) -> bool:
+    return all((skill_root / relative).is_file() for relative in _REQUIRED_ROADMAP_RESOURCES)
+
+
+def _roadmap_builtin_manifest_available(
+    skill_root: Path,
+    manifest_path: Path,
+) -> bool:
+    """Return whether the authoritative builtin manifest enables Roadmap."""
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
+    entries = payload.get("skills") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        return False
+    expected_path = f"{skill_root.name}/SKILL.md"
+    return any(
+        isinstance(entry, dict)
+        and entry.get("name") == "roadmap"
+        and entry.get("path") == expected_path
+        for entry in entries
+    )
+
+
+@lru_cache(maxsize=1)
+def _capability_validator() -> Draft202012Validator:
+    schema = json.loads(_RUNTIME_CAPABILITIES_SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def runtime_capabilities(
+    *,
+    skills_enabled: bool = True,
+    node_available: bool | None = None,
+    roadmap_skill_available: bool | None = None,
+    capabilities_path: Path | None = None,
+    skill_root: Path | None = None,
+    builtin_manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return capabilities that are usable in this runtime, failing closed."""
+
+    manifest_path = capabilities_path or _RUNTIME_CAPABILITIES_PATH
+    root = skill_root or _ROADMAP_SKILL_ROOT
+    skills_manifest_path = builtin_manifest_path or (
+        _BUILTIN_SKILLS_MANIFEST_PATH
+        if skill_root is None
+        else root.parent / "_manifest.json"
+    )
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        _capability_validator().validate(payload)
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        SchemaError,
+        ValidationError,
+    ):
+        return _disabled_capabilities()
+
+    runtime_has_roadmap_skill = (
+        _roadmap_builtin_manifest_available(root, skills_manifest_path)
+        if roadmap_skill_available is None
+        else roadmap_skill_available
+    )
+    if (
+        not skills_enabled
+        or not runtime_has_roadmap_skill
+        or not _roadmap_resources_available(root)
+    ):
+        return _disabled_capabilities()
+    runtime_has_node = _node_runtime_available() if node_available is None else node_available
+    if not runtime_has_node:
+        return _disabled_capabilities()
+    return payload
+
+
+__all__ = ["runtime_capabilities"]

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.8.87",
-  "generated_at": "2026-08-21T07:59:09Z",
+  "generated_at": "2026-08-21T07:59:41Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.8.87",
-  "generated_at": "2026-08-20T14:09:02Z",
+  "generated_at": "2026-08-21T07:59:09Z",
   "skills": [
     {
       "name": "artifacts-builder",
@@ -70,6 +70,10 @@
     {
       "name": "research-to-deck-outline",
       "path": "research-to-deck-outline/SKILL.md"
+    },
+    {
+      "name": "roadmap",
+      "path": "roadmap/SKILL.md"
     },
     {
       "name": "scheduled-task",

--- a/box_agent/skills/roadmap/SKILL.md
+++ b/box_agent/skills/roadmap/SKILL.md
@@ -50,18 +50,19 @@ successful build consumes the temporary Draft and leaves only a versioned HTML
 deliverable in `output/`:
 
 Treat `output/` as a deliverables-only boundary. Never create generator scripts,
-temporary JSON, logs, or other support files there. Prefer writing the temporary
-Draft directly. If programmatic Draft construction is necessary, create the
-helper and Draft in a task-scoped scratch directory outside `output/`, pass the
-Draft to the builder with `--consume-input`, and remove the scratch directory
-after either success or failure. `--consume-input` removes only the supplied
-Draft; it does not clean up helper scripts. Before completing the task, verify
-that every file created by this Roadmap run under `output/` is a versioned HTML
-deliverable.
+temporary JSON, logs, or other support files there. Create a unique task
+directory below `$BOX_AGENT_SCRATCH_DIR` and place the temporary Draft and any
+helper there. Pass that Draft to the builder with `--consume-input`. The builder
+removes the task scratch directory after either success or failure, and the
+session runtime clears any residue at the end of the turn. Never place one
+task's files directly in the scratch root or reuse another task's directory.
+Before completing the task, verify that every file created by this Roadmap run
+under `output/` is a versioned HTML deliverable.
 
 ```bash
 ROADMAP_SKILL_DIR="${BOX_AGENT_ROADMAP_SKILL_DIR:-{skill_dir}}"
-${BOX_AGENT_NODE:-node} "$ROADMAP_SKILL_DIR/scripts/build_roadmap_artifact.js" roadmap-draft.json --out roadmap.html --consume-input
+ROADMAP_DRAFT="$BOX_AGENT_SCRATCH_DIR/<task-id>/roadmap-draft.json"
+${BOX_AGENT_NODE:-node} "$ROADMAP_SKILL_DIR/scripts/build_roadmap_artifact.js" "$ROADMAP_DRAFT" --out roadmap.html --consume-input
 ```
 
 Always inspect the builder report. If `pending_questions` is non-empty, the

--- a/box_agent/skills/roadmap/SKILL.md
+++ b/box_agent/skills/roadmap/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: roadmap
+description: Create structured project roadmaps and schedule swimlanes from ordinary conversation, tables, images, or an existing RoadmapSpec. Use for multi-lane project schedules with roadmap, planning, swimlane, month-scale, or milestone semantics.
+keywords: [roadmap, project roadmap, schedule roadmap, swimlane, roadmap artifact, 路线图, 项目路线图, 排期, 泳道, 月份刻度, 月度刻度, 半月刻度]
+capabilities: [roadmap.contract, roadmap.generate.html, roadmap.preview, roadmap.edit]
+---
+
+# Roadmap Skill
+
+Use this skill for a project schedule whose meaning depends on lanes and dates.
+The Roadmap contract is the source of truth, and controlled HTML is the only
+normal delivery format in the current scope.
+
+## Route decision
+
+Use the Roadmap pipeline when the request combines at least two relevant
+signals and includes either a lane/calendar signal or a roadmap plus
+schedule/Gantt pair. Relevant signals include roadmap, schedule, swimlane,
+month or half-month scale, milestone, and Gantt.
+
+Do not route a plain process, step list, horizontal timeline, or ordinary
+single Gantt table to Roadmap. Those keep their existing workflow unless the
+user also asks for multi-lane or calendar-scale roadmap geometry.
+
+The route does not depend on presentation or document workflows. A request for
+a presentation alone must not select this skill.
+
+## Contract and HTML Artifact workflow
+
+1. Preserve extracted input as `RoadmapDraft v1`. Every lane and item retains
+   its raw value, typed source (`natural-language`, `table`, `image`, or
+   `roadmap-spec`), provenance coordinates where applicable, and confidence.
+2. Compile Draft to `RoadmapSpec v1`. Missing dates are never invented; report
+   a pending question. A present date below confidence `0.8` remains usable but
+   becomes `certainty: tentative` and requires confirmation.
+3. Persist timezone-free `YYYY-MM-DD` dates and half-open `[start, end)` bars.
+   Milestones use `start` only. `certainty` and `progress` remain independent.
+4. Migrate persisted specs through the explicit version boundary. Version 1
+   is lossless; missing or unknown versions are rejected.
+5. Generate renderer-neutral geometry. The HTML renderer consumes this IR
+   instead of recalculating dates, tracks, collisions, labels, or continuation
+   markers.
+6. Render ordinary conversation requests to the controlled HTML Artifact
+   `roadmap-swimlane-v1` without loading another document skill.
+
+Resolve `{skill_dir}` to this skill's installed directory. For ordinary
+generation, create one temporary Draft input and run the unified builder. It
+compiles, migrates, lays out, renders, and self-checks in one process. A
+successful build consumes the temporary Draft and leaves only a versioned HTML
+deliverable in `output/`:
+
+Treat `output/` as a deliverables-only boundary. Never create generator scripts,
+temporary JSON, logs, or other support files there. Prefer writing the temporary
+Draft directly. If programmatic Draft construction is necessary, create the
+helper and Draft in a task-scoped scratch directory outside `output/`, pass the
+Draft to the builder with `--consume-input`, and remove the scratch directory
+after either success or failure. `--consume-input` removes only the supplied
+Draft; it does not clean up helper scripts. Before completing the task, verify
+that every file created by this Roadmap run under `output/` is a versioned HTML
+deliverable.
+
+```bash
+ROADMAP_SKILL_DIR="${BOX_AGENT_ROADMAP_SKILL_DIR:-{skill_dir}}"
+${BOX_AGENT_NODE:-node} "$ROADMAP_SKILL_DIR/scripts/build_roadmap_artifact.js" roadmap-draft.json --out roadmap.html --consume-input
+```
+
+Always inspect the builder report. If `pending_questions` is non-empty, the
+generated HTML is a preview rather than a confirmed final deliverable. Ask the
+listed questions, update the source dates and set the affected items to
+`certainty: confirmed` from the user's answer, and rebuild before presenting
+the Roadmap as final. Pending questions are persisted inside controlled HTML
+and remain active across follow-up versions until the corresponding tentative
+items are confirmed.
+
+The builder never overwrites HTML. A fresh `roadmap.html` request produces
+`roadmap-v1.html`; later generations produce `roadmap-v2.html`,
+`roadmap-v3.html`, and so on. A legacy unversioned `roadmap.html` counts as v1,
+so the next build starts at `roadmap-v2.html`. Never delete, rename, or overwrite
+an earlier Roadmap HTML to reuse its version number; do not run `rm`, `unlink`,
+or equivalent cleanup commands during normal generation. Do not create adjacent Draft,
+Spec, Geometry, extraction, or QA JSON files during normal delivery. Use
+`--debug-dir DIR` only when the user explicitly requests debugging evidence.
+
+For a generated follow-up version, pass the current HTML directly to the same
+builder. It reads the embedded source and emits the next HTML version without
+overwriting the input. Never prefer an older adjacent JSON file:
+
+```bash
+${BOX_AGENT_NODE:-node} "$ROADMAP_SKILL_DIR/scripts/build_roadmap_artifact.js" roadmap-v1.html --out roadmap.html
+```
+
+The renderer writes a standard `.html` deliverable under
+`$BOX_AGENT_OUTPUT_DIR`, with `mime_type=text/html`,
+`layout_id=roadmap-swimlane-v1`, embedded source in `#deck-document`, and
+structured diagnostics. Mention the resulting HTML filename so the shared
+artifact detector can publish it. The host renders the standard artifact event
+as the single clickable workspace file card, so do not add a Markdown
+`workspace-file` or `local-file` link for the same HTML in the final response.
+Do not mention a versioned filename that was not returned by a successful
+builder invocation.
+When `$BOX_AGENT_OUTPUT_DIR` is configured, normal Roadmap outputs are confined
+to that directory; absolute paths and `..` traversal outside it are rejected.
+
+The form/table editor changes RoadmapSpec fields and then invokes the same
+contract validator and geometry core. It never edits pixel positions directly.
+The embedded `#deck-document` is the persisted source of truth after save.
+
+Schemas:
+
+- `references/roadmap-draft.schema.json`
+- `references/roadmap-spec.schema.json`
+
+Examples:
+
+- `examples/draft-natural-language.json`
+- `examples/draft-table.json`
+- `examples/draft-image.json`
+- `examples/roadmap-spec-v1.json`
+- `examples/roadmap-geometry-1440x900.json`
+- `examples/capacity-cases.json`
+
+Runtime resources:
+
+- `runtime/registry.json`
+- `runtime/roadmap.css`
+- `runtime/roadmap-editor.js`
+
+## Capability boundary
+
+Schema, geometry, renderer, preview, and form/table editing are version 1.
+Do not claim Roadmap HTML generation, preview, or editing until the corresponding
+`roadmap.generate.html`, `roadmap.preview`, or `roadmap.edit` capability is
+present. Missing capabilities are disabled, not inferred from bundled files.
+The ACP runtime advertises these capabilities only when Skills are enabled, the
+Roadmap resources are complete, and a managed Node runtime is available.
+
+The recommended limit is 6 months, 8 lanes, and 80 items. Structural contract
+violations block rendering. Dense but valid content stays available with
+structured visual-degradation diagnostics and a deterministic scroll layout.
+
+The frozen runtime payload and schema are:
+
+- `references/runtime-capabilities-v1.json`
+- `references/runtime-capabilities-v1.schema.json`

--- a/box_agent/skills/roadmap/examples/capacity-cases.json
+++ b/box_agent/skills/roadmap/examples/capacity-cases.json
@@ -1,0 +1,12 @@
+{
+  "recommended": {
+    "months": 6,
+    "lanes": 8,
+    "items": 80
+  },
+  "cases": [
+    { "items": 30, "expected": "visual-degradation-warning" },
+    { "items": 80, "expected": "at-limit-warning" },
+    { "items": 81, "expected": "contract-error" }
+  ]
+}

--- a/box_agent/skills/roadmap/examples/draft-image.json
+++ b/box_agent/skills/roadmap/examples/draft-image.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "kind": "roadmap-draft",
+  "title": "截图路线图识别结果",
+  "range": {
+    "start": "2026-08-01",
+    "end": "2026-11-01",
+    "granularity": "half-month"
+  },
+  "lanes": [
+    {
+      "id": "desktop",
+      "label": "Desktop",
+      "order": 1,
+      "raw": {
+        "ocr": "Desktop"
+      },
+      "source": {
+        "type": "image",
+        "confidence": 0.94,
+        "page": 1,
+        "region": [42, 120, 168, 72]
+      }
+    }
+  ],
+  "items": [
+    {
+      "id": "preview-integration",
+      "lane_ref": "desktop",
+      "title": "预览集成",
+      "start": "2026-09-01",
+      "end": "2026-10-01",
+      "kind": "bar",
+      "certainty": "confirmed",
+      "progress": "planned",
+      "raw": {
+        "ocr": "预览集成 9.1-10.1"
+      },
+      "source": {
+        "type": "image",
+        "confidence": 0.72,
+        "field_confidence": {
+          "start": 0.72,
+          "end": 0.7
+        },
+        "page": 1,
+        "region": [238, 120, 386, 72]
+      }
+    }
+  ],
+  "pending_questions": []
+}

--- a/box_agent/skills/roadmap/examples/draft-natural-language.json
+++ b/box_agent/skills/roadmap/examples/draft-natural-language.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "kind": "roadmap-draft",
+  "title": "Agent Box 8—10 月实施路线图",
+  "range": {
+    "start": "2026-08-01",
+    "end": "2026-11-01",
+    "granularity": "half-month"
+  },
+  "lanes": [
+    {
+      "id": "runtime",
+      "label": "Agent Box Runtime",
+      "order": 1,
+      "raw": {
+        "text": "Agent Box Runtime：先固化数据契约，再接入渲染器"
+      },
+      "source": {
+        "type": "natural-language",
+        "confidence": 1,
+        "excerpt": "Agent Box Runtime：先固化数据契约，再接入渲染器"
+      }
+    },
+    {
+      "id": "client",
+      "label": "Office v3 Client",
+      "order": 2,
+      "raw": {
+        "text": "Office v3 Client：四季度接入预览"
+      },
+      "source": {
+        "type": "natural-language",
+        "confidence": 1,
+        "excerpt": "Office v3 Client：四季度接入预览"
+      }
+    }
+  ],
+  "items": [
+    {
+      "id": "runtime-contract",
+      "lane_ref": "runtime",
+      "title": "Roadmap 数据契约",
+      "start": "2026-08-01",
+      "end": "2026-09-01",
+      "kind": "bar",
+      "certainty": "confirmed",
+      "progress": "doing",
+      "raw": {
+        "text": "8 月完成 Roadmap 数据契约"
+      },
+      "source": {
+        "type": "natural-language",
+        "confidence": 1,
+        "excerpt": "8 月完成 Roadmap 数据契约"
+      }
+    },
+    {
+      "id": "geometry-ready",
+      "lane_ref": "runtime",
+      "title": "几何层冻结",
+      "start": "2026-09-16",
+      "kind": "milestone",
+      "certainty": "confirmed",
+      "progress": "planned",
+      "raw": {
+        "text": "9 月下半月冻结几何层"
+      },
+      "source": {
+        "type": "natural-language",
+        "confidence": 0.95,
+        "excerpt": "9 月下半月冻结几何层"
+      }
+    },
+    {
+      "id": "client-preview",
+      "lane_ref": "client",
+      "title": "客户端预览接入",
+      "start": "2026-10-01",
+      "end": "2026-11-01",
+      "kind": "bar",
+      "certainty": "confirmed",
+      "progress": "planned",
+      "raw": {
+        "text": "10 月完成客户端预览接入"
+      },
+      "source": {
+        "type": "natural-language",
+        "confidence": 1,
+        "excerpt": "10 月完成客户端预览接入"
+      }
+    }
+  ],
+  "pending_questions": []
+}

--- a/box_agent/skills/roadmap/examples/draft-table.json
+++ b/box_agent/skills/roadmap/examples/draft-table.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "kind": "roadmap-draft",
+  "title": "产品交付计划",
+  "range": {
+    "start": "2026-08-01",
+    "end": "2026-11-01",
+    "granularity": "half-month"
+  },
+  "lanes": [
+    {
+      "label": "Agent Box",
+      "order": 1,
+      "raw": {
+        "row": ["Agent Box", "数据契约", "2026-08-01", "2026-09-01"]
+      },
+      "source": {
+        "type": "table",
+        "confidence": 0.98,
+        "row": 2,
+        "column": "A"
+      }
+    },
+    {
+      "label": "Office v3",
+      "order": 2,
+      "raw": {
+        "row": ["Office v3", "预览集成", "2026-09-01", "2026-10-16"]
+      },
+      "source": {
+        "type": "table",
+        "confidence": 0.98,
+        "row": 3,
+        "column": "A"
+      }
+    }
+  ],
+  "items": [
+    {
+      "lane_ref": "Agent Box",
+      "title": "数据契约",
+      "start": "2026-08-01",
+      "end": "2026-09-01",
+      "kind": "bar",
+      "progress": "doing",
+      "raw": {
+        "row": ["Agent Box", "数据契约", "2026-08-01", "2026-09-01"]
+      },
+      "source": {
+        "type": "table",
+        "confidence": 0.98,
+        "field_confidence": {
+          "start": 0.99,
+          "end": 0.99
+        },
+        "row": 2,
+        "column": "B:E"
+      }
+    },
+    {
+      "lane_ref": "Office v3",
+      "title": "预览集成",
+      "start": "2026-09-01",
+      "end": "2026-10-16",
+      "kind": "bar",
+      "progress": "planned",
+      "raw": {
+        "row": ["Office v3", "预览集成", "2026-09-01", "2026-10-16"]
+      },
+      "source": {
+        "type": "table",
+        "confidence": 0.98,
+        "field_confidence": {
+          "start": 0.96,
+          "end": 0.96
+        },
+        "row": 3,
+        "column": "B:E"
+      }
+    }
+  ],
+  "pending_questions": []
+}

--- a/box_agent/skills/roadmap/examples/roadmap-geometry-1440x900.json
+++ b/box_agent/skills/roadmap/examples/roadmap-geometry-1440x900.json
@@ -1,0 +1,410 @@
+{
+  "schema_version": 1,
+  "kind": "roadmap-geometry",
+  "source_schema_version": 1,
+  "canvas": {
+    "width": 1440,
+    "height": 784,
+    "plot_left": 292,
+    "plot_right": 1408,
+    "header_top": 60,
+    "header_height": 76
+  },
+  "headers": [
+    {
+      "id": "month-1",
+      "kind": "month",
+      "label": "2026-08",
+      "start": "2026-08-01",
+      "end": "2026-09-01",
+      "x": 292,
+      "y": 60,
+      "width": 376.043,
+      "height": 38
+    },
+    {
+      "id": "month-2",
+      "kind": "month",
+      "label": "2026-09",
+      "start": "2026-09-01",
+      "end": "2026-10-01",
+      "x": 668.043,
+      "y": 60,
+      "width": 363.914,
+      "height": 38
+    },
+    {
+      "id": "month-3",
+      "kind": "month",
+      "label": "2026-10",
+      "start": "2026-10-01",
+      "end": "2026-11-01",
+      "x": 1031.957,
+      "y": 60,
+      "width": 376.043,
+      "height": 38
+    },
+    {
+      "id": "half-month-1",
+      "kind": "half-month",
+      "label": "上半月",
+      "start": "2026-08-01",
+      "end": "2026-08-16",
+      "x": 292,
+      "y": 98,
+      "width": 181.957,
+      "height": 38
+    },
+    {
+      "id": "half-month-2",
+      "kind": "half-month",
+      "label": "下半月",
+      "start": "2026-08-16",
+      "end": "2026-09-01",
+      "x": 473.957,
+      "y": 98,
+      "width": 194.086,
+      "height": 38
+    },
+    {
+      "id": "half-month-3",
+      "kind": "half-month",
+      "label": "上半月",
+      "start": "2026-09-01",
+      "end": "2026-09-16",
+      "x": 668.043,
+      "y": 98,
+      "width": 181.957,
+      "height": 38
+    },
+    {
+      "id": "half-month-4",
+      "kind": "half-month",
+      "label": "下半月",
+      "start": "2026-09-16",
+      "end": "2026-10-01",
+      "x": 850,
+      "y": 98,
+      "width": 181.957,
+      "height": 38
+    },
+    {
+      "id": "half-month-5",
+      "kind": "half-month",
+      "label": "上半月",
+      "start": "2026-10-01",
+      "end": "2026-10-16",
+      "x": 1031.957,
+      "y": 98,
+      "width": 181.956,
+      "height": 38
+    },
+    {
+      "id": "half-month-6",
+      "kind": "half-month",
+      "label": "下半月",
+      "start": "2026-10-16",
+      "end": "2026-11-01",
+      "x": 1213.913,
+      "y": 98,
+      "width": 194.087,
+      "height": 38
+    }
+  ],
+  "lanes": [
+    {
+      "id": "agent-box",
+      "label": "Agent Box",
+      "order": 1,
+      "x": 32,
+      "y": 136,
+      "width": 1376,
+      "height": 154,
+      "track_count": 2
+    },
+    {
+      "id": "office-v3",
+      "label": "Office v3",
+      "order": 2,
+      "x": 32,
+      "y": 290,
+      "width": 1376,
+      "height": 154,
+      "track_count": 2
+    },
+    {
+      "id": "qa",
+      "label": "QA",
+      "order": 3,
+      "x": 32,
+      "y": 444,
+      "width": 1376,
+      "height": 154,
+      "track_count": 2
+    },
+    {
+      "id": "release",
+      "label": "Release",
+      "order": 4,
+      "x": 32,
+      "y": 598,
+      "width": 1376,
+      "height": 154,
+      "track_count": 2
+    }
+  ],
+  "bars": [
+    {
+      "id": "contract-core",
+      "lane_id": "agent-box",
+      "title": "数据契约与编译器",
+      "start": "2026-08-01",
+      "end": "2026-09-01",
+      "track": 0,
+      "x": 292,
+      "y": 156,
+      "width": 376.043,
+      "height": 46,
+      "certainty": "confirmed",
+      "progress": "doing",
+      "line_style": "solid"
+    },
+    {
+      "id": "geometry-core",
+      "lane_id": "agent-box",
+      "title": "纯几何层",
+      "start": "2026-08-16",
+      "end": "2026-09-16",
+      "track": 1,
+      "x": 473.957,
+      "y": 220,
+      "width": 376.043,
+      "height": 46,
+      "certainty": "confirmed",
+      "progress": "planned",
+      "line_style": "solid"
+    },
+    {
+      "id": "client-preview",
+      "lane_id": "office-v3",
+      "title": "预览接入",
+      "start": "2026-09-01",
+      "end": "2026-10-16",
+      "track": 0,
+      "x": 668.043,
+      "y": 310,
+      "width": 545.87,
+      "height": 46,
+      "certainty": "tentative",
+      "progress": "planned",
+      "line_style": "dashed"
+    },
+    {
+      "id": "client-edit",
+      "lane_id": "office-v3",
+      "title": "编辑交互预研",
+      "start": "2026-09-16",
+      "end": "2026-10-01",
+      "track": 1,
+      "x": 850,
+      "y": 374,
+      "width": 181.957,
+      "height": 46,
+      "certainty": "tentative",
+      "progress": "planned",
+      "line_style": "dashed"
+    },
+    {
+      "id": "qa-window",
+      "lane_id": "qa",
+      "title": "跨月合同与边界日期验证",
+      "start": "2026-09-15",
+      "end": "2026-09-20",
+      "track": 0,
+      "x": 837.87,
+      "y": 464,
+      "width": 60.652,
+      "height": 46,
+      "certainty": "confirmed",
+      "progress": "doing",
+      "line_style": "solid"
+    },
+    {
+      "id": "release-candidate",
+      "lane_id": "release",
+      "title": "候选版验证与发布",
+      "start": "2026-10-01",
+      "end": "2026-11-01",
+      "track": 0,
+      "x": 1031.957,
+      "y": 618,
+      "width": 376.043,
+      "height": 46,
+      "certainty": "tentative",
+      "progress": "planned",
+      "line_style": "dashed"
+    }
+  ],
+  "milestones": [
+    {
+      "id": "contract-frozen",
+      "lane_id": "agent-box",
+      "title": "P0 契约冻结",
+      "date": "2026-09-16",
+      "track": 0,
+      "x": 850,
+      "y": 179,
+      "size": 18,
+      "certainty": "confirmed",
+      "progress": "planned",
+      "line_style": "solid"
+    },
+    {
+      "id": "qa-signoff",
+      "lane_id": "qa",
+      "title": "QA 签核",
+      "date": "2026-09-20",
+      "track": 1,
+      "x": 898.522,
+      "y": 551,
+      "size": 18,
+      "certainty": "confirmed",
+      "progress": "planned",
+      "line_style": "solid"
+    },
+    {
+      "id": "release-gate",
+      "lane_id": "release",
+      "title": "上线门禁",
+      "date": "2026-10-31",
+      "track": 1,
+      "x": 1395.87,
+      "y": 705,
+      "size": 18,
+      "certainty": "tentative",
+      "progress": "planned",
+      "line_style": "dashed"
+    }
+  ],
+  "labels": [
+    {
+      "id": "label-contract-core",
+      "item_id": "contract-core",
+      "lane_id": "agent-box",
+      "text": "数据契约与编译器",
+      "placement": "inside",
+      "x": 302,
+      "y": 156,
+      "width": 356.043,
+      "height": 46
+    },
+    {
+      "id": "label-geometry-core",
+      "item_id": "geometry-core",
+      "lane_id": "agent-box",
+      "text": "纯几何层",
+      "placement": "inside",
+      "x": 483.957,
+      "y": 220,
+      "width": 356.043,
+      "height": 46
+    },
+    {
+      "id": "label-contract-frozen",
+      "item_id": "contract-frozen",
+      "lane_id": "agent-box",
+      "text": "P0 契约冻结",
+      "placement": "outside-right",
+      "x": 869,
+      "y": 156,
+      "width": 84,
+      "height": 46
+    },
+    {
+      "id": "label-client-preview",
+      "item_id": "client-preview",
+      "lane_id": "office-v3",
+      "text": "预览接入",
+      "placement": "inside",
+      "x": 678.043,
+      "y": 310,
+      "width": 525.87,
+      "height": 46
+    },
+    {
+      "id": "label-client-edit",
+      "item_id": "client-edit",
+      "lane_id": "office-v3",
+      "text": "编辑交互预研",
+      "placement": "inside",
+      "x": 860,
+      "y": 374,
+      "width": 161.957,
+      "height": 46
+    },
+    {
+      "id": "label-qa-window",
+      "item_id": "qa-window",
+      "lane_id": "qa",
+      "text": "跨月合同与边界日期验证",
+      "placement": "outside-right",
+      "x": 908.522,
+      "y": 464,
+      "width": 165,
+      "height": 46
+    },
+    {
+      "id": "label-qa-signoff",
+      "item_id": "qa-signoff",
+      "lane_id": "qa",
+      "text": "QA 签核",
+      "placement": "outside-right",
+      "x": 917.522,
+      "y": 528,
+      "width": 72,
+      "height": 46
+    },
+    {
+      "id": "label-release-candidate",
+      "item_id": "release-candidate",
+      "lane_id": "release",
+      "text": "候选版验证与发布",
+      "placement": "inside",
+      "x": 1041.957,
+      "y": 618,
+      "width": 356.043,
+      "height": 46
+    },
+    {
+      "id": "label-release-gate",
+      "item_id": "release-gate",
+      "lane_id": "release",
+      "text": "上线门禁",
+      "placement": "outside-left",
+      "x": 1304.87,
+      "y": 682,
+      "width": 72,
+      "height": 46
+    }
+  ],
+  "continuations": [
+    {
+      "id": "continuation-contract-core-before",
+      "item_id": "contract-core",
+      "lane_id": "agent-box",
+      "direction": "before",
+      "x": 292,
+      "y": 179,
+      "size": 10
+    },
+    {
+      "id": "continuation-release-candidate-after",
+      "item_id": "release-candidate",
+      "lane_id": "release",
+      "direction": "after",
+      "x": 1408,
+      "y": 641,
+      "size": 10
+    }
+  ]
+}

--- a/box_agent/skills/roadmap/examples/roadmap-spec-v1.json
+++ b/box_agent/skills/roadmap/examples/roadmap-spec-v1.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": 1,
+  "kind": "roadmap-spec",
+  "title": "Agent Box / Office v3 集成路线图",
+  "range": {
+    "start": "2026-08-01",
+    "end": "2026-11-01",
+    "granularity": "half-month"
+  },
+  "lanes": [
+    {
+      "id": "agent-box",
+      "label": "Agent Box",
+      "order": 1
+    },
+    {
+      "id": "office-v3",
+      "label": "Office v3",
+      "order": 2
+    },
+    {
+      "id": "qa",
+      "label": "QA",
+      "order": 3
+    },
+    {
+      "id": "release",
+      "label": "Release",
+      "order": 4
+    }
+  ],
+  "items": [
+    {
+      "id": "contract-core",
+      "lane_id": "agent-box",
+      "title": "数据契约与编译器",
+      "start": "2026-08-01",
+      "end": "2026-09-01",
+      "kind": "bar",
+      "certainty": "confirmed",
+      "progress": "doing",
+      "continuation": {
+        "before": true
+      },
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 1,
+        "field_path": "items.contract-core"
+      }
+    },
+    {
+      "id": "geometry-core",
+      "lane_id": "agent-box",
+      "title": "纯几何层",
+      "start": "2026-08-16",
+      "end": "2026-09-16",
+      "kind": "bar",
+      "certainty": "confirmed",
+      "progress": "planned",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 1,
+        "field_path": "items.geometry-core"
+      }
+    },
+    {
+      "id": "contract-frozen",
+      "lane_id": "agent-box",
+      "title": "P0 契约冻结",
+      "start": "2026-09-16",
+      "kind": "milestone",
+      "certainty": "confirmed",
+      "progress": "planned",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 1,
+        "field_path": "items.contract-frozen"
+      }
+    },
+    {
+      "id": "client-preview",
+      "lane_id": "office-v3",
+      "title": "预览接入",
+      "start": "2026-09-01",
+      "end": "2026-10-16",
+      "kind": "bar",
+      "certainty": "tentative",
+      "progress": "planned",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 0.85,
+        "field_path": "items.client-preview"
+      }
+    },
+    {
+      "id": "client-edit",
+      "lane_id": "office-v3",
+      "title": "编辑交互预研",
+      "start": "2026-09-16",
+      "end": "2026-10-01",
+      "kind": "bar",
+      "certainty": "tentative",
+      "progress": "planned",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 0.8,
+        "field_path": "items.client-edit"
+      }
+    },
+    {
+      "id": "qa-window",
+      "lane_id": "qa",
+      "title": "跨月合同与边界日期验证",
+      "start": "2026-09-15",
+      "end": "2026-09-20",
+      "kind": "bar",
+      "certainty": "confirmed",
+      "progress": "doing",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 1,
+        "field_path": "items.qa-window"
+      }
+    },
+    {
+      "id": "qa-signoff",
+      "lane_id": "qa",
+      "title": "QA 签核",
+      "start": "2026-09-20",
+      "kind": "milestone",
+      "certainty": "confirmed",
+      "progress": "planned",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 1,
+        "field_path": "items.qa-signoff"
+      }
+    },
+    {
+      "id": "release-candidate",
+      "lane_id": "release",
+      "title": "候选版验证与发布",
+      "start": "2026-10-01",
+      "end": "2026-11-01",
+      "kind": "bar",
+      "certainty": "tentative",
+      "progress": "planned",
+      "continuation": {
+        "after": true
+      },
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 0.85,
+        "field_path": "items.release-candidate"
+      }
+    },
+    {
+      "id": "release-gate",
+      "lane_id": "release",
+      "title": "上线门禁",
+      "start": "2026-10-31",
+      "kind": "milestone",
+      "certainty": "tentative",
+      "progress": "planned",
+      "source": {
+        "type": "roadmap-spec",
+        "confidence": 0.85,
+        "field_path": "items.release-gate"
+      }
+    }
+  ],
+  "legend": [
+    {
+      "key": "confirmed",
+      "label": "已确认"
+    },
+    {
+      "key": "tentative",
+      "label": "待确认"
+    }
+  ]
+}

--- a/box_agent/skills/roadmap/references/roadmap-draft.schema.json
+++ b/box_agent/skills/roadmap/references/roadmap-draft.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://box-agent.local/schemas/roadmap-draft.schema.json",
+  "title": "Box-Agent RoadmapDraft v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "kind", "lanes", "items", "pending_questions"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "roadmap-draft" },
+    "title": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "range": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "start": { "$ref": "#/$defs/plainDate" },
+        "end": { "$ref": "#/$defs/plainDate" },
+        "granularity": { "const": "half-month" }
+      }
+    },
+    "lanes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "order", "raw", "source"],
+        "properties": {
+          "id": { "$ref": "#/$defs/stableId" },
+          "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+          "order": { "type": "integer", "minimum": 1 },
+          "raw": { "type": "object" },
+          "source": { "$ref": "#/$defs/source" }
+        }
+      }
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["lane_ref", "title", "kind", "progress", "raw", "source"],
+        "properties": {
+          "id": { "$ref": "#/$defs/stableId" },
+          "lane_ref": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1, "maxLength": 100 },
+          "start": { "$ref": "#/$defs/plainDate" },
+          "end": { "$ref": "#/$defs/plainDate" },
+          "kind": { "enum": ["bar", "milestone"] },
+          "certainty": { "enum": ["confirmed", "tentative"] },
+          "progress": { "enum": ["planned", "doing", "done", "blocked"] },
+          "continuation": { "$ref": "#/$defs/continuation" },
+          "color": { "type": "string", "maxLength": 40 },
+          "detail": { "type": "string", "maxLength": 500 },
+          "raw": { "type": "object" },
+          "source": { "$ref": "#/$defs/source" }
+        }
+      }
+    },
+    "pending_questions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["field_path", "prompt"],
+        "properties": {
+          "field_path": { "type": "string", "minLength": 1 },
+          "prompt": { "type": "string", "minLength": 1 },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "plainDate": {
+      "type": "string",
+      "anyOf": [
+        {
+          "pattern": "^(?:0[1-9][0-9]{2}|[1-9][0-9]{3})-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))$"
+        },
+        {
+          "pattern": "^(?:(?:0[1-9]|[1-9][0-9])(?:0[48]|[2468][048]|[13579][26])|(?:0[48]|[2468][048]|[13579][26])00)-02-29$"
+        }
+      ]
+    },
+    "stableId": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$" },
+    "continuation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "before": { "const": true },
+        "after": { "const": true }
+      },
+      "minProperties": 1
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "confidence"],
+      "properties": {
+        "type": { "enum": ["natural-language", "table", "image", "roadmap-spec"] },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "field_confidence": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "excerpt": { "type": "string", "maxLength": 500 },
+        "row": { "type": "integer", "minimum": 1 },
+        "column": { "type": "string", "minLength": 1 },
+        "region": {
+          "type": "array",
+          "prefixItems": [
+            { "type": "number", "minimum": 0 },
+            { "type": "number", "minimum": 0 },
+            { "type": "number", "exclusiveMinimum": 0 },
+            { "type": "number", "exclusiveMinimum": 0 }
+          ],
+          "items": false,
+          "minItems": 4,
+          "maxItems": 4
+        },
+        "page": { "type": "integer", "minimum": 1 },
+        "field_path": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "table" } }, "required": ["type"] },
+          "then": { "required": ["row"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "image" } }, "required": ["type"] },
+          "then": { "required": ["region"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "roadmap-spec" } }, "required": ["type"] },
+          "then": { "required": ["field_path"] }
+        }
+      ]
+    }
+  }
+}

--- a/box_agent/skills/roadmap/references/roadmap-spec.schema.json
+++ b/box_agent/skills/roadmap/references/roadmap-spec.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://box-agent.local/schemas/roadmap-spec.schema.json",
+  "title": "Box-Agent RoadmapSpec v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "kind", "title", "range", "lanes", "items"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "roadmap-spec" },
+    "title": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "range": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end", "granularity"],
+      "properties": {
+        "start": { "$ref": "#/$defs/plainDate" },
+        "end": { "$ref": "#/$defs/plainDate" },
+        "granularity": { "const": "half-month" }
+      }
+    },
+    "lanes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "label", "order"],
+        "properties": {
+          "id": { "$ref": "#/$defs/stableId" },
+          "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+          "order": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 80,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "lane_id", "title", "start", "kind", "certainty", "progress"],
+        "properties": {
+          "id": { "$ref": "#/$defs/stableId" },
+          "lane_id": { "$ref": "#/$defs/stableId" },
+          "title": { "type": "string", "minLength": 1, "maxLength": 100 },
+          "start": { "$ref": "#/$defs/plainDate" },
+          "end": { "$ref": "#/$defs/plainDate" },
+          "kind": { "enum": ["bar", "milestone"] },
+          "certainty": { "enum": ["confirmed", "tentative"] },
+          "progress": { "enum": ["planned", "doing", "done", "blocked"] },
+          "continuation": { "$ref": "#/$defs/continuation" },
+          "color": { "type": "string", "maxLength": 40 },
+          "detail": { "type": "string", "maxLength": 500 },
+          "source": { "$ref": "roadmap-draft.schema.json#/$defs/source" }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "kind": { "const": "bar" } }, "required": ["kind"] },
+            "then": { "required": ["end"] }
+          },
+          {
+            "if": { "properties": { "kind": { "const": "milestone" } }, "required": ["kind"] },
+            "then": { "not": { "required": ["end"] } }
+          },
+          {
+            "if": { "required": ["continuation"] },
+            "then": { "properties": { "kind": { "const": "bar" } } }
+          }
+        ]
+      }
+    },
+    "legend": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "label"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "label": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "plainDate": {
+      "type": "string",
+      "anyOf": [
+        {
+          "pattern": "^(?:0[1-9][0-9]{2}|[1-9][0-9]{3})-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))$"
+        },
+        {
+          "pattern": "^(?:(?:0[1-9]|[1-9][0-9])(?:0[48]|[2468][048]|[13579][26])|(?:0[48]|[2468][048]|[13579][26])00)-02-29$"
+        }
+      ]
+    },
+    "stableId": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$" },
+    "continuation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "before": { "const": true },
+        "after": { "const": true }
+      },
+      "minProperties": 1
+    }
+  }
+}

--- a/box_agent/skills/roadmap/references/runtime-capabilities-v1.json
+++ b/box_agent/skills/roadmap/references/runtime-capabilities-v1.json
@@ -1,0 +1,15 @@
+{
+  "contract": "box-agent.runtime-capabilities",
+  "contractVersion": 1,
+  "deckProtocolVersion": 1,
+  "roadmap": {
+    "schemaVersion": 1,
+    "geometryVersion": 1,
+    "rendererVersion": 1,
+    "capabilities": [
+      "roadmap.generate.html",
+      "roadmap.preview",
+      "roadmap.edit"
+    ]
+  }
+}

--- a/box_agent/skills/roadmap/references/runtime-capabilities-v1.schema.json
+++ b/box_agent/skills/roadmap/references/runtime-capabilities-v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://box-agent.local/schemas/runtime-capabilities-v1.schema.json",
+  "title": "Box-Agent runtime capabilities v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "contractVersion", "deckProtocolVersion", "roadmap"],
+  "properties": {
+    "contract": { "const": "box-agent.runtime-capabilities" },
+    "contractVersion": { "const": 1 },
+    "deckProtocolVersion": { "type": "integer", "minimum": 1 },
+    "roadmap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "geometryVersion",
+        "rendererVersion",
+        "capabilities"
+      ],
+      "properties": {
+        "schemaVersion": { "type": "integer", "minimum": 1 },
+        "geometryVersion": { "type": "integer", "minimum": 1 },
+        "rendererVersion": {
+          "type": ["integer", "null"],
+          "minimum": 1
+        },
+        "capabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "roadmap.generate.html",
+              "roadmap.preview",
+              "roadmap.edit"
+            ]
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "capabilities": {
+                "contains": {
+                  "enum": ["roadmap.generate.html", "roadmap.preview", "roadmap.edit"]
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "rendererVersion": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/box_agent/skills/roadmap/runtime/registry.json
+++ b/box_agent/skills/roadmap/runtime/registry.json
@@ -1,0 +1,38 @@
+{
+  "registry_version": 1,
+  "default_palette_id": "roadmap-default-v1",
+  "palettes": [
+    {
+      "id": "roadmap-default-v1",
+      "colors": [
+        "#8e6bf2",
+        "#7092fa",
+        "#56d9b6",
+        "#ebaf78",
+        "#f96565",
+        "#96dee8",
+        "#9f5f8f",
+        "#78d3f8",
+        "#21d3c5",
+        "#f9c955",
+        "#ff9999"
+      ]
+    }
+  ],
+  "layouts": [
+    {
+      "id": "roadmap-swimlane-v1",
+      "artifact_kind": "roadmap",
+      "mime_type": "text/html",
+      "schema_version": 1,
+      "geometry_version": 1,
+      "renderer_version": 1,
+      "default_example": "examples/roadmap-spec-v1.json",
+      "editor": {
+        "mode": "form-table",
+        "source_element_id": "deck-document",
+        "supports_in_place_save": true
+      }
+    }
+  ]
+}

--- a/box_agent/skills/roadmap/runtime/roadmap-editor.js
+++ b/box_agent/skills/roadmap/runtime/roadmap-editor.js
@@ -1,0 +1,672 @@
+(function () {
+  "use strict";
+
+  const RUNTIME_SOURCE = "box-agent-controlled-deck";
+  const HOST_SOURCE = "officev3-controlled-deck-host";
+  const PROTOCOL_VERSION = 1;
+  const LAYOUT_ID = "roadmap-swimlane-v1";
+  const SAVE_TIMEOUT_MS = 15000;
+  const documentNode = document.querySelector("#deck-document");
+  const geometryNode = document.querySelector("#roadmap-geometry");
+  const diagnosticsNode = document.querySelector("#roadmap-diagnostics");
+  const pendingQuestionsNode = document.querySelector("#roadmap-pending-questions");
+  const paletteNode = document.querySelector("#roadmap-palette");
+  const stage = document.querySelector('[data-role="stage"]');
+  const stageShell = document.querySelector('[data-role="stage-shell"]');
+  const editorBackdrop = document.querySelector('[data-role="editor-backdrop"]');
+  const editor = document.querySelector('[data-role="editor"]');
+  const titleNode = document.querySelector('[data-role="roadmap-title"]');
+  const diagnosticBanner = document.querySelector('[data-role="diagnostics"]');
+  const toast = document.querySelector('[data-role="toast"]');
+  const actions = document.querySelector('[data-role="roadmap-actions"]');
+  const adjustButton = document.querySelector('[data-action="adjust"]');
+  const saveButton = document.querySelector('[data-action="save"]');
+  const contractCore = window.__roadmapContractCore;
+  const geometryCore = window.__roadmapGeometryCore;
+  if (!documentNode || !geometryNode || !paletteNode || !stage || !stageShell || !editorBackdrop || !editor || !actions || !adjustButton || !saveButton || !contractCore || !geometryCore) return;
+
+  let model = JSON.parse(documentNode.textContent || "{}");
+  let geometry = JSON.parse(geometryNode.textContent || "{}");
+  let diagnostics = JSON.parse(diagnosticsNode?.textContent || "[]");
+  let pendingQuestions = JSON.parse(pendingQuestionsNode?.textContent || "[]");
+  const palette = JSON.parse(paletteNode.textContent || "{}");
+  const laneAccents = Array.isArray(palette.colors) && palette.colors.length
+    ? palette.colors
+    : ["var(--roadmap-primary)"];
+  let revision = 0;
+  let savedRevision = 0;
+  let modelValid = true;
+  let hostEditAvailable = false;
+  let hostSaveAvailable = false;
+  let saveInFlight = null;
+  let saveTimer = null;
+  let toastTimer = null;
+
+  function element(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = String(text);
+    return node;
+  }
+
+  function safeColor(value) {
+    const normalized = String(value || "").trim();
+    if (/^#[0-9a-f]{3,8}$/i.test(normalized)) return normalized;
+    if (/^(?:rgb|hsl)a?\([0-9.,%\s]+\)$/i.test(normalized)) return normalized;
+    return "var(--roadmap-primary)";
+  }
+
+  function box(node, entry) {
+    node.style.left = `${Number(entry.x) || 0}px`;
+    node.style.top = `${Number(entry.y) || 0}px`;
+    node.style.width = `${Number(entry.width) || 0}px`;
+    node.style.height = `${Number(entry.height) || 0}px`;
+  }
+
+  function progressRatio(value) {
+    return { planned: 0, doing: 0.55, done: 1, blocked: 1 }[value] || 0;
+  }
+
+  function progressLabel(value) {
+    return { planned: "计划中", doing: "进行中", done: "已完成", blocked: "受阻" }[value] || value;
+  }
+
+  function laneAccent(index) {
+    return laneAccents[index % laneAccents.length];
+  }
+
+  function compactHeaderLabel(header) {
+    if (header.kind !== "half-month" || header.width >= 56) return header.label;
+    return header.label.startsWith("上") ? "上" : "下";
+  }
+
+  function renderStage() {
+    stage.replaceChildren();
+    stage.style.width = `${geometry.canvas.width}px`;
+    stage.style.height = `${geometry.canvas.height}px`;
+
+    const firstLane = geometry.lanes[0];
+    const axisLabel = element("div", "roadmap-axis-label");
+    axisLabel.style.left = `${firstLane?.x || 0}px`;
+    axisLabel.style.top = `${geometry.canvas.header_top}px`;
+    axisLabel.style.width = `${geometry.canvas.plot_left - (firstLane?.x || 0)}px`;
+    axisLabel.style.height = `${geometry.canvas.header_height}px`;
+    axisLabel.appendChild(element("span", "", "阶段"));
+    axisLabel.appendChild(element("small", "", "团队泳道"));
+    stage.appendChild(axisLabel);
+
+    geometry.headers.forEach(header => {
+      const node = element("div", "roadmap-header", compactHeaderLabel(header));
+      node.dataset.kind = header.kind;
+      node.title = header.label;
+      box(node, header);
+      stage.appendChild(node);
+    });
+
+    const lanesById = new Map(model.lanes.map(lane => [lane.id, lane]));
+    geometry.lanes.forEach((lane, index) => {
+      const node = element("div", "roadmap-lane");
+      node.dataset.laneId = lane.id;
+      node.style.setProperty("--roadmap-lane-accent", laneAccent(index));
+      box(node, lane);
+      const label = element("div", "roadmap-lane-label");
+      const labelText = lanesById.get(lane.id)?.label || lane.label;
+      label.title = labelText;
+      label.appendChild(element("span", "roadmap-lane-index", String(index + 1).padStart(2, "0")));
+      label.appendChild(element("span", "roadmap-lane-title", labelText));
+      node.appendChild(label);
+      stage.appendChild(node);
+    });
+
+    const halfMonthHeaders = geometry.headers.filter(header => header.kind === "half-month");
+    const gridLineXs = [...new Set([
+      ...halfMonthHeaders.map(header => header.x),
+      ...halfMonthHeaders.map(header => header.x + header.width),
+    ].map(value => Number(value.toFixed(3))))];
+    const laneTop = geometry.canvas.header_top + geometry.canvas.header_height;
+    const laneBottom = geometry.lanes.reduce((bottom, lane) => Math.max(bottom, lane.y + lane.height), laneTop);
+    gridLineXs.forEach(x => {
+      const line = element("div", "roadmap-grid-line");
+      line.style.left = `${x}px`;
+      line.style.top = `${laneTop}px`;
+      line.style.height = `${laneBottom - laneTop}px`;
+      stage.appendChild(line);
+    });
+
+    const itemsById = new Map(model.items.map(item => [item.id, item]));
+    const laneIndexById = new Map(model.lanes.map((lane, index) => [lane.id, index]));
+    geometry.bars.forEach(bar => {
+      const item = itemsById.get(bar.id) || bar;
+      const node = element("div", "roadmap-bar");
+      node.dataset.itemId = bar.id;
+      node.dataset.lineStyle = bar.line_style;
+      node.dataset.progress = item.progress;
+      node.title = `${bar.title} · ${bar.start} → ${bar.end} · ${progressLabel(item.progress)}`;
+      box(node, bar);
+      const color = item.color ? safeColor(item.color) : laneAccent(laneIndexById.get(bar.lane_id) || 0);
+      node.style.setProperty("--roadmap-item-accent", color);
+      const progress = element("div", "roadmap-bar-progress");
+      progress.style.width = `${progressRatio(item.progress) * 100}%`;
+      node.appendChild(progress);
+      stage.appendChild(node);
+    });
+
+    geometry.milestones.forEach(marker => {
+      const node = element("div", "roadmap-milestone");
+      node.dataset.itemId = marker.id;
+      node.dataset.lineStyle = marker.line_style;
+      node.title = `${marker.title} · ${marker.date}`;
+      node.style.left = `${marker.x - marker.size / 2}px`;
+      node.style.top = `${marker.y - marker.size / 2}px`;
+      node.style.width = `${marker.size}px`;
+      node.style.height = `${marker.size}px`;
+      const item = itemsById.get(marker.id) || marker;
+      const color = item.color ? safeColor(item.color) : laneAccent(laneIndexById.get(marker.lane_id) || 0);
+      node.style.setProperty("--roadmap-item-accent", color);
+      stage.appendChild(node);
+    });
+
+    geometry.labels.forEach(label => {
+      const node = element("div", "roadmap-label", label.text);
+      node.dataset.itemId = label.item_id;
+      node.dataset.placement = label.placement;
+      node.title = label.text;
+      box(node, label);
+      stage.appendChild(node);
+    });
+
+    geometry.continuations.forEach(marker => {
+      const before = marker.direction === "before";
+      const node = element("div", "roadmap-continuation", before ? "‹" : "›");
+      node.setAttribute("aria-label", before ? "开始前仍在继续" : "结束后仍将继续");
+      node.style.left = `${marker.x - marker.size}px`;
+      node.style.top = `${marker.y - marker.size}px`;
+      stage.appendChild(node);
+    });
+
+    if (Array.isArray(model.legend) && model.legend.length) {
+      const legend = element("div", "roadmap-legend");
+      model.legend.forEach(entry => legend.appendChild(element("span", "", entry.label)));
+      stage.appendChild(legend);
+    }
+    titleNode.textContent = model.title;
+    resizeStage();
+  }
+
+  function resizeStage() {
+    const width = Math.max(1, stageShell.clientWidth || geometry.canvas.width);
+    const scale = Math.min(1, width / geometry.canvas.width);
+    stage.style.transform = `scale(${scale})`;
+    stageShell.style.height = `${Math.max(480, geometry.canvas.height * scale)}px`;
+  }
+
+  function showToast(message) {
+    toast.textContent = String(message);
+    toast.hidden = false;
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { toast.hidden = true; }, 3200);
+  }
+
+  function updateDiagnostics(nextDiagnostics) {
+    diagnostics = nextDiagnostics;
+    if (diagnosticsNode) diagnosticsNode.textContent = JSON.stringify(diagnostics, null, 2);
+    diagnosticBanner.hidden = diagnostics.length === 0;
+    diagnosticBanner.textContent = diagnostics.map(entry => entry.message).join("；");
+  }
+
+  function safeJsonText(value) {
+    return JSON.stringify(value, null, 2)
+      .replace(/</g, "\\u003c")
+      .replace(/\u2028/g, "\\u2028")
+      .replace(/\u2029/g, "\\u2029");
+  }
+
+  function capacityDiagnostics() {
+    const next = [];
+    if (model.items.length >= 80) {
+      next.push({ code: "capacity.items-at-limit", severity: "warning", message: "任务数量已达到 80 条上限；建议拆分为多个路线图。" });
+    } else if (model.items.length >= 30) {
+      next.push({ code: "capacity.dense", severity: "warning", message: `当前包含 ${model.items.length} 条任务，已启用可滚动的密集视图。` });
+    }
+    if (geometry.canvas.height > 900) {
+      next.push({ code: "layout.vertical-scroll", severity: "warning", message: `内容高度为 ${Math.round(geometry.canvas.height)}px，预览将使用纵向滚动。` });
+    }
+    return next;
+  }
+
+  function relayout() {
+    const started = performance.now();
+    const validation = contractCore.validateAndNormalizeRoadmapSpec(model);
+    if (!validation.ok) {
+      modelValid = false;
+      updateDiagnostics(validation.issues.slice(0, 6).map(message => ({ code: "contract.invalid", severity: "error", message })));
+      updateButtons();
+      return false;
+    }
+    modelValid = true;
+    model = validation.normalized;
+    geometry = geometryCore.layoutRoadmap(model, { width: 1440, height: 900 });
+    const elapsed = performance.now() - started;
+    const next = capacityDiagnostics();
+    if (elapsed >= 100) next.push({ code: "performance.relayout", severity: "warning", message: `本次重排耗时 ${Math.round(elapsed)}ms。` });
+    updateDiagnostics(next);
+    documentNode.textContent = safeJsonText(model);
+    geometryNode.textContent = safeJsonText(geometry);
+    renderStage();
+    updateButtons();
+    return true;
+  }
+
+  function inputField(labelText, value, path, type) {
+    const label = element("label", "roadmap-field");
+    label.appendChild(element("span", "", labelText));
+    const input = document.createElement("input");
+    input.type = type || "text";
+    input.value = value || "";
+    input.dataset.modelPath = path;
+    label.appendChild(input);
+    return label;
+  }
+
+  function selectField(value, path, choices) {
+    const field = element("div", "roadmap-select");
+    field.dataset.modelPath = path;
+    const menuId = `roadmap-select-${path.replace(/[^a-z0-9]+/gi, "-")}`;
+    const selected = choices.find(choice => choice.value === value) || choices[0];
+    const trigger = element("button", "roadmap-select-trigger", selected?.label || "请选择");
+    trigger.type = "button";
+    trigger.dataset.selectTrigger = "true";
+    trigger.setAttribute("role", "combobox");
+    trigger.setAttribute("aria-haspopup", "listbox");
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.setAttribute("aria-controls", menuId);
+    const menu = element("div", "roadmap-select-menu");
+    menu.id = menuId;
+    menu.setAttribute("role", "listbox");
+    menu.setAttribute("popover", "manual");
+    choices.forEach(choice => {
+      const option = element("button", "roadmap-select-option", choice.label);
+      option.type = "button";
+      option.dataset.selectValue = choice.value;
+      option.setAttribute("role", "option");
+      option.setAttribute("aria-selected", String(choice.value === value));
+      menu.appendChild(option);
+    });
+    field.append(trigger, menu);
+    return field;
+  }
+
+  function closeSelectMenu(field, restoreFocus) {
+    const menu = field?.querySelector(".roadmap-select-menu");
+    const trigger = field?.querySelector("[data-select-trigger]");
+    if (!menu || !trigger) return;
+    if (typeof menu.hidePopover === "function" && menu.matches(":popover-open")) menu.hidePopover();
+    else menu.hidden = true;
+    trigger.setAttribute("aria-expanded", "false");
+    if (restoreFocus) trigger.focus();
+  }
+
+  function closeSelectMenus(except, restoreFocus) {
+    editor.querySelectorAll(".roadmap-select").forEach(field => {
+      if (field !== except) closeSelectMenu(field, restoreFocus);
+    });
+  }
+
+  function openSelectMenu(field) {
+    closeSelectMenus(field, false);
+    const trigger = field.querySelector("[data-select-trigger]");
+    const menu = field.querySelector(".roadmap-select-menu");
+    const rect = trigger.getBoundingClientRect();
+    menu.hidden = false;
+    menu.style.width = `${rect.width}px`;
+    menu.style.left = `${Math.max(8, Math.min(rect.left, window.innerWidth - rect.width - 8))}px`;
+    menu.style.top = `${rect.bottom + 4}px`;
+    if (typeof menu.showPopover === "function") menu.showPopover();
+    const menuRect = menu.getBoundingClientRect();
+    if (menuRect.bottom > window.innerHeight - 8 && rect.top > menuRect.height + 12) {
+      menu.style.top = `${rect.top - menuRect.height - 4}px`;
+    }
+    trigger.setAttribute("aria-expanded", "true");
+  }
+
+  function chooseSelectOption(field, option) {
+    const path = field.dataset.modelPath;
+    const value = option.dataset.selectValue;
+    const trigger = field.querySelector("[data-select-trigger]");
+    const rerenderEditor = /\.kind$/.test(path);
+    applyMutation(() => setPath(path, value), rerenderEditor);
+    if (!rerenderEditor) {
+      trigger.textContent = option.textContent;
+      field.querySelectorAll("[data-select-value]").forEach(entry => {
+        entry.setAttribute("aria-selected", String(entry === option));
+      });
+      closeSelectMenu(field, true);
+    }
+  }
+
+  function svgIcon(name) {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("aria-hidden", "true");
+    const paths = {
+      close: ["M6 6l12 12", "M18 6L6 18"],
+      plus: ["M12 5v14", "M5 12h14"],
+      trash: ["M3 6h18", "M8 6V4h8v2", "M19 6l-1 14H6L5 6", "M10 11v5", "M14 11v5"],
+    }[name] || [];
+    paths.forEach(value => {
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("d", value);
+      svg.appendChild(path);
+    });
+    return svg;
+  }
+
+  function actionButton(label, action, index, options = {}) {
+    const button = element("button", "roadmap-button", label);
+    button.type = "button";
+    button.dataset.editorAction = action;
+    if (index !== undefined) button.dataset.index = String(index);
+    if (options.variant) button.dataset.variant = options.variant;
+    if (options.icon) {
+      button.replaceChildren(svgIcon(options.icon));
+      if (!options.iconOnly) button.appendChild(element("span", "", label));
+    }
+    if (options.iconOnly) button.classList.add("roadmap-icon-button");
+    button.setAttribute("aria-label", label);
+    button.title = label;
+    return button;
+  }
+
+  function setEditorOpen(open) {
+    if (!open) closeSelectMenus(null, false);
+    editorBackdrop.hidden = !open;
+    editor.hidden = !open;
+    if (open) document.body.dataset.editorOpen = "true";
+    else delete document.body.dataset.editorOpen;
+  }
+
+  function renderEditor() {
+    editor.replaceChildren();
+    const header = document.createElement("header");
+    header.appendChild(element("h2", "", "调整路线图"));
+    header.appendChild(actionButton("关闭", "close", undefined, { icon: "close", iconOnly: true }));
+    editor.appendChild(header);
+
+    const basic = element("section", "roadmap-editor-section");
+    basic.appendChild(element("h3", "", "基本信息"));
+    const grid = element("div", "roadmap-editor-grid");
+    grid.appendChild(inputField("标题", model.title, "title"));
+    grid.appendChild(inputField("开始日期", model.range.start, "range.start", "date"));
+    grid.appendChild(inputField("结束日期（不包含）", model.range.end, "range.end", "date"));
+    basic.appendChild(grid);
+    editor.appendChild(basic);
+
+    const lanes = element("section", "roadmap-editor-section");
+    const laneHeader = document.createElement("header");
+    laneHeader.appendChild(element("h3", "", `泳道（${model.lanes.length}/8）`));
+    laneHeader.appendChild(actionButton("新增泳道", "add-lane", undefined, { icon: "plus", variant: "primary" }));
+    lanes.appendChild(laneHeader);
+    const laneTable = element("table", "roadmap-table");
+    const laneBody = document.createElement("tbody");
+    model.lanes.forEach((lane, index) => {
+      const row = document.createElement("tr");
+      const labelCell = document.createElement("td");
+      const input = document.createElement("input");
+      input.value = lane.label;
+      input.dataset.modelPath = `lanes.${index}.label`;
+      labelCell.appendChild(input);
+      const actionCell = document.createElement("td");
+      actionCell.appendChild(actionButton("删除泳道", "remove-lane", index, { icon: "trash", iconOnly: true, variant: "danger" }));
+      row.append(labelCell, actionCell);
+      laneBody.appendChild(row);
+    });
+    laneTable.appendChild(laneBody);
+    lanes.appendChild(laneTable);
+    editor.appendChild(lanes);
+
+    const items = element("section", "roadmap-editor-section");
+    const itemHeader = document.createElement("header");
+    itemHeader.appendChild(element("h3", "", `任务与里程碑（${model.items.length}/80）`));
+    itemHeader.appendChild(actionButton("新增任务", "add-item", undefined, { icon: "plus", variant: "primary" }));
+    items.appendChild(itemHeader);
+    const wrap = element("div", "roadmap-table-wrap");
+    const table = element("table", "roadmap-table");
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    ["标题", "泳道", "类型", "开始", "结束", "状态", "确定性", ""].forEach(text => headRow.appendChild(element("th", "", text)));
+    head.appendChild(headRow);
+    const body = document.createElement("tbody");
+    model.items.forEach((item, index) => {
+      const row = document.createElement("tr");
+      const values = [
+        (() => { const input = document.createElement("input"); input.value = item.title; input.dataset.modelPath = `items.${index}.title`; return input; })(),
+        selectField(item.lane_id, `items.${index}.lane_id`, model.lanes.map(lane => ({ value: lane.id, label: lane.label }))),
+        selectField(item.kind, `items.${index}.kind`, [{ value: "bar", label: "任务" }, { value: "milestone", label: "里程碑" }]),
+        (() => { const input = document.createElement("input"); input.type = "date"; input.value = item.start; input.dataset.modelPath = `items.${index}.start`; return input; })(),
+        (() => {
+          const input = document.createElement("input");
+          const isMilestone = item.kind === "milestone";
+          input.type = isMilestone ? "text" : "date";
+          input.value = isMilestone ? "无需结束日期" : (item.end || "");
+          input.disabled = isMilestone;
+          input.dataset.modelPath = `items.${index}.end`;
+          return input;
+        })(),
+        selectField(item.progress, `items.${index}.progress`, [
+          { value: "planned", label: "计划中" },
+          { value: "doing", label: "进行中" },
+          { value: "done", label: "已完成" },
+          { value: "blocked", label: "受阻" },
+        ]),
+        selectField(item.certainty, `items.${index}.certainty`, [{ value: "confirmed", label: "已确认" }, { value: "tentative", label: "待确认" }]),
+        actionButton("删除任务", "remove-item", index, { icon: "trash", iconOnly: true, variant: "danger" }),
+      ];
+      values.forEach(value => { const cell = document.createElement("td"); cell.appendChild(value); row.appendChild(cell); });
+      body.appendChild(row);
+    });
+    table.append(head, body);
+    wrap.appendChild(table);
+    items.appendChild(wrap);
+    editor.appendChild(items);
+  }
+
+  function setPath(path, value) {
+    const segments = path.split(".");
+    let target = model;
+    for (let index = 0; index < segments.length - 1; index += 1) target = target[segments[index]];
+    const key = segments[segments.length - 1];
+    if (/\.end$/.test(path) && !value) delete target[key];
+    else target[key] = value;
+    if (/\.kind$/.test(path) && value === "milestone") delete target.end;
+  }
+
+  function uniqueId(prefix, collection) {
+    let index = collection.length + 1;
+    while (collection.some(entry => entry.id === `${prefix}-${index}`)) index += 1;
+    return `${prefix}-${index}`;
+  }
+
+  function applyMutation(callback, rerenderEditor) {
+    callback();
+    revision += 1;
+    relayout();
+    if (rerenderEditor) renderEditor();
+  }
+
+  editor.addEventListener("input", event => {
+    const control = event.target.closest("[data-model-path]");
+    if (!control || control.classList.contains("roadmap-select")) return;
+    applyMutation(() => setPath(control.dataset.modelPath, control.value), false);
+  });
+  editor.addEventListener("click", event => {
+    const option = event.target.closest("[data-select-value]");
+    if (option) {
+      chooseSelectOption(option.closest(".roadmap-select"), option);
+      return;
+    }
+    const trigger = event.target.closest("[data-select-trigger]");
+    if (trigger) {
+      const field = trigger.closest(".roadmap-select");
+      if (trigger.getAttribute("aria-expanded") === "true") closeSelectMenu(field, false);
+      else openSelectMenu(field);
+      return;
+    }
+    const button = event.target.closest("[data-editor-action]");
+    if (!button) return;
+    const action = button.dataset.editorAction;
+    const index = Number(button.dataset.index);
+    if (action === "close") setEditorOpen(false);
+    if (action === "add-lane") {
+      if (model.lanes.length >= 8) return showToast("最多支持 8 条泳道");
+      applyMutation(() => model.lanes.push({ id: uniqueId("lane", model.lanes), label: "新泳道", order: model.lanes.length + 1 }), true);
+    }
+    if (action === "remove-lane") {
+      const lane = model.lanes[index];
+      if (model.lanes.length <= 1) return showToast("至少保留一条泳道");
+      if (model.items.some(item => item.lane_id === lane.id)) return showToast("请先移动或删除该泳道中的任务");
+      applyMutation(() => { model.lanes.splice(index, 1); model.lanes.forEach((entry, laneIndex) => { entry.order = laneIndex + 1; }); }, true);
+    }
+    if (action === "add-item") {
+      if (model.items.length >= 80) return showToast("最多支持 80 条任务");
+      applyMutation(() => model.items.push({
+        id: uniqueId("item", model.items),
+        lane_id: model.lanes[0].id,
+        title: "新任务",
+        start: model.range.start,
+        end: model.range.end,
+        kind: "bar",
+        certainty: "tentative",
+        progress: "planned",
+      }), true);
+    }
+    if (action === "remove-item") {
+      if (model.items.length <= 1) return showToast("至少保留一条任务或里程碑");
+      applyMutation(() => model.items.splice(index, 1), true);
+    }
+  });
+  editor.addEventListener("keydown", event => {
+    const trigger = event.target.closest("[data-select-trigger]");
+    if (trigger && ["ArrowDown", "ArrowUp"].includes(event.key)) {
+      event.preventDefault();
+      const field = trigger.closest(".roadmap-select");
+      openSelectMenu(field);
+      const options = [...field.querySelectorAll("[data-select-value]")];
+      const selectedIndex = Math.max(0, options.findIndex(option => option.getAttribute("aria-selected") === "true"));
+      options[event.key === "ArrowUp" ? Math.max(0, selectedIndex - 1) : selectedIndex].focus();
+      return;
+    }
+    const option = event.target.closest("[data-select-value]");
+    if (!option || !["ArrowDown", "ArrowUp", "Home", "End", "Escape"].includes(event.key)) return;
+    event.preventDefault();
+    const field = option.closest(".roadmap-select");
+    if (event.key === "Escape") return closeSelectMenu(field, true);
+    const options = [...field.querySelectorAll("[data-select-value]")];
+    const currentIndex = options.indexOf(option);
+    const nextIndex = event.key === "Home" ? 0
+      : event.key === "End" ? options.length - 1
+      : event.key === "ArrowDown" ? Math.min(options.length - 1, currentIndex + 1)
+      : Math.max(0, currentIndex - 1);
+    options[nextIndex].focus();
+  });
+  document.addEventListener("click", event => {
+    if (!event.target.closest(".roadmap-select")) closeSelectMenus(null, false);
+  });
+  editor.addEventListener("scroll", () => closeSelectMenus(null, false), { passive: true });
+  editorBackdrop.addEventListener("click", () => setEditorOpen(false));
+  window.addEventListener("keydown", event => {
+    if (event.defaultPrevented || event.key !== "Escape" || editor.hidden) return;
+    const openField = editor.querySelector('[data-select-trigger][aria-expanded="true"]')?.closest(".roadmap-select");
+    if (openField) closeSelectMenu(openField, true);
+    else setEditorOpen(false);
+  });
+
+  function updateButtons() {
+    actions.hidden = !hostEditAvailable;
+    adjustButton.disabled = !hostEditAvailable;
+    adjustButton.title = hostEditAvailable ? "调整泳道、任务、日期与状态" : "当前运行时未声明 Roadmap 编辑能力";
+    saveButton.disabled = !hostEditAvailable || !hostSaveAvailable || !modelValid || revision === savedRevision || Boolean(saveInFlight);
+    saveButton.textContent = saveInFlight ? "保存中…" : revision === savedRevision ? "已保存" : "保存";
+  }
+
+  function serializeHtml() {
+    const clone = document.documentElement.cloneNode(true);
+    clone.querySelector('[data-role="editor"]').hidden = true;
+    clone.querySelector('[data-role="editor-backdrop"]').hidden = true;
+    clone.querySelector("body").removeAttribute("data-editor-open");
+    clone.querySelector('[data-role="toast"]').hidden = true;
+    clone.querySelector('[data-role="roadmap-actions"]').hidden = true;
+    clone.querySelector("#deck-document").textContent = safeJsonText(model);
+    clone.querySelector("#roadmap-geometry").textContent = safeJsonText(geometry);
+    clone.querySelector("#roadmap-diagnostics").textContent = safeJsonText(diagnostics);
+    const pendingResult = contractCore.pendingQuestionsForRoadmapSpec(model, pendingQuestions);
+    pendingQuestions = pendingResult.pending_questions;
+    clone.querySelector("#roadmap-pending-questions").textContent = safeJsonText(
+      pendingResult.pending_questions
+    );
+    const cloneAdjust = clone.querySelector('[data-action="adjust"]');
+    cloneAdjust.disabled = true;
+    cloneAdjust.title = "当前运行时未声明 Roadmap 编辑能力";
+    const cloneSave = clone.querySelector('[data-action="save"]');
+    cloneSave.disabled = true;
+    cloneSave.textContent = "保存";
+    return `<!doctype html>\n${clone.outerHTML}\n`;
+  }
+
+  function postToHost(type, payload) {
+    if (window.parent === window) return false;
+    window.parent.postMessage({ source: RUNTIME_SOURCE, version: PROTOCOL_VERSION, type, ...payload }, "*");
+    return true;
+  }
+
+  function requestSave() {
+    if (saveButton.disabled || saveInFlight || !modelValid) return;
+    const requestId = `roadmap-save-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    saveInFlight = { requestId, revision };
+    updateButtons();
+    postToHost("save-request", { requestId, revision, title: model.title, html: serializeHtml() });
+    saveTimer = setTimeout(() => {
+      if (!saveInFlight || saveInFlight.requestId !== requestId) return;
+      saveInFlight = null;
+      updateButtons();
+      showToast("保存超时，请重试");
+    }, SAVE_TIMEOUT_MS);
+  }
+
+  adjustButton.addEventListener("click", () => {
+    if (!hostEditAvailable) return;
+    renderEditor();
+    setEditorOpen(true);
+  });
+  saveButton.addEventListener("click", requestSave);
+
+  window.addEventListener("message", event => {
+    if (event.source !== window.parent) return;
+    const message = event.data;
+    if (!message || message.source !== HOST_SOURCE || message.version !== PROTOCOL_VERSION) return;
+    if (message.type === "host-ready") {
+      hostEditAvailable = message.canEdit === true;
+      hostSaveAvailable = message.canSave === true;
+      updateButtons();
+      return;
+    }
+    if (message.type !== "save-result" || !saveInFlight || message.requestId !== saveInFlight.requestId) return;
+    if (saveTimer) clearTimeout(saveTimer);
+    const completed = saveInFlight;
+    saveInFlight = null;
+    saveTimer = null;
+    if (message.ok === true) {
+      savedRevision = completed.revision;
+      showToast(revision === savedRevision ? "已保存到当前 HTML 文件" : "上一版已保存，当前仍有未保存修改");
+    } else {
+      showToast(message.code === "conflict" ? "文件已在外部改变，请重新打开后再编辑" : String(message.error || "保存失败，请重试"));
+    }
+    updateButtons();
+  });
+
+  if (typeof ResizeObserver !== "undefined") new ResizeObserver(resizeStage).observe(stageShell);
+  window.addEventListener("resize", resizeStage);
+  renderStage();
+  updateDiagnostics(diagnostics);
+  updateButtons();
+  postToHost("ready", { revision, title: model.title, layoutId: LAYOUT_ID, paletteId: palette.id });
+})();

--- a/box_agent/skills/roadmap/runtime/roadmap.css
+++ b/box_agent/skills/roadmap/runtime/roadmap.css
@@ -1,0 +1,356 @@
+:root {
+  color-scheme: light dark;
+  --roadmap-bg: #f3f6fa;
+  --roadmap-surface: #ffffff;
+  --roadmap-surface-strong: #f7f9fc;
+  --roadmap-text: #182033;
+  --roadmap-muted: #7b8494;
+  --roadmap-border: #e2e7ef;
+  --roadmap-primary: #8e6bf2;
+  --roadmap-primary-soft: #f0ecff;
+  --roadmap-danger: #c33b52;
+  --roadmap-danger-soft: #fff0f2;
+  --roadmap-shadow: 0 16px 44px rgb(22 32 51 / 12%);
+  font-family: Inter, "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { min-height: 100%; margin: 0; }
+body { background: var(--roadmap-bg); color: var(--roadmap-text); }
+button, input, select { font: inherit; }
+button:focus-visible, input:focus-visible, select:focus-visible {
+  outline: 2px solid var(--roadmap-primary);
+  outline-offset: 2px;
+}
+
+.roadmap-app { min-height: 100vh; padding: 24px; }
+.roadmap-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 auto 16px;
+  max-width: 1440px;
+}
+.roadmap-heading { min-width: 0; }
+.roadmap-heading h1 { margin: 0; overflow: hidden; font-size: 22px; font-weight: 720; letter-spacing: -.02em; text-overflow: ellipsis; white-space: nowrap; }
+.roadmap-heading p { margin: 5px 0 0; color: var(--roadmap-muted); font-size: 12px; }
+.roadmap-actions { display: flex; flex: none; gap: 8px; }
+.roadmap-actions[hidden] { display: none; }
+.roadmap-button {
+  min-height: 34px;
+  border: 1px solid var(--roadmap-border);
+  border-radius: 8px;
+  background: var(--roadmap-surface);
+  color: var(--roadmap-text);
+  cursor: pointer;
+  padding: 6px 12px;
+}
+.roadmap-button:hover:not(:disabled) { border-color: var(--roadmap-primary); }
+.roadmap-button:disabled { cursor: not-allowed; opacity: .55; }
+.roadmap-button[data-primary="true"] { border-color: var(--roadmap-primary); background: var(--roadmap-primary); color: white; }
+.roadmap-button[data-variant="primary"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-color: var(--roadmap-primary);
+  background: var(--roadmap-primary);
+  color: white;
+  font-size: 12px;
+  font-weight: 540;
+  box-shadow: 0 3px 9px color-mix(in srgb, var(--roadmap-primary) 24%, transparent);
+  transition: background-color .16s ease, box-shadow .16s ease, translate .16s ease;
+}
+.roadmap-button[data-variant="primary"]:hover:not(:disabled) {
+  border-color: var(--roadmap-primary);
+  background: color-mix(in srgb, var(--roadmap-primary) 88%, black);
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--roadmap-primary) 30%, transparent);
+  translate: 0 -1px;
+}
+.roadmap-icon-button {
+  display: inline-grid;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  min-height: 32px;
+  place-items: center;
+  padding: 0;
+}
+.roadmap-button svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
+.roadmap-button[data-variant="primary"] svg { width: 14px; height: 14px; }
+.roadmap-button[data-variant="danger"] { color: var(--roadmap-muted); }
+.roadmap-button[data-variant="danger"]:hover:not(:disabled) { border-color: var(--roadmap-danger); background: var(--roadmap-danger-soft); color: var(--roadmap-danger); }
+
+.roadmap-diagnostics {
+  max-width: 1440px;
+  margin: 0 auto 12px;
+  border: 1px solid #e5b75c;
+  border-radius: 8px;
+  background: #fff8e8;
+  color: #6b4b08;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+.roadmap-diagnostics[hidden] { display: none; }
+
+.roadmap-stage-shell {
+  position: relative;
+  max-width: 1440px;
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--roadmap-border);
+  border-radius: 18px;
+  background: var(--roadmap-surface);
+  box-shadow: var(--roadmap-shadow);
+}
+.roadmap-stage {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1440px;
+  min-height: 900px;
+  transform-origin: top left;
+  background: var(--roadmap-surface);
+}
+.roadmap-header, .roadmap-axis-label, .roadmap-lane, .roadmap-bar, .roadmap-label, .roadmap-milestone, .roadmap-continuation, .roadmap-grid-line {
+  position: absolute;
+}
+.roadmap-axis-label {
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  border: 1px solid var(--roadmap-border);
+  border-width: 1px 1px 1px 0;
+  background: var(--roadmap-surface);
+  padding: 0 22px;
+}
+.roadmap-axis-label span { font-size: 15px; font-weight: 720; }
+.roadmap-axis-label small { color: var(--roadmap-muted); font-size: 11px; letter-spacing: .08em; }
+.roadmap-header {
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--roadmap-border);
+  border-width: 0 1px 1px 0;
+  background: var(--roadmap-surface);
+  color: var(--roadmap-muted);
+  padding: 0 8px;
+  font-size: 13px;
+  font-weight: 620;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roadmap-header[data-kind="month"] { background: var(--roadmap-surface-strong); color: var(--roadmap-text); font-size: 14px; font-weight: 680; }
+.roadmap-lane {
+  z-index: 0;
+  border-bottom: 1px solid var(--roadmap-border);
+  background: color-mix(in srgb, var(--roadmap-lane-accent) 2.5%, var(--roadmap-surface));
+}
+.roadmap-lane-label {
+  position: absolute;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  width: 260px;
+  height: 100%;
+  border-right: 1px solid var(--roadmap-border);
+  background: color-mix(in srgb, var(--roadmap-lane-accent) 3.5%, var(--roadmap-surface));
+  padding: 0 22px;
+}
+.roadmap-lane-index {
+  flex: none;
+  color: var(--roadmap-muted);
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: .08em;
+}
+.roadmap-lane-title {
+  overflow: hidden;
+  color: var(--roadmap-lane-accent);
+  font-size: 17px;
+  font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roadmap-grid-line {
+  z-index: 1;
+  width: 1px;
+  background: color-mix(in srgb, var(--roadmap-border) 70%, transparent);
+  pointer-events: none;
+}
+.roadmap-bar {
+  z-index: 3;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-left: 6px solid var(--roadmap-item-accent, var(--roadmap-primary));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--roadmap-item-accent, var(--roadmap-primary)) 12%, var(--roadmap-surface));
+  box-shadow: 0 5px 16px color-mix(in srgb, var(--roadmap-item-accent, var(--roadmap-primary)) 11%, transparent);
+}
+.roadmap-bar[data-line-style="dashed"] { border-color: var(--roadmap-item-accent, var(--roadmap-primary)); border-style: dashed; border-left-width: 6px; }
+.roadmap-bar-progress { height: 100%; background: var(--roadmap-item-accent, var(--roadmap-primary)); opacity: .1; }
+.roadmap-bar[data-progress="doing"] .roadmap-bar-progress { opacity: .22; }
+.roadmap-bar[data-progress="done"] .roadmap-bar-progress { opacity: .16; }
+.roadmap-bar[data-progress="blocked"] {
+  border-color: color-mix(in srgb, var(--roadmap-danger) 58%, transparent);
+  border-left-color: var(--roadmap-danger);
+  background: color-mix(in srgb, var(--roadmap-danger) 7%, var(--roadmap-surface));
+  box-shadow: 0 5px 16px color-mix(in srgb, var(--roadmap-danger) 13%, transparent);
+}
+.roadmap-bar[data-progress="blocked"] .roadmap-bar-progress {
+  background: repeating-linear-gradient(-45deg, color-mix(in srgb, var(--roadmap-danger) 24%, transparent) 0 8px, transparent 8px 16px);
+  opacity: 1;
+}
+.roadmap-label {
+  z-index: 4;
+  overflow: hidden;
+  color: var(--roadmap-text);
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 46px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roadmap-label[data-placement="inside"] { padding: 0 8px; }
+.roadmap-milestone {
+  z-index: 3;
+  rotate: 45deg;
+  border: 3px solid var(--roadmap-item-accent, var(--roadmap-primary));
+  border-radius: 3px;
+  background: var(--roadmap-surface);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--roadmap-item-accent, var(--roadmap-primary)) 20%, transparent);
+}
+.roadmap-milestone[data-line-style="dashed"] { border-style: dashed; }
+.roadmap-continuation { z-index: 4; color: var(--roadmap-primary); font-size: 22px; line-height: 1; }
+.roadmap-legend { position: absolute; left: 24px; bottom: 18px; display: flex; gap: 18px; color: var(--roadmap-muted); font-size: 12px; }
+.roadmap-legend span::before { content: ""; display: inline-block; width: 10px; height: 10px; margin-right: 6px; border: 2px solid var(--roadmap-primary); border-radius: 2px; vertical-align: -1px; }
+
+.roadmap-editor-backdrop {
+  position: fixed;
+  z-index: 19;
+  inset: 0;
+  background: rgb(22 32 51 / 28%);
+  cursor: default;
+}
+.roadmap-editor-backdrop[hidden] { display: none; }
+body[data-editor-open="true"] { overflow: hidden; }
+.roadmap-editor {
+  position: fixed;
+  z-index: 20;
+  inset: 0 0 0 auto;
+  width: min(720px, 94vw);
+  overflow: auto;
+  border-left: 1px solid var(--roadmap-border);
+  background: var(--roadmap-surface);
+  box-shadow: -16px 0 44px rgb(22 32 51 / 16%);
+  padding: 20px;
+}
+.roadmap-editor[hidden] { display: none; }
+.roadmap-editor header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.roadmap-editor h2 { margin: 0; font-size: 18px; }
+.roadmap-editor > header { position: sticky; z-index: 2; top: -20px; margin: -20px -20px 0; border-bottom: 1px solid var(--roadmap-border); background: var(--roadmap-surface); padding: 16px 20px; }
+.roadmap-editor-section { margin-top: 18px; }
+.roadmap-editor-section h3 { margin: 0 0 8px; font-size: 14px; }
+.roadmap-editor-section > header .roadmap-button { flex: none; }
+.roadmap-editor-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.roadmap-field { display: grid; gap: 4px; color: var(--roadmap-muted); font-size: 11px; }
+.roadmap-field input, .roadmap-field select {
+  min-width: 0;
+  height: 34px;
+  border: 1px solid var(--roadmap-border);
+  border-radius: 6px;
+  background: var(--roadmap-surface);
+  color: var(--roadmap-text);
+  padding: 4px 8px;
+}
+.roadmap-table-wrap { overflow-x: auto; }
+.roadmap-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.roadmap-table th, .roadmap-table td { border-bottom: 1px solid var(--roadmap-border); padding: 6px 4px; text-align: left; }
+.roadmap-table input, .roadmap-select-trigger { width: 100%; min-width: 90px; height: 32px; border: 1px solid var(--roadmap-border); border-radius: 5px; background: var(--roadmap-surface); color: var(--roadmap-text); padding: 3px 7px; }
+.roadmap-select { min-width: 90px; }
+.roadmap-select-trigger {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+}
+.roadmap-select-trigger::after {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border: solid currentColor;
+  border-width: 0 1.5px 1.5px 0;
+  content: "";
+  rotate: 45deg;
+  translate: 0 -2px;
+  transition: rotate .14s ease, translate .14s ease;
+}
+.roadmap-select-trigger[aria-expanded="true"] { border-color: var(--roadmap-primary); box-shadow: 0 0 0 2px color-mix(in srgb, var(--roadmap-primary) 16%, transparent); }
+.roadmap-select-trigger[aria-expanded="true"]::after { rotate: 225deg; translate: 0 2px; }
+.roadmap-select-menu {
+  position: fixed;
+  z-index: 50;
+  inset: auto;
+  max-height: 224px;
+  overflow: auto;
+  margin: 0;
+  border: 1px solid var(--roadmap-border);
+  border-radius: 8px;
+  background: var(--roadmap-surface);
+  color: var(--roadmap-text);
+  box-shadow: 0 12px 28px rgb(22 32 51 / 18%);
+  padding: 4px;
+}
+.roadmap-select-option {
+  display: flex;
+  width: 100%;
+  min-height: 30px;
+  align-items: center;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 5px 8px;
+  text-align: left;
+  white-space: nowrap;
+}
+.roadmap-select-option:hover, .roadmap-select-option:focus-visible { background: var(--roadmap-primary-soft); color: var(--roadmap-primary); outline: none; }
+.roadmap-select-option[aria-selected="true"] { background: var(--roadmap-primary); color: white; }
+.roadmap-table th:last-child, .roadmap-table td:last-child { width: 40px; text-align: right; }
+.roadmap-toast { position: fixed; z-index: 40; left: 50%; bottom: 24px; translate: -50% 0; border-radius: 8px; background: #162033; color: white; padding: 9px 14px; font-size: 12px; box-shadow: var(--roadmap-shadow); }
+.roadmap-toast[hidden] { display: none; }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --roadmap-bg: #111722;
+    --roadmap-surface: #192130;
+    --roadmap-surface-strong: #202938;
+    --roadmap-text: #eef3fb;
+    --roadmap-muted: #aab6c9;
+    --roadmap-border: #344158;
+    --roadmap-primary: #8fa6ff;
+    --roadmap-primary-soft: #27365f;
+    --roadmap-danger-soft: #3c2530;
+    --roadmap-shadow: 0 16px 44px rgb(0 0 0 / 32%);
+  }
+  .roadmap-diagnostics { background: #3b321d; color: #f5d58e; border-color: #80672f; }
+}
+
+@media (max-width: 720px) {
+  .roadmap-app { padding: 10px; }
+  .roadmap-toolbar { align-items: flex-start; }
+  .roadmap-heading h1 { font-size: 16px; }
+  .roadmap-editor-grid { grid-template-columns: 1fr; }
+}

--- a/box_agent/skills/roadmap/scripts/build_roadmap_artifact.js
+++ b/box_agent/skills/roadmap/scripts/build_roadmap_artifact.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const { compileRoadmapInput } = require("./roadmap_contract_core.js");
+const {
+  extractRoadmapArtifactState,
+} = require("./extract_roadmap_spec.js");
+const { migrateRoadmapSpec } = require("./migrate_roadmap_spec.js");
+const { renderRoadmapHtml } = require("./roadmap_html_core.js");
+const {
+  consumeArtifactFileSync,
+  resolveArtifactPath,
+  resolveOutputPath,
+  snapshotArtifactFileSync,
+  writeOutputFileSync,
+} = require("./roadmap_io.js");
+
+const MAX_ARTIFACT_VERSION = Number.MAX_SAFE_INTEGER - 1;
+const MAX_VERSION_ALLOCATION_ATTEMPTS = 100;
+
+function usage() {
+  console.error(
+    "Usage: build_roadmap_artifact.js roadmap-draft.json|roadmap-spec.json|roadmap.html --out roadmap.html [--viewport 1440x900] [--consume-input] [--debug-dir DIR]"
+  );
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  if (!argv[0] || argv[0].startsWith("-")) usage();
+  const options = {
+    input: resolveArtifactPath(argv[0]),
+    out: null,
+    viewport: { width: 1440, height: 900 },
+    consumeInput: false,
+    debugDir: null,
+  };
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--out" && value) {
+      options.out = resolveOutputPath(value);
+      index += 1;
+    } else if (arg === "--viewport" && value) {
+      const match = /^(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)$/.exec(value);
+      if (!match) throw new Error("--viewport must be WIDTHxHEIGHT");
+      options.viewport = { width: Number(match[1]), height: Number(match[2]) };
+      index += 1;
+    } else if (arg === "--consume-input") {
+      options.consumeInput = true;
+    } else if (arg === "--debug-dir" && value) {
+      options.debugDir = resolveArtifactPath(value);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!options.out) usage();
+  if (path.extname(options.out).toLowerCase() !== ".html") {
+    throw new Error("--out must use an .html filename");
+  }
+  if (options.consumeInput && path.extname(options.input).toLowerCase() === ".html") {
+    throw new Error("--consume-input is only allowed for generated JSON input");
+  }
+  return options;
+}
+
+function readRoadmapSpec(inputPath) {
+  const extension = path.extname(inputPath).toLowerCase();
+  if (extension === ".html" || extension === ".htm") {
+    const state = extractRoadmapArtifactState(fs.readFileSync(inputPath, "utf8"));
+    return {
+      inputKind: "roadmap-html",
+      spec: state.spec,
+      warnings: [],
+      pendingQuestions: state.pendingQuestions,
+    };
+  }
+  const source = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  const compiled = compileRoadmapInput(source);
+  if (!compiled.ok || !compiled.spec) {
+    const error = new Error(`Roadmap compilation failed with ${compiled.issues.length} issue(s)`);
+    error.issues = compiled.issues;
+    error.pendingQuestions = compiled.pending_questions;
+    throw error;
+  }
+  return {
+    inputKind: compiled.input_kind,
+    spec: migrateRoadmapSpec(compiled.spec),
+    warnings: compiled.warnings,
+    pendingQuestions: compiled.pending_questions,
+  };
+}
+
+function versionedOutputCandidate(requestedPath) {
+  const directory = path.dirname(requestedPath);
+  const extension = path.extname(requestedPath);
+  const requestedStem = path.basename(requestedPath, extension);
+  const stem = requestedStem.replace(/-v\d+$/i, "");
+  const legacyPath = path.join(directory, `${stem}${extension}`);
+  let maximumVersion = fs.existsSync(legacyPath) ? 1 : 0;
+  if (fs.existsSync(directory)) {
+    const matcher = new RegExp(`^${stem.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-v(\\d+)\\${extension}$`, "i");
+    for (const name of fs.readdirSync(directory)) {
+      const match = matcher.exec(name);
+      if (match) {
+        const version = Number(match[1]);
+        if (!Number.isSafeInteger(version) || version > MAX_ARTIFACT_VERSION) {
+          throw new Error(`Roadmap artifact version is outside the supported range: ${name}`);
+        }
+        maximumVersion = Math.max(maximumVersion, version);
+      }
+    }
+  }
+  if (maximumVersion >= MAX_ARTIFACT_VERSION) {
+    throw new Error(`Roadmap artifact version limit reached for ${requestedPath}`);
+  }
+  const version = maximumVersion + 1;
+  return {
+    baseFilename: `${stem}${extension}`,
+    path: path.join(directory, `${stem}-v${version}${extension}`),
+    version,
+  };
+}
+
+function writeDebugArtifacts(debugDir, rendered, report) {
+  if (!debugDir) return;
+  const files = [
+    ["roadmap-spec-v1.json", rendered.spec],
+    ["roadmap-geometry.json", rendered.geometry],
+    ["roadmap-build-report.json", report],
+  ];
+  for (const [filename, value] of files) {
+    writeOutputFileSync(
+      path.join(debugDir, filename),
+      `${JSON.stringify(value, null, 2)}\n`,
+    );
+  }
+}
+
+function buildRoadmapArtifact(options) {
+  const consumedInputSnapshot = options.consumeInput
+    ? snapshotArtifactFileSync(options.input)
+    : null;
+  const input = readRoadmapSpec(options.input);
+  if (options.consumeInput && input.inputKind !== "roadmap-draft") {
+    throw new Error("--consume-input is only allowed for RoadmapDraft input");
+  }
+  let candidate;
+  let rendered;
+  let written = false;
+  for (let attempt = 0; attempt < MAX_VERSION_ALLOCATION_ATTEMPTS; attempt += 1) {
+    candidate = versionedOutputCandidate(options.out);
+    rendered = renderRoadmapHtml(input.spec, {
+      viewport: options.viewport,
+      generationVersion: candidate.version,
+      pendingQuestions: input.pendingQuestions,
+    });
+    try {
+      writeOutputFileSync(candidate.path, rendered.html, { exclusive: true });
+      written = true;
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+  }
+  if (!written || !candidate || !rendered) {
+    throw new Error(
+      `Unable to allocate a unique Roadmap artifact after ${MAX_VERSION_ALLOCATION_ATTEMPTS} attempts`,
+    );
+  }
+  const writtenArtifactSnapshot = snapshotArtifactFileSync(candidate.path);
+  const extracted = extractRoadmapArtifactState(fs.readFileSync(candidate.path, "utf8"));
+  if (
+    JSON.stringify(extracted.spec) !== JSON.stringify(rendered.spec)
+    || JSON.stringify(extracted.pendingQuestions) !== JSON.stringify(rendered.pendingQuestions)
+  ) {
+    consumeArtifactFileSync(candidate.path, writtenArtifactSnapshot.identity);
+    throw new Error("Roadmap HTML self-check failed: embedded #deck-document drifted from rendered spec");
+  }
+  const report = {
+    ok: true,
+    path: candidate.path,
+    filename: path.basename(candidate.path),
+    base_filename: candidate.baseFilename,
+    generation_version: candidate.version,
+    input_kind: input.inputKind,
+    mime_type: "text/html",
+    layout_id: "roadmap-swimlane-v1",
+    palette_id: "roadmap-default-v1",
+    editable: true,
+    status: rendered.pendingQuestions.length ? "preview" : "final",
+    warnings: input.warnings,
+    pending_questions: rendered.pendingQuestions,
+    diagnostics: rendered.diagnostics,
+  };
+  writeDebugArtifacts(options.debugDir, rendered, report);
+  if (consumedInputSnapshot) {
+    consumeArtifactFileSync(options.input, consumedInputSnapshot.identity);
+  }
+  return report;
+}
+
+function main() {
+  const report = buildRoadmapArtifact(parseArgs(process.argv.slice(2)));
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    for (const issue of Array.isArray(error?.issues) ? error.issues : []) console.error(`- ${issue}`);
+    for (const question of Array.isArray(error?.pendingQuestions) ? error.pendingQuestions : []) {
+      console.error(`? ${question.prompt}`);
+    }
+    console.error(error instanceof Error ? error.message : String(error));
+    console.log(JSON.stringify({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      issues: Array.isArray(error?.issues) ? error.issues : [],
+      pending_questions: Array.isArray(error?.pendingQuestions) ? error.pendingQuestions : [],
+    }, null, 2));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  buildRoadmapArtifact,
+  MAX_ARTIFACT_VERSION,
+  MAX_VERSION_ALLOCATION_ATTEMPTS,
+  parseArgs,
+  readRoadmapSpec,
+  versionedOutputCandidate,
+};

--- a/box_agent/skills/roadmap/scripts/build_roadmap_artifact.js
+++ b/box_agent/skills/roadmap/scripts/build_roadmap_artifact.js
@@ -11,9 +11,12 @@ const {
 const { migrateRoadmapSpec } = require("./migrate_roadmap_spec.js");
 const { renderRoadmapHtml } = require("./roadmap_html_core.js");
 const {
+  cleanupScratchTaskDirectorySync,
   consumeArtifactFileSync,
+  consumeScratchInputFileSync,
   resolveArtifactPath,
   resolveOutputPath,
+  snapshotConsumedInputFileSync,
   snapshotArtifactFileSync,
   writeOutputFileSync,
 } = require("./roadmap_io.js");
@@ -140,10 +143,7 @@ function writeDebugArtifacts(debugDir, rendered, report) {
   }
 }
 
-function buildRoadmapArtifact(options) {
-  const consumedInputSnapshot = options.consumeInput
-    ? snapshotArtifactFileSync(options.input)
-    : null;
+function buildRoadmapArtifactOnce(options, consumedInputSnapshot) {
   const input = readRoadmapSpec(options.input);
   if (options.consumeInput && input.inputKind !== "roadmap-draft") {
     throw new Error("--consume-input is only allowed for RoadmapDraft input");
@@ -198,9 +198,35 @@ function buildRoadmapArtifact(options) {
   };
   writeDebugArtifacts(options.debugDir, rendered, report);
   if (consumedInputSnapshot) {
-    consumeArtifactFileSync(options.input, consumedInputSnapshot.identity);
+    consumeScratchInputFileSync(options.input, consumedInputSnapshot);
   }
   return report;
+}
+
+function buildRoadmapArtifact(options) {
+  let consumedInputSnapshot = null;
+  let buildError = null;
+  try {
+    consumedInputSnapshot = options.consumeInput
+      ? snapshotConsumedInputFileSync(options.input)
+      : null;
+    return buildRoadmapArtifactOnce(options, consumedInputSnapshot);
+  } catch (error) {
+    buildError = error;
+    throw error;
+  } finally {
+    if (options.consumeInput) {
+      try {
+        cleanupScratchTaskDirectorySync(options.input, consumedInputSnapshot);
+      } catch (cleanupError) {
+        if (buildError instanceof Error) {
+          buildError.message += `; failed to clean scratch task: ${cleanupError.message}`;
+        } else {
+          throw cleanupError;
+        }
+      }
+    }
+  }
 }
 
 function main() {

--- a/box_agent/skills/roadmap/scripts/compile_roadmap_spec.js
+++ b/box_agent/skills/roadmap/scripts/compile_roadmap_spec.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const {
+  resolveArtifactPath,
+  resolveOutputPath,
+  writeOutputFileSync,
+} = require("./roadmap_io.js");
+const { compileRoadmapInput } = require("./roadmap_contract_core.js");
+
+function usage() {
+  console.error("Usage: compile_roadmap_spec.js roadmap-draft.json --out roadmap-spec.json [--report qa/roadmap_contract.json]");
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  if (!argv[0] || argv[0].startsWith("-")) usage();
+  const opts = { input: resolveArtifactPath(argv[0]), out: null, report: null };
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--out" && value) {
+      opts.out = resolveOutputPath(value);
+      index += 1;
+    } else if (arg === "--report" && value) {
+      opts.report = resolveOutputPath(value);
+      index += 1;
+    } else usage();
+  }
+  if (!opts.out) usage();
+  return opts;
+}
+
+function writeJson(filePath, value) {
+  writeOutputFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const input = JSON.parse(fs.readFileSync(opts.input, "utf8"));
+  const result = compileRoadmapInput(input);
+  const report = {
+    ok: result.ok,
+    input: opts.input,
+    input_kind: result.input_kind,
+    output: result.ok ? opts.out : null,
+    issues: result.issues,
+    warnings: result.warnings,
+    pending_questions: result.pending_questions,
+  };
+  if (result.ok) writeJson(opts.out, result.spec);
+  if (opts.report) writeJson(opts.report, report);
+  console.log(JSON.stringify({ ...report, ...(result.ok ? { spec: result.spec } : {}) }));
+  if (!result.ok) process.exit(1);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+}

--- a/box_agent/skills/roadmap/scripts/extract_roadmap_spec.js
+++ b/box_agent/skills/roadmap/scripts/extract_roadmap_spec.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+
+const {
+  pendingQuestionsForRoadmapSpec,
+  validateAndNormalizeRoadmapSpec,
+} = require("./roadmap_contract_core.js");
+const {
+  resolveArtifactPath,
+  resolveOutputPath,
+  writeOutputFileSync,
+} = require("./roadmap_io.js");
+
+function parseArgs(argv) {
+  if (!argv[0] || argv[0] === "--help" || argv[0] === "-h") {
+    console.log("Usage: extract_roadmap_spec.js roadmap.html --out roadmap-spec.json");
+    process.exit(argv[0] ? 0 : 2);
+  }
+  const options = { html: argv[0], out: null };
+  for (let index = 1; index < argv.length; index += 1) {
+    if (argv[index] === "--out" && argv[index + 1]) {
+      options.out = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argv[index]}`);
+    }
+  }
+  if (!options.out) throw new Error("--out is required");
+  return options;
+}
+
+function extractRoadmapSpec(html) {
+  const match = String(html).match(
+    /<script\b(?=[^>]*\bid=["']deck-document["'])(?=[^>]*\btype=["']application\/json["'])[^>]*>([\s\S]*?)<\/script\s*>/i,
+  );
+  if (!match) throw new Error("Roadmap HTML is missing #deck-document application/json source");
+  const parsed = JSON.parse(match[1]);
+  const result = validateAndNormalizeRoadmapSpec(parsed);
+  if (!result.ok) {
+    const error = new Error(`Embedded RoadmapSpec validation failed with ${result.issues.length} issue(s)`);
+    error.issues = result.issues;
+    throw error;
+  }
+  return result.normalized;
+}
+
+function extractRoadmapArtifactState(html) {
+  const source = String(html);
+  const spec = extractRoadmapSpec(source);
+  const match = source.match(
+    /<script\b(?=[^>]*\bid=["']roadmap-pending-questions["'])(?=[^>]*\btype=["']application\/json["'])[^>]*>([\s\S]*?)<\/script\s*>/i,
+  );
+  const persistedQuestions = match ? JSON.parse(match[1]) : [];
+  const questionResult = pendingQuestionsForRoadmapSpec(spec, persistedQuestions);
+  if (!questionResult.ok) {
+    const error = new Error(`Embedded pending question validation failed with ${questionResult.issues.length} issue(s)`);
+    error.issues = questionResult.issues;
+    throw error;
+  }
+  return { spec, pendingQuestions: questionResult.pending_questions };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const htmlPath = resolveArtifactPath(options.html);
+  const outputPath = resolveOutputPath(options.out);
+  const spec = extractRoadmapSpec(fs.readFileSync(htmlPath, "utf8"));
+  writeOutputFileSync(outputPath, `${JSON.stringify(spec, null, 2)}\n`);
+  console.log(JSON.stringify({
+    source: htmlPath,
+    output: outputPath,
+    schema_version: spec.schema_version,
+    source_of_truth: "#deck-document",
+  }, null, 2));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    for (const issue of Array.isArray(error?.issues) ? error.issues : []) console.error(`- ${issue}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = { extractRoadmapArtifactState, extractRoadmapSpec, parseArgs };

--- a/box_agent/skills/roadmap/scripts/layout_roadmap.js
+++ b/box_agent/skills/roadmap/scripts/layout_roadmap.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const {
+  resolveArtifactPath,
+  resolveOutputPath,
+  writeOutputFileSync,
+} = require("./roadmap_io.js");
+const { layoutRoadmap } = require("./roadmap_geometry_core.js");
+
+function usage() {
+  console.error("Usage: layout_roadmap.js roadmap-spec.json --out roadmap-geometry.json [--viewport WxH]");
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  if (!argv[0] || argv[0].startsWith("-")) usage();
+  const opts = {
+    input: resolveArtifactPath(argv[0]),
+    out: null,
+    viewport: { width: 1440, height: 900 },
+  };
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--out" && value) {
+      opts.out = resolveOutputPath(value);
+      index += 1;
+    } else if (arg === "--viewport" && value) {
+      const match = /^(\d+)\s*[xX]\s*(\d+)$/.exec(value);
+      if (!match) usage();
+      opts.viewport = { width: Number(match[1]), height: Number(match[2]) };
+      index += 1;
+    } else usage();
+  }
+  if (!opts.out) usage();
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const spec = JSON.parse(fs.readFileSync(opts.input, "utf8"));
+  const geometry = layoutRoadmap(spec, opts.viewport);
+  writeOutputFileSync(opts.out, `${JSON.stringify(geometry, null, 2)}\n`);
+  console.log(JSON.stringify({ ok: true, output: opts.out, geometry }));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+}

--- a/box_agent/skills/roadmap/scripts/migrate_roadmap_spec.js
+++ b/box_agent/skills/roadmap/scripts/migrate_roadmap_spec.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const {
+  resolveArtifactPath,
+  resolveOutputPath,
+  writeOutputFileSync,
+} = require("./roadmap_io.js");
+
+const CURRENT_ROADMAP_SCHEMA_VERSION = 1;
+
+function migrateRoadmapSpec(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("$: roadmap spec must be an object");
+  }
+  if (value.kind !== "roadmap-spec") {
+    throw new Error("kind: expected roadmap-spec");
+  }
+  if (!Number.isInteger(value.schema_version)) {
+    throw new Error("schema_version: required integer; migration never guesses a version");
+  }
+  if (value.schema_version !== CURRENT_ROADMAP_SCHEMA_VERSION) {
+    throw new Error(
+      `schema_version: unsupported ${value.schema_version}; expected ${CURRENT_ROADMAP_SCHEMA_VERSION}`,
+    );
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function usage() {
+  console.error("Usage: migrate_roadmap_spec.js roadmap-spec.json --out roadmap-spec-v1.json");
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  if (!argv[0] || argv[0].startsWith("-")) usage();
+  const opts = { input: resolveArtifactPath(argv[0]), out: null };
+  for (let index = 1; index < argv.length; index += 1) {
+    if (argv[index] === "--out" && argv[index + 1]) {
+      opts.out = resolveOutputPath(argv[index + 1]);
+      index += 1;
+    } else usage();
+  }
+  if (!opts.out) usage();
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const migrated = migrateRoadmapSpec(JSON.parse(fs.readFileSync(opts.input, "utf8")));
+  writeOutputFileSync(opts.out, `${JSON.stringify(migrated, null, 2)}\n`);
+  console.log(JSON.stringify({ ok: true, schema_version: migrated.schema_version, output: opts.out }));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  CURRENT_ROADMAP_SCHEMA_VERSION,
+  migrateRoadmapSpec,
+};

--- a/box_agent/skills/roadmap/scripts/render_roadmap_html.js
+++ b/box_agent/skills/roadmap/scripts/render_roadmap_html.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("path");
+
+const fs = require("fs");
+const {
+  resolveArtifactPath,
+  resolveOutputPath,
+  writeOutputFileSync,
+} = require("./roadmap_io.js");
+const {
+  ROADMAP_LAYOUT_ID,
+  ROADMAP_MIME_TYPE,
+  ROADMAP_RENDERER_VERSION,
+  renderRoadmapHtml,
+} = require("./roadmap_html_core.js");
+
+function parseArgs(argv) {
+  if (!argv[0] || argv[0] === "--help" || argv[0] === "-h") {
+    console.log("Usage: render_roadmap_html.js roadmap-spec.json --out roadmap.html [--viewport 1440x900]");
+    process.exit(argv[0] ? 0 : 2);
+  }
+  const options = { spec: argv[0], out: null, viewport: { width: 1440, height: 900 } };
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--out" && value) {
+      options.out = value;
+      index += 1;
+    } else if (arg === "--viewport" && value) {
+      const match = /^(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)$/.exec(value);
+      if (!match) throw new Error("--viewport must be WIDTHxHEIGHT");
+      options.viewport = { width: Number(match[1]), height: Number(match[2]) };
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!options.out) throw new Error("--out is required");
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const sourcePath = resolveArtifactPath(options.spec);
+  const outputPath = resolveOutputPath(options.out);
+  const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+  const rendered = renderRoadmapHtml(source, { viewport: options.viewport });
+  writeOutputFileSync(outputPath, rendered.html);
+  console.log(JSON.stringify({
+    path: outputPath,
+    filename: path.basename(outputPath),
+    mime_type: ROADMAP_MIME_TYPE,
+    layout_id: ROADMAP_LAYOUT_ID,
+    schema_version: rendered.spec.schema_version,
+    geometry_version: rendered.geometry.schema_version,
+    renderer_version: ROADMAP_RENDERER_VERSION,
+    editable: true,
+    diagnostics: rendered.diagnostics,
+  }, null, 2));
+}
+
+try {
+  main();
+} catch (error) {
+  const issues = Array.isArray(error?.issues) ? error.issues : [];
+  for (const issue of issues) console.error(`- ${issue}`);
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/box_agent/skills/roadmap/scripts/roadmap_contract_core.js
+++ b/box_agent/skills/roadmap/scripts/roadmap_contract_core.js
@@ -1,0 +1,813 @@
+"use strict";
+
+const crypto = require("crypto");
+
+const ROADMAP_DRAFT_SCHEMA_VERSION = 1;
+const ROADMAP_SPEC_SCHEMA_VERSION = 1;
+const ROADMAP_KIND_DRAFT = "roadmap-draft";
+const ROADMAP_KIND_SPEC = "roadmap-spec";
+const LOW_CONFIDENCE_THRESHOLD = 0.8;
+const MAX_LANES = 8;
+const MAX_ITEMS = 80;
+const MAX_RANGE_DAYS = 184;
+const ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+const PLAIN_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const SOURCE_TYPES = new Set([
+  "natural-language",
+  "table",
+  "image",
+  "roadmap-spec",
+]);
+const ITEM_KINDS = new Set(["bar", "milestone"]);
+const CERTAINTIES = new Set(["confirmed", "tentative"]);
+const PROGRESS_STATES = new Set(["planned", "doing", "done", "blocked"]);
+const GRANULARITIES = new Set(["half-month"]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function unknownFields(value, allowed, fieldPath, issues) {
+  if (!isPlainObject(value)) return;
+  const unknown = Object.keys(value).filter(key => !allowed.has(key));
+  if (unknown.length) issues.push(`${fieldPath}: unknown field(s): ${unknown.join(", ")}`);
+}
+
+function normalizeNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function plainDateToDay(value) {
+  if (!PLAIN_DATE_RE.test(String(value || ""))) return null;
+  const [year, month, day] = String(value).split("-").map(Number);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const date = new Date(timestamp);
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return Math.floor(timestamp / 86400000);
+}
+
+function dayToPlainDate(day) {
+  if (!Number.isInteger(day)) return null;
+  return new Date(day * 86400000).toISOString().slice(0, 10);
+}
+
+function stableId(value, prefix, identityParts) {
+  const supplied = text(value);
+  if (supplied) return supplied;
+  const seed = identityParts.map(part => String(part || "").normalize("NFKC")).join("\u001f");
+  const slug = text(identityParts[0])
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+  const digest = crypto.createHash("sha256").update(seed).digest("hex").slice(0, 10);
+  return `${prefix}-${slug ? `${slug}-` : ""}${digest}`;
+}
+
+function normalizeConfidence(value, fieldPath, issues) {
+  const number = normalizeNumber(value);
+  if (number == null || number < 0 || number > 1) {
+    issues.push(`${fieldPath}: expected number between 0 and 1`);
+    return null;
+  }
+  return number;
+}
+
+function normalizeSource(value, fieldPath, issues) {
+  if (!isPlainObject(value)) {
+    issues.push(`${fieldPath}: expected object`);
+    return null;
+  }
+  unknownFields(
+    value,
+    new Set(["type", "confidence", "field_confidence", "excerpt", "row", "column", "region", "page", "field_path"]),
+    fieldPath,
+    issues
+  );
+  const type = text(value.type);
+  if (!SOURCE_TYPES.has(type)) {
+    issues.push(`${fieldPath}.type: expected one of ${[...SOURCE_TYPES].join(", ")}`);
+  }
+  const confidence = normalizeConfidence(value.confidence, `${fieldPath}.confidence`, issues);
+  const fieldConfidence = {};
+  if (value.field_confidence !== undefined) {
+    if (!isPlainObject(value.field_confidence)) {
+      issues.push(`${fieldPath}.field_confidence: expected object`);
+    } else {
+      Object.entries(value.field_confidence).forEach(([key, entry]) => {
+        const normalized = normalizeConfidence(
+          entry,
+          `${fieldPath}.field_confidence.${key}`,
+          issues
+        );
+        if (normalized != null) fieldConfidence[key] = normalized;
+      });
+    }
+  }
+  const normalized = {
+    type,
+    ...(confidence == null ? {} : { confidence }),
+    ...(Object.keys(fieldConfidence).length ? { field_confidence: fieldConfidence } : {}),
+  };
+  if (value.excerpt !== undefined) {
+    const excerpt = text(value.excerpt);
+    if (!excerpt || Array.from(excerpt).length > 500) {
+      issues.push(`${fieldPath}.excerpt: expected 1-500 characters`);
+    } else normalized.excerpt = excerpt;
+  }
+  if (value.row !== undefined) {
+    if (!Number.isInteger(value.row) || value.row < 1) {
+      issues.push(`${fieldPath}.row: expected positive integer`);
+    } else normalized.row = value.row;
+  }
+  if (value.column !== undefined) {
+    const column = text(value.column);
+    if (!column) issues.push(`${fieldPath}.column: expected non-empty text`);
+    else normalized.column = column;
+  }
+  if (value.page !== undefined) {
+    if (!Number.isInteger(value.page) || value.page < 1) {
+      issues.push(`${fieldPath}.page: expected positive integer`);
+    } else normalized.page = value.page;
+  }
+  if (value.field_path !== undefined) {
+    const fieldPathValue = text(value.field_path);
+    if (!fieldPathValue) issues.push(`${fieldPath}.field_path: expected non-empty text`);
+    else normalized.field_path = fieldPathValue;
+  }
+  if (value.region !== undefined) {
+    const region = value.region;
+    if (
+      !Array.isArray(region)
+      || region.length !== 4
+      || region.some(entry => !Number.isFinite(entry))
+      || region[0] < 0
+      || region[1] < 0
+      || region[2] <= 0
+      || region[3] <= 0
+    ) {
+      issues.push(`${fieldPath}.region: expected [x, y, width, height] with positive size`);
+    } else normalized.region = region.slice();
+  }
+  if (type === "table" && normalized.row === undefined) {
+    issues.push(`${fieldPath}.row: required for table source`);
+  }
+  if (type === "image" && normalized.region === undefined) {
+    issues.push(`${fieldPath}.region: required for image source`);
+  }
+  if (type === "roadmap-spec" && !normalized.field_path) {
+    issues.push(`${fieldPath}.field_path: required for roadmap-spec source`);
+  }
+  return normalized;
+}
+
+function normalizeQuestion(value, fieldPath, issues) {
+  if (!isPlainObject(value)) {
+    issues.push(`${fieldPath}: expected object`);
+    return null;
+  }
+  unknownFields(value, new Set(["field_path", "prompt", "reason"]), fieldPath, issues);
+  const target = text(value.field_path);
+  const prompt = text(value.prompt);
+  const reason = text(value.reason);
+  if (!target) issues.push(`${fieldPath}.field_path: expected non-empty text`);
+  if (!prompt) issues.push(`${fieldPath}.prompt: expected non-empty text`);
+  return target && prompt
+    ? { field_path: target, prompt, ...(reason ? { reason } : {}) }
+    : null;
+}
+
+function validateAndNormalizePendingQuestions(value, fieldPath = "pending_questions") {
+  const issues = [];
+  const pendingQuestions = [];
+  if (!Array.isArray(value)) {
+    issues.push(`${fieldPath}: expected array`);
+  } else {
+    value.forEach((question, index) => {
+      const normalized = normalizeQuestion(question, `${fieldPath}.${index}`, issues);
+      if (normalized) pendingQuestions.push(normalized);
+    });
+  }
+  return { ok: issues.length === 0, pending_questions: pendingQuestions, issues };
+}
+
+function pendingQuestionsForRoadmapSpec(spec, existingQuestions = []) {
+  const result = validateAndNormalizePendingQuestions(existingQuestions);
+  const questions = result.pending_questions.filter(
+    question => !/^items\.\d+\./.test(question.field_path)
+  );
+  if (!isPlainObject(spec) || !Array.isArray(spec.items)) return result;
+  spec.items.forEach((item, index) => {
+    if (!isPlainObject(item) || item.certainty !== "tentative") return;
+    addQuestion(
+      questions,
+      `items.${index}.start`,
+      `请确认“${text(item.title) || "该任务"}”的起止日期。`,
+      [fieldConfidence(item.source, "start"), fieldConfidence(item.source, "end")]
+        .some(confidence => confidence != null && confidence < LOW_CONFIDENCE_THRESHOLD)
+        ? `date confidence is below ${LOW_CONFIDENCE_THRESHOLD}`
+        : "item remains tentative"
+    );
+  });
+  return { ...result, pending_questions: questions };
+}
+
+function normalizeContinuation(value, fieldPath, issues) {
+  if (value === undefined) return null;
+  if (!isPlainObject(value)) {
+    issues.push(`${fieldPath}: expected object`);
+    return null;
+  }
+  unknownFields(value, new Set(["before", "after"]), fieldPath, issues);
+  const normalized = {};
+  for (const key of ["before", "after"]) {
+    if (value[key] === undefined) continue;
+    if (value[key] !== true) issues.push(`${fieldPath}.${key}: expected true when present`);
+    else normalized[key] = true;
+  }
+  if (!Object.keys(normalized).length) {
+    issues.push(`${fieldPath}: expected before=true or after=true`);
+    return null;
+  }
+  return normalized;
+}
+
+function validateAndNormalizeRoadmapDraft(value) {
+  const issues = [];
+  const warnings = [];
+  if (!isPlainObject(value)) {
+    return { ok: false, normalized: null, issues: ["roadmap draft: expected object"], warnings };
+  }
+  unknownFields(
+    value,
+    new Set(["schema_version", "kind", "title", "range", "lanes", "items", "pending_questions"]),
+    "roadmap draft",
+    issues
+  );
+  if (value.schema_version !== ROADMAP_DRAFT_SCHEMA_VERSION) {
+    issues.push(`schema_version: expected ${ROADMAP_DRAFT_SCHEMA_VERSION}`);
+  }
+  if (value.kind !== ROADMAP_KIND_DRAFT) {
+    issues.push(`kind: expected ${ROADMAP_KIND_DRAFT}`);
+  }
+  const title = text(value.title);
+  if (!title) warnings.push("title: missing; compilation requires a roadmap title");
+  else if (Array.from(title).length > 120) issues.push("title: expected at most 120 characters");
+
+  let range = null;
+  if (value.range !== undefined) {
+    if (!isPlainObject(value.range)) {
+      issues.push("range: expected object");
+    } else {
+      unknownFields(value.range, new Set(["start", "end", "granularity"]), "range", issues);
+      const start = text(value.range.start);
+      const end = text(value.range.end);
+      const granularity = text(value.range.granularity) || "half-month";
+      if (start && plainDateToDay(start) == null) issues.push("range.start: expected valid YYYY-MM-DD");
+      if (end && plainDateToDay(end) == null) issues.push("range.end: expected valid YYYY-MM-DD");
+      if (!GRANULARITIES.has(granularity)) {
+        issues.push(`range.granularity: expected one of ${[...GRANULARITIES].join(", ")}`);
+      }
+      range = {
+        ...(start ? { start } : {}),
+        ...(end ? { end } : {}),
+        granularity,
+      };
+    }
+  }
+
+  const lanes = [];
+  if (!Array.isArray(value.lanes)) {
+    issues.push("lanes: expected array");
+  } else {
+    value.lanes.forEach((lane, index) => {
+      const fieldPath = `lanes.${index}`;
+      if (!isPlainObject(lane)) {
+        issues.push(`${fieldPath}: expected object`);
+        return;
+      }
+      unknownFields(lane, new Set(["id", "label", "order", "raw", "source"]), fieldPath, issues);
+      const id = text(lane.id);
+      const label = text(lane.label);
+      if (id && !ID_RE.test(id)) issues.push(`${fieldPath}.id: invalid stable id`);
+      if (!label) issues.push(`${fieldPath}.label: required non-empty text`);
+      else if (Array.from(label).length > 60) issues.push(`${fieldPath}.label: expected at most 60 characters`);
+      const order = lane.order;
+      if (!Number.isInteger(order) || order < 1) issues.push(`${fieldPath}.order: expected positive integer`);
+      if (!isPlainObject(lane.raw)) issues.push(`${fieldPath}.raw: expected object with original fields`);
+      const source = normalizeSource(lane.source, `${fieldPath}.source`, issues);
+      lanes.push({
+        ...(id ? { id } : {}),
+        ...(label ? { label } : {}),
+        order,
+        raw: isPlainObject(lane.raw) ? clone(lane.raw) : {},
+        ...(source ? { source } : {}),
+      });
+    });
+  }
+
+  const items = [];
+  if (!Array.isArray(value.items)) {
+    issues.push("items: expected array");
+  } else {
+    value.items.forEach((item, index) => {
+      const fieldPath = `items.${index}`;
+      if (!isPlainObject(item)) {
+        issues.push(`${fieldPath}: expected object`);
+        return;
+      }
+      unknownFields(
+        item,
+        new Set(["id", "lane_ref", "title", "start", "end", "kind", "certainty", "progress", "continuation", "color", "detail", "raw", "source"]),
+        fieldPath,
+        issues
+      );
+      const id = text(item.id);
+      const laneRef = text(item.lane_ref);
+      const titleValue = text(item.title);
+      const start = text(item.start);
+      const end = text(item.end);
+      const kind = text(item.kind);
+      const certainty = text(item.certainty);
+      const progress = text(item.progress);
+      const continuation = normalizeContinuation(
+        item.continuation,
+        `${fieldPath}.continuation`,
+        issues
+      );
+      const color = text(item.color);
+      const detail = text(item.detail);
+      if (id && !ID_RE.test(id)) issues.push(`${fieldPath}.id: invalid stable id`);
+      if (!laneRef) issues.push(`${fieldPath}.lane_ref: required non-empty text`);
+      if (!titleValue) issues.push(`${fieldPath}.title: required non-empty text`);
+      else if (Array.from(titleValue).length > 100) issues.push(`${fieldPath}.title: expected at most 100 characters`);
+      if (start && plainDateToDay(start) == null) issues.push(`${fieldPath}.start: expected valid YYYY-MM-DD`);
+      if (end && plainDateToDay(end) == null) issues.push(`${fieldPath}.end: expected valid YYYY-MM-DD`);
+      if (!ITEM_KINDS.has(kind)) issues.push(`${fieldPath}.kind: expected bar or milestone`);
+      if (certainty && !CERTAINTIES.has(certainty)) {
+        issues.push(`${fieldPath}.certainty: expected confirmed or tentative`);
+      }
+      if (!PROGRESS_STATES.has(progress)) {
+        issues.push(`${fieldPath}.progress: expected one of ${[...PROGRESS_STATES].join(", ")}`);
+      }
+      if (color && Array.from(color).length > 40) issues.push(`${fieldPath}.color: expected at most 40 characters`);
+      if (detail && Array.from(detail).length > 500) issues.push(`${fieldPath}.detail: expected at most 500 characters`);
+      if (!isPlainObject(item.raw)) issues.push(`${fieldPath}.raw: expected object with original fields`);
+      const source = normalizeSource(item.source, `${fieldPath}.source`, issues);
+      items.push({
+        ...(id ? { id } : {}),
+        ...(laneRef ? { lane_ref: laneRef } : {}),
+        ...(titleValue ? { title: titleValue } : {}),
+        ...(start ? { start } : {}),
+        ...(end ? { end } : {}),
+        kind,
+        ...(certainty ? { certainty } : {}),
+        progress,
+        ...(continuation ? { continuation } : {}),
+        ...(color ? { color } : {}),
+        ...(detail ? { detail } : {}),
+        raw: isPlainObject(item.raw) ? clone(item.raw) : {},
+        ...(source ? { source } : {}),
+      });
+    });
+  }
+
+  let pendingQuestions = [];
+  if (value.pending_questions === undefined) {
+    issues.push("pending_questions: required array");
+  } else {
+    const questionResult = validateAndNormalizePendingQuestions(value.pending_questions);
+    issues.push(...questionResult.issues);
+    pendingQuestions = questionResult.pending_questions;
+  }
+  return {
+    ok: issues.length === 0,
+    normalized: {
+      schema_version: ROADMAP_DRAFT_SCHEMA_VERSION,
+      kind: ROADMAP_KIND_DRAFT,
+      ...(title ? { title } : {}),
+      ...(range ? { range } : {}),
+      lanes,
+      items,
+      pending_questions: pendingQuestions,
+    },
+    issues,
+    warnings,
+  };
+}
+
+function fieldConfidence(source, field) {
+  if (!source) return null;
+  if (source.field_confidence && source.field_confidence[field] !== undefined) {
+    return source.field_confidence[field];
+  }
+  return source.confidence;
+}
+
+function addQuestion(questions, fieldPath, prompt, reason) {
+  if (questions.some(question => question.field_path === fieldPath)) return;
+  questions.push({ field_path: fieldPath, prompt, reason });
+}
+
+function compileRoadmapDraft(value) {
+  const draftResult = validateAndNormalizeRoadmapDraft(value);
+  const issues = draftResult.issues.slice();
+  const warnings = draftResult.warnings.slice();
+  const draft = draftResult.normalized;
+  const questions = draft ? draft.pending_questions.map(clone) : [];
+  if (!draftResult.ok || !draft) {
+    return { ok: false, spec: null, draft, issues, warnings, pending_questions: questions };
+  }
+  if (!draft.title) {
+    issues.push("title: required to compile RoadmapSpec");
+    addQuestion(questions, "title", "这份路线图的标题是什么？", "renderer requires a title");
+  }
+  if (!draft.lanes.length) issues.push("lanes: expected at least one lane");
+  if (draft.lanes.length > MAX_LANES) issues.push(`lanes: expected at most ${MAX_LANES}`);
+  if (!draft.items.length) issues.push("items: expected at least one item");
+  if (draft.items.length > MAX_ITEMS) issues.push(`items: expected at most ${MAX_ITEMS}`);
+
+  const laneIds = new Set();
+  const laneAliases = new Map();
+  const lanes = draft.lanes.map((lane, index) => {
+    if (!lane.label) issues.push(`lanes.${index}.label: required to compile RoadmapSpec`);
+    let id = stableId(lane.id, "lane", [lane.label, lane.order, JSON.stringify(lane.raw)]);
+    if (!ID_RE.test(id)) issues.push(`lanes.${index}.id: invalid stable id`);
+    if (laneIds.has(id)) {
+      id = stableId(null, "lane", [lane.label, lane.order, JSON.stringify(lane.raw), index]);
+    }
+    if (laneIds.has(id)) issues.push(`lanes.${index}.id: duplicate id ${id}`);
+    laneIds.add(id);
+    [lane.id, lane.label, id].filter(Boolean).forEach(alias => laneAliases.set(alias, id));
+    return { id, label: lane.label || "待确认泳道", order: lane.order };
+  });
+
+  const itemIds = new Set();
+  const items = draft.items.map((item, index) => {
+    const fieldPath = `items.${index}`;
+    if (!item.title) issues.push(`${fieldPath}.title: required to compile RoadmapSpec`);
+    const laneId = laneAliases.get(item.lane_ref);
+    if (!laneId) issues.push(`${fieldPath}.lane_ref: unknown lane ${JSON.stringify(item.lane_ref || "")}`);
+    if (!item.start) {
+      issues.push(`${fieldPath}.start: required to compile RoadmapSpec`);
+      addQuestion(questions, `${fieldPath}.start`, `“${item.title || "该任务"}”从哪一天开始？`, "missing date cannot be invented");
+    }
+    if (item.kind === "bar" && !item.end) {
+      issues.push(`${fieldPath}.end: required for bar item`);
+      addQuestion(questions, `${fieldPath}.end`, `“${item.title || "该任务"}”在哪一天结束（结束日不包含）？`, "bar interval uses [start, end)");
+    }
+    const startConfidence = fieldConfidence(item.source, "start");
+    const endConfidence = item.kind === "milestone" ? 1 : fieldConfidence(item.source, "end");
+    const lowDateConfidence = (
+      (startConfidence != null && startConfidence < LOW_CONFIDENCE_THRESHOLD)
+      || (endConfidence != null && endConfidence < LOW_CONFIDENCE_THRESHOLD)
+    );
+    let certainty = item.certainty || (lowDateConfidence ? "tentative" : "confirmed");
+    if (lowDateConfidence && certainty !== "tentative") {
+      certainty = "tentative";
+      warnings.push(`${fieldPath}.certainty: normalized to tentative from low-confidence date source`);
+    }
+    if (lowDateConfidence) {
+      addQuestion(
+        questions,
+        `${fieldPath}.start`,
+        `请确认“${item.title || "该任务"}”的起止日期。`,
+        `date confidence is below ${LOW_CONFIDENCE_THRESHOLD}`
+      );
+    }
+    let id = stableId(item.id, "item", [
+      item.title,
+      item.lane_ref,
+      item.start,
+      item.end,
+      item.kind,
+      JSON.stringify(item.raw),
+    ]);
+    if (itemIds.has(id)) {
+      id = stableId(null, "item", [item.title, item.lane_ref, item.start, item.end, JSON.stringify(item.raw), index]);
+    }
+    if (itemIds.has(id)) issues.push(`${fieldPath}.id: duplicate id ${id}`);
+    itemIds.add(id);
+    return {
+      id,
+      lane_id: laneId || "invalid-lane",
+      title: item.title || "待确认任务",
+      ...(item.start ? { start: item.start } : {}),
+      ...(item.kind === "bar" && item.end ? { end: item.end } : {}),
+      kind: item.kind,
+      certainty,
+      progress: item.progress,
+      ...(item.continuation ? { continuation: clone(item.continuation) } : {}),
+      ...(item.color ? { color: item.color } : {}),
+      ...(item.detail ? { detail: item.detail } : {}),
+      ...(item.source ? { source: clone(item.source) } : {}),
+    };
+  });
+
+  const validStarts = items.map(item => plainDateToDay(item.start)).filter(Number.isInteger);
+  const validEnds = items.map(item => {
+    const startDay = plainDateToDay(item.start);
+    if (item.kind === "milestone") return startDay == null ? null : startDay + 1;
+    return plainDateToDay(item.end);
+  }).filter(Number.isInteger);
+  const rangeStart = draft.range && draft.range.start
+    ? draft.range.start
+    : (validStarts.length ? dayToPlainDate(Math.min(...validStarts)) : null);
+  const rangeEnd = draft.range && draft.range.end
+    ? draft.range.end
+    : (validEnds.length ? dayToPlainDate(Math.max(...validEnds)) : null);
+  if (!rangeStart) issues.push("range.start: missing and cannot be derived from items");
+  if (!rangeEnd) issues.push("range.end: missing and cannot be derived from items");
+
+  if (issues.length) {
+    return { ok: false, spec: null, draft, issues, warnings, pending_questions: questions };
+  }
+  const specCandidate = {
+    schema_version: ROADMAP_SPEC_SCHEMA_VERSION,
+    kind: ROADMAP_KIND_SPEC,
+    title: draft.title,
+    range: {
+      start: rangeStart,
+      end: rangeEnd,
+      granularity: draft.range && draft.range.granularity || "half-month",
+    },
+    lanes,
+    items,
+  };
+  const specResult = validateAndNormalizeRoadmapSpec(specCandidate);
+  return {
+    ok: specResult.ok,
+    spec: specResult.ok ? specResult.normalized : null,
+    draft,
+    issues: specResult.issues,
+    warnings: [...warnings, ...specResult.warnings],
+    pending_questions: questions,
+  };
+}
+
+function validateAndNormalizeRoadmapSpec(value) {
+  const issues = [];
+  const warnings = [];
+  if (!isPlainObject(value)) {
+    return { ok: false, normalized: null, issues: ["RoadmapSpec: expected object"], warnings };
+  }
+  unknownFields(value, new Set(["schema_version", "kind", "title", "range", "lanes", "items", "legend"]), "RoadmapSpec", issues);
+  if (value.schema_version !== ROADMAP_SPEC_SCHEMA_VERSION) {
+    issues.push(`schema_version: expected ${ROADMAP_SPEC_SCHEMA_VERSION}`);
+  }
+  if (value.kind !== ROADMAP_KIND_SPEC) issues.push(`kind: expected ${ROADMAP_KIND_SPEC}`);
+  const title = text(value.title);
+  if (!title || Array.from(title).length > 120) issues.push("title: expected 1-120 characters");
+
+  let range = { start: "", end: "", granularity: "half-month" };
+  if (!isPlainObject(value.range)) {
+    issues.push("range: expected object");
+  } else {
+    unknownFields(value.range, new Set(["start", "end", "granularity"]), "range", issues);
+    const start = text(value.range.start);
+    const end = text(value.range.end);
+    const granularity = text(value.range.granularity);
+    const startDay = plainDateToDay(start);
+    const endDay = plainDateToDay(end);
+    if (startDay == null) issues.push("range.start: expected valid YYYY-MM-DD");
+    if (endDay == null) issues.push("range.end: expected valid YYYY-MM-DD");
+    if (startDay != null && endDay != null) {
+      if (startDay >= endDay) issues.push("range: expected [start, end) with start before end");
+      if (endDay - startDay > MAX_RANGE_DAYS) {
+        issues.push(`range: expected at most ${MAX_RANGE_DAYS} days for one page`);
+      }
+    }
+    if (!GRANULARITIES.has(granularity)) {
+      issues.push(`range.granularity: expected one of ${[...GRANULARITIES].join(", ")}`);
+    }
+    range = { start, end, granularity };
+  }
+
+  const lanes = [];
+  const laneIds = new Set();
+  const laneOrders = new Set();
+  if (!Array.isArray(value.lanes) || !value.lanes.length) {
+    issues.push("lanes: expected 1-8 lanes");
+  } else {
+    if (value.lanes.length > MAX_LANES) issues.push(`lanes: expected at most ${MAX_LANES}`);
+    value.lanes.forEach((lane, index) => {
+      const fieldPath = `lanes.${index}`;
+      if (!isPlainObject(lane)) {
+        issues.push(`${fieldPath}: expected object`);
+        return;
+      }
+      unknownFields(lane, new Set(["id", "label", "order"]), fieldPath, issues);
+      const id = text(lane.id);
+      const label = text(lane.label);
+      const order = lane.order;
+      if (!ID_RE.test(id)) issues.push(`${fieldPath}.id: invalid stable id`);
+      if (laneIds.has(id)) issues.push(`${fieldPath}.id: duplicate id ${id}`);
+      laneIds.add(id);
+      if (!label || Array.from(label).length > 60) issues.push(`${fieldPath}.label: expected 1-60 characters`);
+      if (!Number.isInteger(order) || order < 1) issues.push(`${fieldPath}.order: expected positive integer`);
+      if (laneOrders.has(order)) issues.push(`${fieldPath}.order: duplicate order ${order}`);
+      laneOrders.add(order);
+      lanes.push({ id, label, order });
+    });
+  }
+  lanes.sort((left, right) => left.order - right.order || left.id.localeCompare(right.id));
+  const laneOrder = new Map(lanes.map((lane, index) => [lane.id, index]));
+
+  const items = [];
+  const itemIds = new Set();
+  if (!Array.isArray(value.items) || !value.items.length) {
+    issues.push("items: expected 1-80 items");
+  } else {
+    if (value.items.length > MAX_ITEMS) issues.push(`items: expected at most ${MAX_ITEMS}`);
+    value.items.forEach((item, index) => {
+      const fieldPath = `items.${index}`;
+      if (!isPlainObject(item)) {
+        issues.push(`${fieldPath}: expected object`);
+        return;
+      }
+      unknownFields(
+        item,
+        new Set(["id", "lane_id", "title", "start", "end", "kind", "certainty", "progress", "continuation", "color", "detail", "source"]),
+        fieldPath,
+        issues
+      );
+      const id = text(item.id);
+      const laneId = text(item.lane_id);
+      const titleValue = text(item.title);
+      const start = text(item.start);
+      const end = text(item.end);
+      const kind = text(item.kind);
+      const certainty = text(item.certainty);
+      const progress = text(item.progress);
+      const continuation = normalizeContinuation(
+        item.continuation,
+        `${fieldPath}.continuation`,
+        issues
+      );
+      const color = text(item.color);
+      const detail = text(item.detail);
+      if (!ID_RE.test(id)) issues.push(`${fieldPath}.id: invalid stable id`);
+      if (itemIds.has(id)) issues.push(`${fieldPath}.id: duplicate id ${id}`);
+      itemIds.add(id);
+      if (!laneIds.has(laneId)) issues.push(`${fieldPath}.lane_id: unknown lane ${JSON.stringify(laneId)}`);
+      if (!titleValue || Array.from(titleValue).length > 100) issues.push(`${fieldPath}.title: expected 1-100 characters`);
+      const startDay = plainDateToDay(start);
+      const endDay = plainDateToDay(end);
+      if (startDay == null) issues.push(`${fieldPath}.start: expected valid YYYY-MM-DD`);
+      if (!ITEM_KINDS.has(kind)) issues.push(`${fieldPath}.kind: expected bar or milestone`);
+      if (kind === "bar") {
+        if (endDay == null) issues.push(`${fieldPath}.end: required valid YYYY-MM-DD for bar`);
+        else if (startDay != null && startDay >= endDay) {
+          issues.push(`${fieldPath}: expected [start, end) with start before end`);
+        }
+      } else if (kind === "milestone" && item.end !== undefined) {
+        issues.push(`${fieldPath}.end: milestone uses start only`);
+      }
+      if (continuation && kind !== "bar") {
+        issues.push(`${fieldPath}.continuation: only bar items may continue`);
+      }
+      if (!CERTAINTIES.has(certainty)) issues.push(`${fieldPath}.certainty: expected confirmed or tentative`);
+      if (!PROGRESS_STATES.has(progress)) {
+        issues.push(`${fieldPath}.progress: expected one of ${[...PROGRESS_STATES].join(", ")}`);
+      }
+      if (color && Array.from(color).length > 40) issues.push(`${fieldPath}.color: expected at most 40 characters`);
+      if (detail && Array.from(detail).length > 500) issues.push(`${fieldPath}.detail: expected at most 500 characters`);
+      const source = item.source === undefined
+        ? null
+        : normalizeSource(item.source, `${fieldPath}.source`, issues);
+      const rangeStart = plainDateToDay(range.start);
+      const rangeEnd = plainDateToDay(range.end);
+      const effectiveEnd = kind === "milestone" && startDay != null ? startDay + 1 : endDay;
+      if (
+        startDay != null
+        && effectiveEnd != null
+        && rangeStart != null
+        && rangeEnd != null
+        && (startDay < rangeStart || effectiveEnd > rangeEnd)
+      ) {
+        issues.push(`${fieldPath}: item interval must stay within roadmap range`);
+      }
+      if (continuation && continuation.before && start !== range.start) {
+        issues.push(`${fieldPath}.continuation.before: item must start at range.start`);
+      }
+      if (continuation && continuation.after && end !== range.end) {
+        issues.push(`${fieldPath}.continuation.after: item must end at range.end`);
+      }
+      items.push({
+        id,
+        lane_id: laneId,
+        title: titleValue,
+        start,
+        ...(kind === "bar" ? { end } : {}),
+        kind,
+        certainty,
+        progress,
+        ...(continuation ? { continuation } : {}),
+        ...(color ? { color } : {}),
+        ...(detail ? { detail } : {}),
+        ...(source ? { source } : {}),
+      });
+    });
+  }
+  items.sort((left, right) => {
+    const laneDelta = (laneOrder.get(left.lane_id) ?? Number.MAX_SAFE_INTEGER)
+      - (laneOrder.get(right.lane_id) ?? Number.MAX_SAFE_INTEGER);
+    if (laneDelta) return laneDelta;
+    const startDelta = (plainDateToDay(left.start) ?? 0) - (plainDateToDay(right.start) ?? 0);
+    if (startDelta) return startDelta;
+    const leftEnd = left.kind === "milestone" ? plainDateToDay(left.start) + 1 : plainDateToDay(left.end);
+    const rightEnd = right.kind === "milestone" ? plainDateToDay(right.start) + 1 : plainDateToDay(right.end);
+    return leftEnd - rightEnd || left.id.localeCompare(right.id);
+  });
+
+  let legend;
+  if (value.legend !== undefined) {
+    if (!Array.isArray(value.legend)) issues.push("legend: expected array");
+    else {
+      legend = value.legend.map((entry, index) => {
+        if (!isPlainObject(entry)) {
+          issues.push(`legend.${index}: expected object`);
+          return null;
+        }
+        unknownFields(entry, new Set(["key", "label"]), `legend.${index}`, issues);
+        const label = text(entry.label);
+        const key = text(entry.key);
+        if (!key || !label) issues.push(`legend.${index}: key and label are required`);
+        return key && label ? { key, label } : null;
+      }).filter(Boolean);
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    normalized: {
+      schema_version: ROADMAP_SPEC_SCHEMA_VERSION,
+      kind: ROADMAP_KIND_SPEC,
+      title,
+      range,
+      lanes,
+      items,
+      ...(legend ? { legend } : {}),
+    },
+    issues,
+    warnings,
+  };
+}
+
+function compileRoadmapInput(value) {
+  if (isPlainObject(value) && value.kind === ROADMAP_KIND_SPEC) {
+    const result = validateAndNormalizeRoadmapSpec(value);
+    const questionResult = result.ok
+      ? pendingQuestionsForRoadmapSpec(result.normalized)
+      : { pending_questions: [] };
+    return {
+      ok: result.ok,
+      input_kind: ROADMAP_KIND_SPEC,
+      spec: result.ok ? result.normalized : null,
+      issues: result.issues,
+      warnings: result.warnings,
+      pending_questions: questionResult.pending_questions,
+    };
+  }
+  const result = compileRoadmapDraft(value);
+  return { ...result, input_kind: ROADMAP_KIND_DRAFT };
+}
+
+module.exports = {
+  CERTAINTIES,
+  GRANULARITIES,
+  ITEM_KINDS,
+  LOW_CONFIDENCE_THRESHOLD,
+  MAX_ITEMS,
+  MAX_LANES,
+  MAX_RANGE_DAYS,
+  PROGRESS_STATES,
+  ROADMAP_DRAFT_SCHEMA_VERSION,
+  ROADMAP_KIND_DRAFT,
+  ROADMAP_KIND_SPEC,
+  ROADMAP_SPEC_SCHEMA_VERSION,
+  SOURCE_TYPES,
+  compileRoadmapDraft,
+  compileRoadmapInput,
+  dayToPlainDate,
+  plainDateToDay,
+  pendingQuestionsForRoadmapSpec,
+  validateAndNormalizeRoadmapDraft,
+  validateAndNormalizePendingQuestions,
+  validateAndNormalizeRoadmapSpec,
+};

--- a/box_agent/skills/roadmap/scripts/roadmap_geometry_core.js
+++ b/box_agent/skills/roadmap/scripts/roadmap_geometry_core.js
@@ -1,0 +1,403 @@
+"use strict";
+
+const {
+  dayToPlainDate,
+  plainDateToDay,
+  validateAndNormalizeRoadmapSpec,
+} = require("./roadmap_contract_core.js");
+
+const DEFAULT_VIEWPORT = Object.freeze({ width: 1440, height: 900 });
+const MIN_VIEWPORT = Object.freeze({ width: 640, height: 360 });
+const LAYOUT = Object.freeze({
+  outerPadding: 32,
+  titleHeight: 28,
+  headerHeight: 76,
+  laneLabelWidth: 260,
+  lanePadding: 20,
+  trackHeight: 50,
+  trackGap: 14,
+  barHeight: 46,
+  milestoneSize: 18,
+  minLaneHeight: 124,
+  labelHeight: 46,
+  labelGap: 10,
+  collisionGap: 10,
+  continuationSize: 10,
+});
+
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function normalizeViewport(value) {
+  const width = value && Number.isFinite(value.width) ? value.width : DEFAULT_VIEWPORT.width;
+  const height = value && Number.isFinite(value.height) ? value.height : DEFAULT_VIEWPORT.height;
+  if (width < MIN_VIEWPORT.width || height < MIN_VIEWPORT.height) {
+    throw new Error(
+      `viewport: expected at least ${MIN_VIEWPORT.width}x${MIN_VIEWPORT.height}, got ${width}x${height}`
+    );
+  }
+  return { width: round(width), height: round(height) };
+}
+
+function nextMonthStart(day) {
+  const date = new Date(day * 86400000);
+  return Math.floor(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1) / 86400000);
+}
+
+function monthStart(day) {
+  const date = new Date(day * 86400000);
+  return Math.floor(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1) / 86400000);
+}
+
+function halfMonthBoundaries(startDay, endDay) {
+  const boundaries = new Set([startDay, endDay]);
+  let cursor = monthStart(startDay);
+  while (cursor < endDay) {
+    const date = new Date(cursor * 86400000);
+    const firstHalfEnd = Math.floor(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 16) / 86400000
+    );
+    const next = nextMonthStart(cursor);
+    if (firstHalfEnd > startDay && firstHalfEnd < endDay) boundaries.add(firstHalfEnd);
+    if (next > startDay && next < endDay) boundaries.add(next);
+    cursor = next;
+  }
+  return [...boundaries].sort((left, right) => left - right);
+}
+
+function monthSegments(startDay, endDay) {
+  const segments = [];
+  let cursor = monthStart(startDay);
+  while (cursor < endDay) {
+    const next = nextMonthStart(cursor);
+    const clippedStart = Math.max(startDay, cursor);
+    const clippedEnd = Math.min(endDay, next);
+    if (clippedStart < clippedEnd) {
+      const date = new Date(cursor * 86400000);
+      segments.push({
+        start: clippedStart,
+        end: clippedEnd,
+        label: `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`,
+      });
+    }
+    cursor = next;
+  }
+  return segments;
+}
+
+function estimatedLabelWidth(title) {
+  const width = Array.from(title).reduce(
+    (total, character) => total + (/^[\u0000-\u00ff]$/.test(character) ? 8 : 15),
+    0
+  );
+  return Math.min(260, Math.max(72, width));
+}
+
+function visualBounds(item, options) {
+  const startDay = plainDateToDay(item.start);
+  const endDay = item.kind === "milestone"
+    ? startDay + 1
+    : plainDateToDay(item.end);
+  const startX = options.xForDay(startDay);
+  const endX = options.xForDay(endDay);
+  const labelWidth = estimatedLabelWidth(item.title);
+  if (item.kind === "milestone") {
+    const rightStart = startX + LAYOUT.milestoneSize / 2 + LAYOUT.labelGap;
+    if (rightStart + labelWidth <= options.plotRight) {
+      return {
+        startDay,
+        endDay,
+        labelWidth,
+        labelPlacement: "outside-right",
+        visualStart: startX - LAYOUT.milestoneSize / 2,
+        visualEnd: rightStart + labelWidth,
+      };
+    }
+    const leftEnd = startX - LAYOUT.milestoneSize / 2 - LAYOUT.labelGap;
+    return {
+      startDay,
+      endDay,
+      labelWidth,
+      labelPlacement: "outside-left",
+      visualStart: Math.max(options.plotLeft, leftEnd - labelWidth),
+      visualEnd: startX + LAYOUT.milestoneSize / 2,
+    };
+  }
+  const width = endX - startX;
+  if (width >= labelWidth + LAYOUT.labelGap * 2) {
+    return {
+      startDay,
+      endDay,
+      labelWidth,
+      labelPlacement: "inside",
+      visualStart: startX,
+      visualEnd: endX,
+    };
+  }
+  const rightStart = endX + LAYOUT.labelGap;
+  if (rightStart + labelWidth <= options.plotRight) {
+    return {
+      startDay,
+      endDay,
+      labelWidth,
+      labelPlacement: "outside-right",
+      visualStart: startX,
+      visualEnd: rightStart + labelWidth,
+    };
+  }
+  const leftEnd = startX - LAYOUT.labelGap;
+  return {
+    startDay,
+    endDay,
+    labelWidth,
+    labelPlacement: "outside-left",
+    visualStart: Math.max(options.plotLeft, leftEnd - labelWidth),
+    visualEnd: endX,
+  };
+}
+
+function assignTracks(items, options) {
+  const entries = items.map((item, index) => ({
+    item,
+    index,
+    ...visualBounds(item, options),
+  }));
+  entries.sort((left, right) => (
+    left.visualStart - right.visualStart
+    || left.visualEnd - right.visualEnd
+    || left.item.id.localeCompare(right.item.id)
+  ));
+  const trackEnds = [];
+  entries.forEach(entry => {
+    let track = trackEnds.findIndex(
+      trackEnd => trackEnd + LAYOUT.collisionGap <= entry.visualStart
+    );
+    if (track === -1) {
+      track = trackEnds.length;
+      trackEnds.push(entry.visualEnd);
+    } else {
+      trackEnds[track] = entry.visualEnd;
+    }
+    entry.track = track;
+  });
+  return entries.sort((left, right) => left.index - right.index);
+}
+
+function layoutRoadmap(value, viewportValue = DEFAULT_VIEWPORT) {
+  const validation = validateAndNormalizeRoadmapSpec(value);
+  if (!validation.ok) {
+    throw new Error(`RoadmapSpec invalid:\n${validation.issues.join("\n")}`);
+  }
+  const spec = validation.normalized;
+  const viewport = normalizeViewport(viewportValue);
+  const rangeStart = plainDateToDay(spec.range.start);
+  const rangeEnd = plainDateToDay(spec.range.end);
+  const rangeDays = rangeEnd - rangeStart;
+  const plotLeft = LAYOUT.outerPadding + LAYOUT.laneLabelWidth;
+  const plotRight = viewport.width - LAYOUT.outerPadding;
+  const plotWidth = plotRight - plotLeft;
+  const headerTop = LAYOUT.outerPadding + LAYOUT.titleHeight;
+  const laneTop = headerTop + LAYOUT.headerHeight;
+  const xForDay = day => round(plotLeft + ((day - rangeStart) / rangeDays) * plotWidth);
+
+  const itemsByLane = new Map(spec.lanes.map(lane => [lane.id, []]));
+  spec.items.forEach(item => itemsByLane.get(item.lane_id).push(item));
+  const laneTrackRecords = spec.lanes.map(lane => {
+    const assigned = assignTracks(itemsByLane.get(lane.id), {
+      plotLeft,
+      plotRight,
+      xForDay,
+    });
+    const trackCount = Math.max(1, ...assigned.map(entry => entry.track + 1));
+    const contentHeight = (trackCount * LAYOUT.trackHeight)
+      + ((trackCount - 1) * LAYOUT.trackGap)
+      + (LAYOUT.lanePadding * 2);
+    return {
+      lane,
+      assigned,
+      trackCount,
+      height: Math.max(LAYOUT.minLaneHeight, contentHeight),
+    };
+  });
+  const requiredHeight = laneTop
+    + laneTrackRecords.reduce((sum, record) => sum + record.height, 0)
+    + LAYOUT.outerPadding;
+  const canvasHeight = Math.max(MIN_VIEWPORT.height, requiredHeight);
+
+  const headers = [];
+  monthSegments(rangeStart, rangeEnd).forEach((segment, index) => {
+    headers.push({
+      id: `month-${index + 1}`,
+      kind: "month",
+      label: segment.label,
+      start: dayToPlainDate(segment.start),
+      end: dayToPlainDate(segment.end),
+      x: xForDay(segment.start),
+      y: round(headerTop),
+      width: round(xForDay(segment.end) - xForDay(segment.start)),
+      height: round(LAYOUT.headerHeight / 2),
+    });
+  });
+  const halfBoundaries = halfMonthBoundaries(rangeStart, rangeEnd);
+  halfBoundaries.slice(0, -1).forEach((startDay, index) => {
+    const endDay = halfBoundaries[index + 1];
+    const date = new Date(startDay * 86400000);
+    headers.push({
+      id: `half-month-${index + 1}`,
+      kind: "half-month",
+      label: date.getUTCDate() <= 15 ? "上半月" : "下半月",
+      start: dayToPlainDate(startDay),
+      end: dayToPlainDate(endDay),
+      x: xForDay(startDay),
+      y: round(headerTop + LAYOUT.headerHeight / 2),
+      width: round(xForDay(endDay) - xForDay(startDay)),
+      height: round(LAYOUT.headerHeight / 2),
+    });
+  });
+
+  const lanes = [];
+  const bars = [];
+  const milestones = [];
+  const labels = [];
+  const continuations = [];
+  let currentY = laneTop;
+  laneTrackRecords.forEach(record => {
+    const laneY = currentY;
+    lanes.push({
+      id: record.lane.id,
+      label: record.lane.label,
+      order: record.lane.order,
+      x: round(LAYOUT.outerPadding),
+      y: round(laneY),
+      width: round(viewport.width - LAYOUT.outerPadding * 2),
+      height: round(record.height),
+      track_count: record.trackCount,
+    });
+    record.assigned.forEach(entry => {
+      const trackY = laneY
+        + LAYOUT.lanePadding
+        + entry.track * (LAYOUT.trackHeight + LAYOUT.trackGap);
+      const startX = xForDay(entry.startDay);
+      const endX = xForDay(entry.endDay);
+      if (entry.item.kind === "milestone") {
+        const x = startX;
+        milestones.push({
+          id: entry.item.id,
+          lane_id: record.lane.id,
+          title: entry.item.title,
+          date: entry.item.start,
+          track: entry.track,
+          x,
+          y: round(trackY + LAYOUT.barHeight / 2),
+          size: LAYOUT.milestoneSize,
+          certainty: entry.item.certainty,
+          progress: entry.item.progress,
+          line_style: entry.item.certainty === "tentative" ? "dashed" : "solid",
+          ...(entry.item.color ? { color: entry.item.color } : {}),
+        });
+        const labelOnLeft = entry.labelPlacement === "outside-left";
+        const preferredX = labelOnLeft
+          ? x - LAYOUT.milestoneSize / 2 - LAYOUT.labelGap - entry.labelWidth
+          : x + LAYOUT.milestoneSize / 2 + LAYOUT.labelGap;
+        labels.push({
+          id: `label-${entry.item.id}`,
+          item_id: entry.item.id,
+          lane_id: record.lane.id,
+          text: entry.item.title,
+          placement: entry.labelPlacement,
+          x: round(clamp(preferredX, plotLeft + 4, plotRight - entry.labelWidth - 4)),
+          y: round(trackY),
+          width: round(entry.labelWidth),
+          height: LAYOUT.labelHeight,
+        });
+        return;
+      }
+      const width = round(endX - startX);
+      const placement = entry.labelPlacement;
+      bars.push({
+        id: entry.item.id,
+        lane_id: record.lane.id,
+        title: entry.item.title,
+        start: entry.item.start,
+        end: entry.item.end,
+        track: entry.track,
+        x: startX,
+        y: round(trackY),
+        width,
+        height: LAYOUT.barHeight,
+        certainty: entry.item.certainty,
+        progress: entry.item.progress,
+        line_style: entry.item.certainty === "tentative" ? "dashed" : "solid",
+        ...(entry.item.color ? { color: entry.item.color } : {}),
+      });
+      const labelX = placement === "inside"
+        ? startX + LAYOUT.labelGap
+        : placement === "outside-left"
+          ? startX - LAYOUT.labelGap - entry.labelWidth
+          : endX + LAYOUT.labelGap;
+      const renderedLabelWidth = placement === "inside"
+        ? Math.max(0, width - LAYOUT.labelGap * 2)
+        : entry.labelWidth;
+      labels.push({
+        id: `label-${entry.item.id}`,
+        item_id: entry.item.id,
+        lane_id: record.lane.id,
+        text: entry.item.title,
+        placement,
+        x: round(clamp(labelX, plotLeft + 4, plotRight - renderedLabelWidth - 4)),
+        y: round(trackY),
+        width: round(renderedLabelWidth),
+        height: LAYOUT.labelHeight,
+      });
+      for (const direction of ["before", "after"]) {
+        if (!entry.item.continuation || entry.item.continuation[direction] !== true) continue;
+        continuations.push({
+          id: `continuation-${entry.item.id}-${direction}`,
+          item_id: entry.item.id,
+          lane_id: record.lane.id,
+          direction,
+          x: direction === "before" ? round(plotLeft) : round(plotRight),
+          y: round(trackY + LAYOUT.barHeight / 2),
+          size: LAYOUT.continuationSize,
+        });
+      }
+    });
+    currentY += record.height;
+  });
+
+  return {
+    schema_version: 1,
+    kind: "roadmap-geometry",
+    source_schema_version: spec.schema_version,
+    canvas: {
+      width: viewport.width,
+      height: round(canvasHeight),
+      plot_left: round(plotLeft),
+      plot_right: round(plotRight),
+      header_top: round(headerTop),
+      header_height: LAYOUT.headerHeight,
+    },
+    headers,
+    lanes,
+    bars,
+    milestones,
+    labels,
+    continuations,
+  };
+}
+
+module.exports = {
+  DEFAULT_VIEWPORT,
+  LAYOUT,
+  assignTracks,
+  estimatedLabelWidth,
+  halfMonthBoundaries,
+  layoutRoadmap,
+  monthSegments,
+  normalizeViewport,
+};

--- a/box_agent/skills/roadmap/scripts/roadmap_html_core.js
+++ b/box_agent/skills/roadmap/scripts/roadmap_html_core.js
@@ -1,0 +1,293 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const {
+  pendingQuestionsForRoadmapSpec,
+  validateAndNormalizeRoadmapSpec,
+} = require("./roadmap_contract_core.js");
+const { layoutRoadmap } = require("./roadmap_geometry_core.js");
+
+const ROADMAP_LAYOUT_ID = "roadmap-swimlane-v1";
+const ROADMAP_RENDERER_VERSION = 1;
+const ROADMAP_MIME_TYPE = "text/html";
+const ROADMAP_GENERATOR = "Box Agent Roadmap Artifact v1";
+const SKILL_ROOT = path.resolve(__dirname, "..");
+
+function loadDefaultPalette() {
+  const registryPath = path.join(SKILL_ROOT, "runtime", "registry.json");
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+  const palette = Array.isArray(registry.palettes)
+    ? registry.palettes.find(entry => entry?.id === registry.default_palette_id)
+    : null;
+  if (!palette || !Array.isArray(palette.colors) || palette.colors.length < 8) {
+    throw new Error("Roadmap runtime registry is missing a valid default palette");
+  }
+  return Object.freeze({
+    id: registry.default_palette_id,
+    colors: Object.freeze([...palette.colors]),
+  });
+}
+
+const ROADMAP_DEFAULT_PALETTE = loadDefaultPalette();
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function safeJson(value) {
+  return JSON.stringify(value, null, 2)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function safeInlineScript(value) {
+  return String(value).replace(/<\/script/gi, "<\\/script");
+}
+
+function cssColor(value, fallback = "var(--roadmap-primary)") {
+  const normalized = String(value || "").trim();
+  if (/^#[0-9a-f]{3,8}$/i.test(normalized)) return normalized;
+  if (/^(?:rgb|hsl)a?\([0-9.,%\s]+\)$/i.test(normalized)) return normalized;
+  return fallback;
+}
+
+function px(value) {
+  const number = Number(value);
+  return `${Number.isFinite(number) ? number : 0}px`;
+}
+
+function styleBox(entry) {
+  return `left:${px(entry.x)};top:${px(entry.y)};width:${px(entry.width)};height:${px(entry.height)}`;
+}
+
+function progressRatio(progress) {
+  return { planned: 0, doing: 0.55, done: 1, blocked: 1 }[progress] ?? 0;
+}
+
+function progressLabel(progress) {
+  return { planned: "计划中", doing: "进行中", done: "已完成", blocked: "受阻" }[progress] || progress;
+}
+
+function laneAccent(index) {
+  return ROADMAP_DEFAULT_PALETTE.colors[index % ROADMAP_DEFAULT_PALETTE.colors.length];
+}
+
+function compactHeaderLabel(header) {
+  if (header.kind !== "half-month" || header.width >= 56) return header.label;
+  return header.label.startsWith("上") ? "上" : "下";
+}
+
+function buildDiagnostics(spec, geometry) {
+  const diagnostics = [];
+  if (spec.items.length >= 80) {
+    diagnostics.push({
+      code: "capacity.items-at-limit",
+      severity: "warning",
+      message: "任务数量已达到 80 条上限；建议拆分为多个 Roadmap Artifact。",
+    });
+  } else if (spec.items.length >= 30) {
+    diagnostics.push({
+      code: "capacity.dense",
+      severity: "warning",
+      message: `当前包含 ${spec.items.length} 条任务，已启用可滚动的密集视图。`,
+    });
+  }
+  if (geometry.canvas.height > 900) {
+    diagnostics.push({
+      code: "layout.vertical-scroll",
+      severity: "warning",
+      message: `内容高度为 ${Math.round(geometry.canvas.height)}px，预览将使用纵向滚动。`,
+    });
+  }
+  return diagnostics;
+}
+
+function renderGeometryMarkup(spec, geometry) {
+  const laneById = new Map(spec.lanes.map(lane => [lane.id, lane]));
+  const laneIndexById = new Map(spec.lanes.map((lane, index) => [lane.id, index]));
+  const itemById = new Map(spec.items.map(item => [item.id, item]));
+  const headers = geometry.headers.map(header => (
+    `<div class="roadmap-header" data-kind="${escapeHtml(header.kind)}" title="${escapeHtml(header.label)}" style="${styleBox(header)}">${escapeHtml(compactHeaderLabel(header))}</div>`
+  ));
+  const lanes = geometry.lanes.map((lane, index) => (
+    `<div class="roadmap-lane" data-lane-id="${escapeHtml(lane.id)}" style="${styleBox(lane)};--roadmap-lane-accent:${laneAccent(index)}"><div class="roadmap-lane-label" title="${escapeHtml(laneById.get(lane.id)?.label || lane.label)}"><span class="roadmap-lane-index">${String(index + 1).padStart(2, "0")}</span><span class="roadmap-lane-title">${escapeHtml(lane.label)}</span></div></div>`
+  ));
+  const bars = geometry.bars.map(bar => {
+    const item = itemById.get(bar.id) || bar;
+    const color = cssColor(item.color, laneAccent(laneIndexById.get(bar.lane_id) || 0));
+    return `<div class="roadmap-bar" data-item-id="${escapeHtml(bar.id)}" data-line-style="${escapeHtml(bar.line_style)}" data-progress="${escapeHtml(item.progress)}" title="${escapeHtml(`${bar.title} · ${bar.start} → ${bar.end} · ${progressLabel(item.progress)}`)}" style="${styleBox(bar)};--roadmap-item-accent:${color}"><div class="roadmap-bar-progress" style="width:${progressRatio(item.progress) * 100}%"></div></div>`;
+  });
+  const milestones = geometry.milestones.map(marker => {
+    const item = itemById.get(marker.id) || marker;
+    const color = cssColor(item.color, laneAccent(laneIndexById.get(marker.lane_id) || 0));
+    return `<div class="roadmap-milestone" data-item-id="${escapeHtml(marker.id)}" data-line-style="${escapeHtml(marker.line_style)}" title="${escapeHtml(`${marker.title} · ${marker.date}`)}" style="left:${px(marker.x - marker.size / 2)};top:${px(marker.y - marker.size / 2)};width:${px(marker.size)};height:${px(marker.size)};--roadmap-item-accent:${color}"></div>`;
+  });
+  const labels = geometry.labels.map(label => (
+    `<div class="roadmap-label" data-item-id="${escapeHtml(label.item_id)}" data-placement="${escapeHtml(label.placement)}" title="${escapeHtml(label.text)}" style="${styleBox(label)}">${escapeHtml(label.text)}</div>`
+  ));
+  const continuations = geometry.continuations.map(marker => (
+    `<div class="roadmap-continuation" aria-label="${marker.direction === "before" ? "开始前仍在继续" : "结束后仍将继续"}" style="left:${px(marker.x - marker.size)};top:${px(marker.y - marker.size)}">${marker.direction === "before" ? "‹" : "›"}</div>`
+  ));
+  const halfMonthHeaders = geometry.headers.filter(header => header.kind === "half-month");
+  const gridLineXs = [...new Set([
+    ...halfMonthHeaders.map(header => header.x),
+    ...halfMonthHeaders.map(header => header.x + header.width),
+  ].map(round => Number(round.toFixed(3))))];
+  const laneTop = geometry.canvas.header_top + geometry.canvas.header_height;
+  const laneBottom = geometry.lanes.reduce((bottom, lane) => Math.max(bottom, lane.y + lane.height), laneTop);
+  const gridLines = gridLineXs.map(x => (
+    `<div class="roadmap-grid-line" style="left:${px(x)};top:${px(laneTop)};height:${px(laneBottom - laneTop)}"></div>`
+  ));
+  const legend = (spec.legend || []).map(entry => `<span>${escapeHtml(entry.label)}</span>`);
+  return [
+    `<div class="roadmap-axis-label" style="left:${px(geometry.lanes[0]?.x || 0)};top:${px(geometry.canvas.header_top)};width:${px(geometry.canvas.plot_left - (geometry.lanes[0]?.x || 0))};height:${px(geometry.canvas.header_height)}"><span>阶段</span><small>团队泳道</small></div>`,
+    ...headers,
+    ...lanes,
+    ...gridLines,
+    ...bars,
+    ...milestones,
+    ...labels,
+    ...continuations,
+    legend.length ? `<div class="roadmap-legend">${legend.join("")}</div>` : "",
+  ].join("\n");
+}
+
+function runtimeModule(source, name, requireBody = "") {
+  return [
+    `(function(){const module={exports:{}};const exports=module.exports;${requireBody}`,
+    safeInlineScript(source),
+    `;window.${name}=module.exports;})();`,
+  ].join("\n");
+}
+
+function renderRoadmapHtml(source, options = {}) {
+  const result = validateAndNormalizeRoadmapSpec(source);
+  if (!result.ok) {
+    const error = new Error(`Roadmap spec validation failed with ${result.issues.length} issue(s)`);
+    error.issues = result.issues;
+    throw error;
+  }
+  const spec = result.normalized;
+  const questionResult = pendingQuestionsForRoadmapSpec(
+    spec,
+    options.pendingQuestions || []
+  );
+  if (!questionResult.ok) {
+    const error = new Error(`Roadmap pending question validation failed with ${questionResult.issues.length} issue(s)`);
+    error.issues = questionResult.issues;
+    throw error;
+  }
+  const pendingQuestions = questionResult.pending_questions;
+  const viewport = options.viewport || { width: 1440, height: 900 };
+  const generationVersion = Number.isInteger(options.generationVersion) && options.generationVersion > 0
+    ? options.generationVersion
+    : null;
+  const geometry = layoutRoadmap(spec, viewport);
+  const diagnostics = [...result.warnings.map(message => ({
+    code: "contract.warning",
+    severity: "warning",
+    message,
+  })), ...buildDiagnostics(spec, geometry)];
+  const runtimeCss = fs.readFileSync(path.join(SKILL_ROOT, "runtime", "roadmap.css"), "utf8");
+  const editorJs = fs.readFileSync(path.join(SKILL_ROOT, "runtime", "roadmap-editor.js"), "utf8");
+  const contractJs = fs.readFileSync(path.join(__dirname, "roadmap_contract_core.js"), "utf8");
+  const geometryJs = fs.readFileSync(path.join(__dirname, "roadmap_geometry_core.js"), "utf8");
+  const contractModule = runtimeModule(
+    contractJs,
+    "__roadmapContractCore",
+    'const require=(request)=>{if(request==="crypto")return {createHash:()=>{throw new Error("crypto hashing is unavailable in the Roadmap editor runtime")}};throw new Error(`Unsupported runtime module: ${request}`);};'
+  );
+  const geometryModule = runtimeModule(
+    geometryJs,
+    "__roadmapGeometryCore",
+    'const require=(request)=>{if(request==="./roadmap_contract_core.js")return window.__roadmapContractCore;throw new Error(`Unsupported runtime module: ${request}`);};'
+  );
+  const html = [
+    "<!doctype html>",
+    '<html lang="zh-CN">',
+    "<head>",
+    '  <meta charset="utf-8" />',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `  <meta name="generator" content="${ROADMAP_GENERATOR}" />`,
+    `  <meta name="box-agent-artifact-layout-id" content="${ROADMAP_LAYOUT_ID}" />`,
+    `  <meta name="box-agent-artifact-version" content="${ROADMAP_RENDERER_VERSION}" />`,
+    ...(generationVersion
+      ? [`  <meta name="box-agent-roadmap-generation-version" content="${generationVersion}" />`]
+      : []),
+    `  <title>${escapeHtml(spec.title)} · 路线图</title>`,
+    "  <style>",
+    runtimeCss,
+    "  </style>",
+    "</head>",
+    `<body data-artifact-kind="roadmap" data-layout-id="${ROADMAP_LAYOUT_ID}" data-palette-id="${ROADMAP_DEFAULT_PALETTE.id}"${generationVersion ? ` data-generation-version="${generationVersion}"` : ""} data-schema-version="1" data-geometry-version="1" data-renderer-version="1">`,
+    '  <main class="roadmap-app">',
+    '    <header class="roadmap-toolbar">',
+    '      <div class="roadmap-heading"><h1 data-role="roadmap-title"></h1><p>路线图 · 双层月份刻度 · 泳道排期</p></div>',
+    '      <div class="roadmap-actions" data-role="roadmap-actions" hidden>',
+    '        <button class="roadmap-button" type="button" data-action="adjust" disabled title="当前运行时未声明 Roadmap 编辑能力">调整</button>',
+    '        <button class="roadmap-button" data-primary="true" type="button" data-action="save" disabled>保存</button>',
+    "      </div>",
+    "    </header>",
+    `    <aside class="roadmap-diagnostics" data-role="diagnostics"${diagnostics.length ? "" : " hidden"}>${diagnostics.map(entry => escapeHtml(entry.message)).join("；")}</aside>`,
+    `    <div class="roadmap-stage-shell" data-role="stage-shell" style="height:${px(geometry.canvas.height)}">`,
+    `      <div class="roadmap-stage" data-role="stage" style="width:${px(geometry.canvas.width)};height:${px(geometry.canvas.height)}">`,
+    renderGeometryMarkup(spec, geometry),
+    "      </div>",
+    "    </div>",
+    "  </main>",
+    '  <div class="roadmap-editor-backdrop" data-role="editor-backdrop" hidden></div>',
+    '  <aside class="roadmap-editor" data-role="editor" role="dialog" aria-modal="true" aria-label="路线图调整" hidden></aside>',
+    '  <div class="roadmap-toast" data-role="toast" role="status" aria-live="polite" hidden></div>',
+    '  <script type="application/json" id="deck-document">',
+    safeJson(spec),
+    "  </script>",
+    '  <script type="application/json" id="roadmap-geometry">',
+    safeJson(geometry),
+    "  </script>",
+    '  <script type="application/json" id="roadmap-diagnostics">',
+    safeJson(diagnostics),
+    "  </script>",
+    '  <script type="application/json" id="roadmap-pending-questions">',
+    safeJson(pendingQuestions),
+    "  </script>",
+    '  <script type="application/json" id="roadmap-palette">',
+    safeJson(ROADMAP_DEFAULT_PALETTE),
+    "  </script>",
+    '  <script type="application/json" id="roadmap-editor-metadata">',
+    safeJson({ mode: "form-table", source_element_id: "deck-document", layout_id: ROADMAP_LAYOUT_ID, palette_id: ROADMAP_DEFAULT_PALETTE.id }),
+    "  </script>",
+    '  <script data-roadmap-runtime="contract-core">',
+    contractModule,
+    "  </script>",
+    '  <script data-roadmap-runtime="geometry-core">',
+    geometryModule,
+    "  </script>",
+    '  <script data-roadmap-runtime="editor">',
+    safeInlineScript(editorJs),
+    "  </script>",
+    "</body>",
+    "</html>",
+    "",
+  ].join("\n");
+  return { html, spec, geometry, diagnostics, pendingQuestions };
+}
+
+module.exports = {
+  ROADMAP_GENERATOR,
+  ROADMAP_DEFAULT_PALETTE,
+  ROADMAP_LAYOUT_ID,
+  ROADMAP_MIME_TYPE,
+  ROADMAP_RENDERER_VERSION,
+  buildDiagnostics,
+  escapeHtml,
+  renderRoadmapHtml,
+  safeJson,
+};

--- a/box_agent/skills/roadmap/scripts/roadmap_io.js
+++ b/box_agent/skills/roadmap/scripts/roadmap_io.js
@@ -15,6 +15,11 @@ function artifactRoot() {
   return configured ? path.resolve(configured) : process.cwd();
 }
 
+function scratchRoot() {
+  const configured = String(process.env.BOX_AGENT_SCRATCH_DIR || "").trim();
+  return configured ? path.resolve(configured) : null;
+}
+
 function resolveArtifactPath(filePath) {
   if (path.isAbsolute(filePath)) return path.resolve(filePath);
   return path.resolve(artifactRoot(), filePath);
@@ -130,18 +135,19 @@ function removePublishedFileOnBoundaryFailure(resolved, publishedIdentity, bound
   }
 }
 
-function snapshotArtifactFileSync(filePath) {
-  const resolved = resolveArtifactPath(filePath);
-  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
-  const root = configured ? artifactRoot() : path.parse(resolved).root;
-
-  if (configured && !isWithin(root, resolved)) {
+function snapshotFileWithinRootSync(filePath, root, boundaryName) {
+  const resolved = path.resolve(filePath);
+  if (!isWithin(root, resolved)) {
     throw outputPathError(
-      "consumed input must stay within BOX_AGENT_OUTPUT_DIR",
+      `consumed input must stay within ${boundaryName}`,
       filePath,
     );
   }
 
+  const rootStats = rejectLink(root, filePath, "input");
+  if (rootStats === null || !rootStats.isDirectory()) {
+    throw outputPathError("consumed input root must be a real directory", filePath);
+  }
   let current = root;
   let targetStats = null;
   const segments = path.relative(root, resolved).split(path.sep).filter(Boolean);
@@ -166,19 +172,59 @@ function snapshotArtifactFileSync(filePath) {
     throw outputPathError("consumed input must be a regular file", filePath);
   }
 
-  if (configured) {
-    const realRoot = fs.realpathSync(root);
-    if (!isWithin(realRoot, fs.realpathSync(resolved))) {
-      throw outputPathError(
-        "consumed input resolves outside BOX_AGENT_OUTPUT_DIR",
-        filePath,
-      );
-    }
+  const realRoot = fs.realpathSync(root);
+  if (!isWithin(realRoot, fs.realpathSync(resolved))) {
+    throw outputPathError(
+      `consumed input resolves outside ${boundaryName}`,
+      filePath,
+    );
   }
   return {
     path: resolved,
     identity: artifactFileIdentity(targetStats),
+    rootIdentity: artifactFileIdentity(rootStats),
   };
+}
+
+function snapshotArtifactFileSync(filePath) {
+  const resolved = resolveArtifactPath(filePath);
+  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
+  const root = configured ? artifactRoot() : path.parse(resolved).root;
+  return snapshotFileWithinRootSync(
+    resolved,
+    root,
+    configured ? "BOX_AGENT_OUTPUT_DIR" : "filesystem root",
+  );
+}
+
+function snapshotConsumedInputFileSync(filePath) {
+  const resolved = path.resolve(filePath);
+  const scratch = scratchRoot();
+  if (scratch !== null) {
+    const segments = path.relative(scratch, resolved).split(path.sep).filter(Boolean);
+    if (segments.length < 2) {
+      throw outputPathError(
+        "consumed input must stay in a task directory within BOX_AGENT_SCRATCH_DIR",
+        filePath,
+      );
+    }
+    const snapshot = snapshotFileWithinRootSync(
+      resolved,
+      scratch,
+      "BOX_AGENT_SCRATCH_DIR",
+    );
+    const taskDirectory = path.join(scratch, segments[0]);
+    const taskStats = rejectLink(taskDirectory, filePath, "input");
+    if (taskStats === null || !taskStats.isDirectory()) {
+      throw outputPathError("scratch task path must be a directory", filePath);
+    }
+    return {
+      ...snapshot,
+      taskDirectory,
+      taskDirectoryIdentity: artifactFileIdentity(taskStats),
+    };
+  }
+  return snapshotArtifactFileSync(resolved);
 }
 
 function consumeArtifactFileSync(filePath, expectedIdentity) {
@@ -187,6 +233,62 @@ function consumeArtifactFileSync(filePath, expectedIdentity) {
     throw outputPathError("consumed input changed before deletion", filePath);
   }
   fs.unlinkSync(current.path);
+}
+
+function consumeScratchInputFileSync(filePath, expectedSnapshot) {
+  const current = snapshotConsumedInputFileSync(filePath);
+  if (
+    expectedSnapshot.rootIdentity
+    && !sameArtifactInode(current.rootIdentity, expectedSnapshot.rootIdentity)
+  ) {
+    throw outputPathError("scratch root changed before deletion", filePath);
+  }
+  if (
+    expectedSnapshot.taskDirectoryIdentity
+    && !sameArtifactInode(
+      current.taskDirectoryIdentity,
+      expectedSnapshot.taskDirectoryIdentity,
+    )
+  ) {
+    throw outputPathError("scratch task directory changed before deletion", filePath);
+  }
+  if (!sameArtifactFileIdentity(current.identity, expectedSnapshot.identity)) {
+    throw outputPathError("consumed input changed before deletion", filePath);
+  }
+  fs.unlinkSync(current.path);
+}
+
+function cleanupScratchTaskDirectorySync(filePath, expectedSnapshot = null) {
+  const scratch = scratchRoot();
+  if (scratch === null) return;
+  const resolved = path.resolve(filePath);
+  if (!isWithin(scratch, resolved)) return;
+  const segments = path.relative(scratch, resolved).split(path.sep).filter(Boolean);
+  if (segments.length < 2) return;
+
+  const rootStats = rejectLink(scratch, filePath, "input");
+  if (rootStats === null || !rootStats.isDirectory()) {
+    throw outputPathError("consumed input root must be a real directory", filePath);
+  }
+  const taskDir = path.join(scratch, segments[0]);
+  const taskStats = rejectLink(taskDir, filePath, "input");
+  if (taskStats === null) return;
+  if (!taskStats.isDirectory()) {
+    throw outputPathError("scratch task path must be a directory", filePath);
+  }
+  if (
+    expectedSnapshot?.rootIdentity
+    && !sameArtifactInode(rootStats, expectedSnapshot.rootIdentity)
+  ) {
+    throw outputPathError("scratch root changed before cleanup", filePath);
+  }
+  if (
+    expectedSnapshot?.taskDirectoryIdentity
+    && !sameArtifactInode(taskStats, expectedSnapshot.taskDirectoryIdentity)
+  ) {
+    throw outputPathError("scratch task directory changed before cleanup", filePath);
+  }
+  fs.rmSync(taskDir, { recursive: true });
 }
 
 function prepareOutputPath(filePath) {
@@ -323,9 +425,12 @@ function resolveOutputPath(filePath) {
 
 module.exports = {
   artifactRoot,
+  cleanupScratchTaskDirectorySync,
   consumeArtifactFileSync,
+  consumeScratchInputFileSync,
   resolveArtifactPath,
   resolveOutputPath,
+  snapshotConsumedInputFileSync,
   snapshotArtifactFileSync,
   writeOutputFileSync,
 };

--- a/box_agent/skills/roadmap/scripts/roadmap_io.js
+++ b/box_agent/skills/roadmap/scripts/roadmap_io.js
@@ -1,0 +1,331 @@
+"use strict";
+
+// BOX_AGENT_OUTPUT_DIR is a host-owned path boundary. Roadmap writers reject
+// traversal, links/reparse points, and directory-identity changes before and
+// after publication. A separate process running with the same OS identity can
+// already mutate host-owned files directly; callers must not intentionally
+// replace the output-root topology while a synchronous write is in progress.
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+function artifactRoot() {
+  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
+  return configured ? path.resolve(configured) : process.cwd();
+}
+
+function resolveArtifactPath(filePath) {
+  if (path.isAbsolute(filePath)) return path.resolve(filePath);
+  return path.resolve(artifactRoot(), filePath);
+}
+
+function isWithin(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (
+    !relative.startsWith(`..${path.sep}`)
+    && relative !== ".."
+    && !path.isAbsolute(relative)
+  );
+}
+
+function isMissing(error) {
+  return error && error.code === "ENOENT";
+}
+
+function outputPathError(message, filePath) {
+  return new Error(`${message}: ${filePath}`);
+}
+
+function rejectLink(filePath, displayPath, pathKind = "output") {
+  let stats;
+  try {
+    stats = fs.lstatSync(filePath);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+  if (stats.isSymbolicLink()) {
+    throw outputPathError(
+      `${pathKind} path must not contain a symlink or reparse point`,
+      displayPath,
+    );
+  }
+  return stats;
+}
+
+function artifactFileIdentity(stats) {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    ctimeMs: stats.ctimeMs,
+  };
+}
+
+function sameArtifactFileIdentity(left, right) {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+function sameArtifactInode(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function snapshotOutputDirectoryChain(resolved, displayPath) {
+  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
+  if (!configured) return null;
+  const root = artifactRoot();
+  const parent = path.dirname(resolved);
+  const paths = [root];
+  let current = root;
+  for (const segment of path.relative(root, parent).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    paths.push(current);
+  }
+  return paths.map((directory) => {
+    const stats = rejectLink(directory, displayPath);
+    if (stats === null || !stats.isDirectory()) {
+      throw outputPathError("output parent path must be a directory", displayPath);
+    }
+    return {
+      path: directory,
+      identity: { dev: stats.dev, ino: stats.ino },
+    };
+  });
+}
+
+function assertOutputDirectoryChainUnchanged(snapshot, displayPath) {
+  if (snapshot === null) return;
+  for (const entry of snapshot) {
+    const stats = rejectLink(entry.path, displayPath);
+    if (
+      stats === null
+      || !stats.isDirectory()
+      || stats.dev !== entry.identity.dev
+      || stats.ino !== entry.identity.ino
+    ) {
+      throw outputPathError(
+        "output directory changed during publication",
+        displayPath,
+      );
+    }
+  }
+}
+
+function removePublishedFileOnBoundaryFailure(resolved, publishedIdentity, boundaryError) {
+  try {
+    const stats = fs.lstatSync(resolved);
+    if (stats.isFile() && sameArtifactInode(stats, publishedIdentity)) {
+      fs.unlinkSync(resolved);
+    }
+  } catch (cleanupError) {
+    if (!isMissing(cleanupError)) {
+      boundaryError.message += `; failed to remove rejected output: ${cleanupError.message}`;
+    }
+  }
+}
+
+function snapshotArtifactFileSync(filePath) {
+  const resolved = resolveArtifactPath(filePath);
+  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
+  const root = configured ? artifactRoot() : path.parse(resolved).root;
+
+  if (configured && !isWithin(root, resolved)) {
+    throw outputPathError(
+      "consumed input must stay within BOX_AGENT_OUTPUT_DIR",
+      filePath,
+    );
+  }
+
+  let current = root;
+  let targetStats = null;
+  const segments = path.relative(root, resolved).split(path.sep).filter(Boolean);
+  for (let index = 0; index < segments.length; index += 1) {
+    current = path.join(current, segments[index]);
+    const stats = rejectLink(current, filePath, "input");
+    if (stats === null) {
+      throw outputPathError("consumed input does not exist", filePath);
+    }
+    if (index < segments.length - 1 && !stats.isDirectory()) {
+      throw outputPathError("consumed input parent must be a directory", filePath);
+    }
+    targetStats = stats;
+  }
+  if (segments.length === 0) {
+    targetStats = rejectLink(resolved, filePath, "input");
+  }
+  if (targetStats === null) {
+    throw outputPathError("consumed input does not exist", filePath);
+  }
+  if (!targetStats.isFile()) {
+    throw outputPathError("consumed input must be a regular file", filePath);
+  }
+
+  if (configured) {
+    const realRoot = fs.realpathSync(root);
+    if (!isWithin(realRoot, fs.realpathSync(resolved))) {
+      throw outputPathError(
+        "consumed input resolves outside BOX_AGENT_OUTPUT_DIR",
+        filePath,
+      );
+    }
+  }
+  return {
+    path: resolved,
+    identity: artifactFileIdentity(targetStats),
+  };
+}
+
+function consumeArtifactFileSync(filePath, expectedIdentity) {
+  const current = snapshotArtifactFileSync(filePath);
+  if (!sameArtifactFileIdentity(current.identity, expectedIdentity)) {
+    throw outputPathError("consumed input changed before deletion", filePath);
+  }
+  fs.unlinkSync(current.path);
+}
+
+function prepareOutputPath(filePath) {
+  const resolved = resolveOutputPath(filePath);
+  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
+  const parent = path.dirname(resolved);
+
+  if (!configured) {
+    fs.mkdirSync(parent, { recursive: true });
+    rejectLink(resolved, filePath);
+    return resolved;
+  }
+
+  const root = artifactRoot();
+  fs.mkdirSync(root, { recursive: true });
+  const realRoot = fs.realpathSync(root);
+  const relativeParent = path.relative(root, parent);
+  let current = root;
+  for (const segment of relativeParent.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    let stats = rejectLink(current, filePath);
+    if (stats === null) {
+      try {
+        fs.mkdirSync(current);
+      } catch (error) {
+        if (error?.code !== "EEXIST") throw error;
+      }
+      stats = rejectLink(current, filePath);
+    }
+    if (!stats?.isDirectory()) {
+      throw outputPathError("output parent path must be a directory", filePath);
+    }
+  }
+  if (!isWithin(realRoot, fs.realpathSync(parent))) {
+    throw outputPathError(
+      "output path resolves outside BOX_AGENT_OUTPUT_DIR",
+      filePath,
+    );
+  }
+  const targetStats = rejectLink(resolved, filePath);
+  if (targetStats !== null && !targetStats.isFile()) {
+    throw outputPathError("output target must be a regular file", filePath);
+  }
+  return resolved;
+}
+
+function writeOutputFileSync(filePath, value, options = {}) {
+  const resolved = prepareOutputPath(filePath);
+  const exclusive = options.exclusive === true;
+  if (exclusive && fs.existsSync(resolved)) {
+    const error = new Error(`EEXIST: output already exists, open '${resolved}'`);
+    error.code = "EEXIST";
+    throw error;
+  }
+
+  const directory = path.dirname(resolved);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(resolved)}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`,
+  );
+  let descriptor = null;
+  let publishedIdentity = null;
+  try {
+    descriptor = fs.openSync(temporaryPath, "wx", 0o666);
+    fs.writeFileSync(descriptor, value, { encoding: options.encoding || "utf8" });
+    fs.fsyncSync(descriptor);
+    publishedIdentity = artifactFileIdentity(fs.fstatSync(descriptor));
+    fs.closeSync(descriptor);
+    descriptor = null;
+
+    // Re-check immediately before replacement so an existing target link is
+    // never followed, even if it appeared after the initial validation.
+    prepareOutputPath(resolved);
+    const directorySnapshot = snapshotOutputDirectoryChain(resolved, filePath);
+    assertOutputDirectoryChainUnchanged(directorySnapshot, filePath);
+    if (exclusive && fs.existsSync(resolved)) {
+      const error = new Error(`EEXIST: output already exists, rename '${resolved}'`);
+      error.code = "EEXIST";
+      throw error;
+    }
+    if (exclusive) {
+      // link(2) publishes the fully written inode without replacing a path
+      // another concurrent builder may have won since the last check.
+      fs.linkSync(temporaryPath, resolved);
+      fs.unlinkSync(temporaryPath);
+    } else {
+      fs.renameSync(temporaryPath, resolved);
+    }
+    try {
+      assertOutputDirectoryChainUnchanged(directorySnapshot, filePath);
+    } catch (boundaryError) {
+      removePublishedFileOnBoundaryFailure(
+        resolved,
+        publishedIdentity,
+        boundaryError,
+      );
+      throw boundaryError;
+    }
+  } catch (error) {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch (cleanupError) {
+      if (!isMissing(cleanupError)) throw cleanupError;
+    }
+    throw error;
+  }
+  return resolved;
+}
+
+function resolveOutputPath(filePath) {
+  const root = artifactRoot();
+  const resolved = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(root, filePath);
+  const configured = String(process.env.BOX_AGENT_OUTPUT_DIR || "").trim();
+  if (!configured) return resolved;
+  if (!isWithin(root, resolved)) {
+    throw new Error(`output path must stay within BOX_AGENT_OUTPUT_DIR: ${filePath}`);
+  }
+  fs.mkdirSync(root, { recursive: true });
+  const realRoot = fs.realpathSync(root);
+  let existingParent = path.dirname(resolved);
+  while (!fs.existsSync(existingParent)) {
+    const parent = path.dirname(existingParent);
+    if (parent === existingParent) break;
+    existingParent = parent;
+  }
+  if (!isWithin(realRoot, fs.realpathSync(existingParent))) {
+    throw new Error(`output path resolves outside BOX_AGENT_OUTPUT_DIR: ${filePath}`);
+  }
+  return resolved;
+}
+
+module.exports = {
+  artifactRoot,
+  consumeArtifactFileSync,
+  resolveArtifactPath,
+  resolveOutputPath,
+  snapshotArtifactFileSync,
+  writeOutputFileSync,
+};

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -325,7 +325,8 @@ async def initialize_base_tools(
             user_skills_dir = Path.home() / ".box-agent" / "skills"
             user_skills_dir.mkdir(parents=True, exist_ok=True)
 
-            # User skills take priority over builtin on name conflict
+            # User skills take priority on ordinary name conflicts. Runtime-
+            # contract skills such as roadmap remain canonical builtin entries.
             sources = [
                 (user_skills_dir, "user"),
                 (builtin_dir, "builtin"),

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -44,6 +44,7 @@ from box_agent.tools.request_user_decision_tool import RequestUserDecisionTool
 from box_agent.tools.request_user_input_tool import RequestUserInputTool
 from box_agent.tools.runtime import SkillRuntimeContext, build_skill_runtime_context
 from box_agent.tools.skill_execution_env import build_skill_execution_env
+from box_agent.tools.skill_scratch import prepare_skill_scratch_dir
 from box_agent.tools.mcp_config_tool import McpConfigTool
 from box_agent.tools.schedule_tool import CreateScheduledTaskTool
 from box_agent.tools.skill_tool import create_skill_tools
@@ -572,6 +573,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
     # Relative tool paths use the project root or the active artifact root.
     runtime_context = skill_runtime_context or build_skill_runtime_context(sandbox_mode=sandbox_mode)
     runtime_env = build_skill_execution_env(runtime_context)
+    skill_scratch_dir = None
     if artifact_root is not None:
         # Make the canonical delivery root available to subprocess-backed
         # skills even when a generated command unnecessarily changes cwd.
@@ -579,6 +581,8 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
         # this directory; exposing the same root keeps shell authoring on the
         # identical boundary.
         runtime_env["BOX_AGENT_OUTPUT_DIR"] = str(artifact_root)
+        skill_scratch_dir = prepare_skill_scratch_dir(workspace_dir)
+        runtime_env["BOX_AGENT_SCRATCH_DIR"] = str(skill_scratch_dir.path)
     if config.tools.enable_bash:
         sandbox_venv_path = None
         if sandbox_mode and not getattr(sys, "frozen", False):
@@ -681,9 +685,13 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
 
     # Jupyter sandbox tool - Python code execution environment
     if sandbox_mode:
+        sandbox_runtime_env = runtime_context.env()
+        if artifact_root is not None and skill_scratch_dir is not None:
+            sandbox_runtime_env["BOX_AGENT_OUTPUT_DIR"] = str(artifact_root)
+            sandbox_runtime_env["BOX_AGENT_SCRATCH_DIR"] = str(skill_scratch_dir.path)
         sandbox_tool = JupyterSandboxTool(
             workspace_dir=str(workspace_dir),
-            runtime_env=runtime_context.env(),
+            runtime_env=sandbox_runtime_env,
             use_output_dir=use_output_dir,
             output_dir=str(artifact_root) if artifact_root else None,
             process_owner_id=process_owner_id,
@@ -709,6 +717,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                 relative_root_dir=str(relative_root),
             )
         )
+
         _out(f"{Colors.GREEN}✅ Loaded vision review tool (vision_review){Colors.RESET}")
 
     # Image generation tool — standard Box-Agent capability shared by CLI and ACP
@@ -759,3 +768,5 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             sub_agent_tool.set_capability_state_provider(capability_state_provider)
         tools.append(sub_agent_tool)
         _out(f"{Colors.GREEN}✅ Loaded sub-agent tool (sub_agent){Colors.RESET}")
+
+    return skill_scratch_dir

--- a/box_agent/tools/skill_loader.py
+++ b/box_agent/tools/skill_loader.py
@@ -4,7 +4,7 @@ Skill Loader - Load Claude Skills from multiple sources.
 Supports:
 - Builtin skills shipped with the package (read-only)
 - User skills at ~/.box-agent/skills/ (writable from officev3)
-- User skills override builtin ones on name conflict
+- User skills override builtin ones on name conflict, except reserved runtime skills
 - mtime-based auto reload (no explicit trigger needed)
 - Manifest-based whitelist for builtin sources: any SKILL.md left on disk
   (e.g. by a downstream host that updated box-agent without deleting old
@@ -24,6 +24,7 @@ import yaml
 SkillSource = Literal["builtin", "user"]
 
 MANIFEST_FILENAME = "_manifest.json"
+RESERVED_BUILTIN_SKILL_NAMES = frozenset({"roadmap"})
 
 
 def _warn(msg: str) -> None:
@@ -526,12 +527,13 @@ class SkillLoader:
         return content
 
     def discover_skills(self) -> List[Skill]:
-        """Discover skills from all sources; user overrides builtin on name conflict."""
+        """Discover skills, preserving canonical implementations of reserved runtimes."""
         self.loaded_skills = {}
         self._all_skills = {}
         # Reset per-run parse errors so callers always see the current pass only.
         self.parse_errors = []
         orphan_count = 0
+        reserved_override_count = 0
         discovered: List[Skill] = []
         disabled_skill_names = _read_disabled_skill_names(self._skill_settings_path)
 
@@ -560,6 +562,16 @@ class SkillLoader:
                     # Orphan builtin skill (installer left old files behind).
                     # Silent by default; the aggregate count is logged below.
                     orphan_count += 1
+                    continue
+
+                if (
+                    entry.source == "user"
+                    and skill.name in RESERVED_BUILTIN_SKILL_NAMES
+                ):
+                    # These skills own host-negotiated runtime contracts.  A
+                    # user prompt skill may extend the workflow under another
+                    # name, but must not replace the packaged implementation.
+                    reserved_override_count += 1
                     continue
 
                 self._all_skills[skill.name] = skill
@@ -598,6 +610,11 @@ class SkillLoader:
             _warn(
                 f"⚠️  Ignored {orphan_count} orphan builtin skill(s) not listed in "
                 f"{MANIFEST_FILENAME} (leftovers from a previous installer)."
+            )
+        if reserved_override_count:
+            _warn(
+                f"⚠️  Ignored {reserved_override_count} user skill override(s) for "
+                "reserved builtin runtime names. Rename the user skill to extend it."
             )
 
         return discovered

--- a/box_agent/tools/skill_preload.py
+++ b/box_agent/tools/skill_preload.py
@@ -39,6 +39,59 @@ _BROWSER_OPERATION_SIGNAL_RE = re.compile(
     r"爬虫|表单|人工接管|让我检查|我最后提交|内网)",
     re.IGNORECASE,
 )
+_ROADMAP_SIGNAL_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("roadmap", re.compile(r"\broadmap\b|路线图", re.IGNORECASE)),
+    (
+        "schedule",
+        re.compile(r"\b(?:schedule|planning)\b|排期|项目计划|实施计划", re.IGNORECASE),
+    ),
+    ("swimlane", re.compile(r"\bswim[\s-]?lane\b|泳道", re.IGNORECASE)),
+    (
+        "calendar-scale",
+        re.compile(
+            r"\b(?:monthly|by\s+month|month(?:ly)?[\s-]+(?:scale|axis)|half[\s-]?month)\b|"
+            r"月份?刻度|月度刻度|按月|半月|上下旬|上旬|下旬",
+            re.IGNORECASE,
+        ),
+    ),
+    ("gantt", re.compile(r"\bgantt\b|甘特", re.IGNORECASE)),
+    ("milestone", re.compile(r"\bmilestones?\b|里程碑", re.IGNORECASE)),
+)
+_ROADMAP_STRONG_DELIVERABLE_EN_PATTERN = (
+    r"build|create|design|draft|generate|make|output|produce|render|turn"
+)
+_ROADMAP_STRONG_DELIVERABLE_ZH_PATTERN = (
+    r"生成|创建|制作|做一|做个|"
+    r"(?<!怎么)(?<!如何)做(?=(?:未来|接下来|今后|\d|[一二三四五六七八九十]))|"
+    r"画一|绘制|设计|输出|整理成|转成|转换为"
+)
+_ROADMAP_STRONG_DELIVERABLE_INTENT_RE = re.compile(
+    rf"\b(?:{_ROADMAP_STRONG_DELIVERABLE_EN_PATTERN})\b|"
+    rf"(?:{_ROADMAP_STRONG_DELIVERABLE_ZH_PATTERN})",
+    re.IGNORECASE,
+)
+_ROADMAP_DELIVERABLE_INTENT_RE = re.compile(
+    rf"\b(?:{_ROADMAP_STRONG_DELIVERABLE_EN_PATTERN}|need|want)\b|"
+    rf"(?:{_ROADMAP_STRONG_DELIVERABLE_ZH_PATTERN}|帮我|给我|需要|想要)",
+    re.IGNORECASE,
+)
+_ROADMAP_INFORMATION_REQUEST_RE = re.compile(
+    r"\b(?:advice|analy[sz]e|analysis|compare|define|difference|evaluate|explain|recommend|what\s+is)\b|"
+    r"(?:建议|分析|评估|解释|说明|原则|区别|差异|是什么|什么意思|含义|怎么|如何|介绍一下)",
+    re.IGNORECASE,
+)
+_ROADMAP_NEGATED_ACTION_CLAUSE_RE = re.compile(
+    r"(?:\b(?:do\s+not|don't|dont)\s+"
+    r"(?:build|create|design|draft|generate|make|output|produce|render)\b|"
+    r"(?:不要|别|无需|不需要|禁止)(?:再)?(?:生成|创建|制作|做|画|绘制|设计|输出))"
+    r"[^,，.;；。!！?？\n]*",
+    re.IGNORECASE,
+)
+_ROADMAP_SINGLE_GANTT_RE = re.compile(
+    r"\b(?:single(?:[\s-]+project)?|one)[\s-]+gantt\b|"
+    r"(?:单张|单个|单项目|单泳道)[^,，.;；。!！?？\n]{0,20}(?:甘特|gantt)",
+    re.IGNORECASE,
+)
 _VIDEO_DELIVERABLE_SIGNAL_RE = re.compile(
     r"\b(?:videos?|mp4|gifs?|hyperframes)\b|"
     r"\bmotion[\s-]+graphics?\b|"
@@ -208,6 +261,58 @@ def has_browser_operation_intent(user_text: str | None) -> bool:
     return bool(_BROWSER_OPERATION_SIGNAL_RE.search(user_text))
 
 
+def roadmap_artifact_intent_signals(user_text: str | None) -> tuple[str, ...]:
+    """Return ordered semantic signals for a dedicated roadmap artifact."""
+    if not user_text or not user_text.strip():
+        return ()
+    return tuple(
+        name
+        for name, pattern in _ROADMAP_SIGNAL_PATTERNS
+        if pattern.search(user_text)
+    )
+
+
+def has_roadmap_artifact_intent(user_text: str | None) -> bool:
+    """Distinguish schedule swimlanes from plain processes and Gantt tables."""
+    if not user_text:
+        return False
+    positive_text = _ROADMAP_NEGATED_ACTION_CLAUSE_RE.sub("", user_text)
+    if not _ROADMAP_DELIVERABLE_INTENT_RE.search(positive_text):
+        return False
+    if (
+        _ROADMAP_INFORMATION_REQUEST_RE.search(positive_text)
+        and not _ROADMAP_STRONG_DELIVERABLE_INTENT_RE.search(positive_text)
+    ):
+        return False
+    signals = set(roadmap_artifact_intent_signals(positive_text))
+    if (
+        _ROADMAP_SINGLE_GANTT_RE.search(positive_text)
+        and "roadmap" not in signals
+        and "swimlane" not in signals
+    ):
+        return False
+    if len(signals) < 2:
+        return False
+    has_dedicated_geometry = bool(signals & {"swimlane", "calendar-scale"})
+    has_roadmap_schedule_pair = "roadmap" in signals and bool(
+        signals & {"schedule", "gantt"}
+    )
+    return has_dedicated_geometry or has_roadmap_schedule_pair
+
+
+def semantic_artifact_preload_skill_names(
+    matched_skill_names: tuple[str, ...],
+    user_text: str | None,
+) -> list[str]:
+    """Preload entry-independent artifact skills on strong semantic intent."""
+    if (
+        "roadmap" in matched_skill_names
+        and has_roadmap_artifact_intent(user_text)
+    ):
+        return ["roadmap"]
+    return []
+
+
 def host_runtime_preload_skill_names(
     matched_skill_names: tuple[str, ...],
     env_context: Any | None,
@@ -249,6 +354,12 @@ def turn_preload_skill_names(
         matched_skill_names,
         completion_gate,
         presentation_skill_name=presentation_skill_name,
+    ):
+        if skill_name not in preload:
+            preload.append(skill_name)
+    for skill_name in semantic_artifact_preload_skill_names(
+        matched_skill_names,
+        user_text,
     ):
         if skill_name not in preload:
             preload.append(skill_name)

--- a/box_agent/tools/skill_scratch.py
+++ b/box_agent/tools/skill_scratch.py
@@ -1,0 +1,65 @@
+"""Session-scoped scratch storage for subprocess-backed Skills."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SKILL_SCRATCH_DIR_NAME = ".box-agent-scratch"
+
+
+@dataclass(frozen=True)
+class SkillScratchDirectory:
+    path: Path
+    device: int
+    inode: int
+
+
+def prepare_skill_scratch_dir(workspace_dir: Path) -> SkillScratchDirectory:
+    """Create the reserved Skill scratch root without accepting links."""
+    scratch_dir = workspace_dir.resolve() / SKILL_SCRATCH_DIR_NAME
+    try:
+        stats = scratch_dir.lstat()
+    except FileNotFoundError:
+        scratch_dir.mkdir(mode=0o700)
+        stats = scratch_dir.lstat()
+    else:
+        if stat.S_ISLNK(stats.st_mode) or not stat.S_ISDIR(stats.st_mode):
+            raise RuntimeError(f"Skill scratch root must be a real directory: {scratch_dir}")
+    if os.name != "nt":
+        scratch_dir.chmod(0o700)
+    return SkillScratchDirectory(
+        path=scratch_dir,
+        device=stats.st_dev,
+        inode=stats.st_ino,
+    )
+
+
+def cleanup_skill_scratch_dir(scratch: SkillScratchDirectory) -> list[str]:
+    """Remove all entries from a reserved scratch root without following links."""
+    scratch_dir = scratch.path
+    try:
+        stats = scratch_dir.lstat()
+    except FileNotFoundError:
+        return []
+    if (
+        stat.S_ISLNK(stats.st_mode)
+        or not stat.S_ISDIR(stats.st_mode)
+        or stats.st_dev != scratch.device
+        or stats.st_ino != scratch.inode
+    ):
+        raise RuntimeError(f"Skill scratch root must be a real directory: {scratch_dir}")
+
+    removed: list[str] = []
+    for entry in scratch_dir.iterdir():
+        entry_mode = entry.lstat().st_mode
+        if stat.S_ISDIR(entry_mode) and not stat.S_ISLNK(entry_mode):
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+        removed.append(str(entry))
+    return removed

--- a/docs/ARTIFACT_PROTOCOL.md
+++ b/docs/ARTIFACT_PROTOCOL.md
@@ -126,6 +126,33 @@ created and uses `params.cwd` (or `config.agent.workspace_dir`) as the
 workspace root. If you want the artifact directory in a custom place,
 override the workspace itself — `output/` always lives under it.
 
+## Runtime capability discovery
+
+`initialize._meta.runtime_capabilities` is a conservative startup snapshot and
+may report Roadmap disabled while background Skill discovery is still running.
+A host restoring persisted artifacts without creating a conversation session
+can request the stable runtime snapshot through the read-only ACP extension
+`_runtime/capabilities`. The request has no parameters and does not create a
+workspace or session.
+
+```json
+{
+  "contract": "box-agent.runtime-capabilities-query",
+  "contractVersion": 1,
+  "ready": true,
+  "_meta": {
+    "runtime_capabilities": {}
+  }
+}
+```
+
+The query waits for Skill discovery using the same bounded wait as
+`session/new`. When the bound expires, `ready` is `false` and the returned
+capabilities remain conservative. Hosts should fail closed, may retry later,
+and must treat an `unknown_method` response from older runtimes as unsupported.
+Capability snapshots belong to the current runtime connection and should not
+be persisted with conversation history.
+
 ## Non-goals
 
 - **No streaming chunks for artifact content.** The artifact payload is

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -4760,6 +4760,12 @@ async def test_acp_host_env_context_feeds_bash_and_execute_code_runtime_env(tmp_
     assert bash_env["BOX_AGENT_NODE"] == str(node_path)
     assert bash_env["BOX_AGENT_NPM"] == str(npm_path)
     assert bash_env["BOX_AGENT_NPX"] == str(npx_path)
+    assert bash_env["BOX_AGENT_SCRATCH_DIR"] == str(
+        workspace / ".box-agent-scratch"
+    )
+    assert execute_code_env["BOX_AGENT_SCRATCH_DIR"] == str(
+        workspace / ".box-agent-scratch"
+    )
     assert bash_env["NODE_PATH"].split(os.pathsep)[-1] == str(node_modules)
     assert bash_env["NPM_CONFIG_PREFIX"] == str(
         Path.home() / ".box-agent" / "skill-tools"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -194,6 +194,82 @@ async def test_acp_workspace_config_methods_share_profiles(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_acp_runtime_capabilities_query_waits_for_skill_discovery(tmp_path):
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(
+        DummyConn(),
+        config,
+        DummyLLM(),
+        [],
+        "system",
+        skill_task=skill_task,
+    )
+    capabilities = {
+        "contract": "box-agent.runtime-capabilities",
+        "contractVersion": 1,
+        "deckProtocolVersion": 1,
+        "roadmap": {
+            "schemaVersion": 1,
+            "geometryVersion": 1,
+            "rendererVersion": 1,
+            "capabilities": ["roadmap.generate.html", "roadmap.preview", "roadmap.edit"],
+        },
+    }
+    agent._runtime_capabilities_meta = lambda: capabilities  # type: ignore[method-assign]
+
+    query = asyncio.create_task(agent.extMethod("runtime/capabilities", {}))
+    await asyncio.sleep(0)
+    assert not query.done()
+
+    discovery_gate.set()
+    result = await query
+
+    assert result == {
+        "contract": "box-agent.runtime-capabilities-query",
+        "contractVersion": 1,
+        "ready": True,
+        "_meta": {"runtime_capabilities": capabilities},
+    }
+
+
+@pytest.mark.asyncio
+async def test_acp_runtime_capabilities_query_reports_pending_after_bounded_wait(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr("box_agent.acp._SKILL_DISCOVERY_WAIT_SECONDS", 0.01)
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(
+        DummyConn(),
+        config,
+        DummyLLM(),
+        [],
+        "system",
+        skill_task=skill_task,
+    )
+
+    try:
+        result = await agent.extMethod("runtime/capabilities", {})
+    finally:
+        skill_task.cancel()
+
+    assert result["ready"] is False
+    assert result["_meta"]["runtime_capabilities"]["roadmap"]["capabilities"] == []
+
+
+@pytest.mark.asyncio
 async def test_acp_uses_saved_code_type_when_host_omits_session_mode(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     workspace = tmp_path / "project"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2457,7 +2457,7 @@ async def test_acp_default_artifact_mode_creates_output(tmp_path):
     assert state.output_dir == str(tmp_path / "output")
     assert state.artifact_mode == "output"
     assert "cwd 已是 `{workspace}/output/`" in state.agent.system_prompt
-    assert session.field_meta is None
+    assert session.field_meta["runtime_capabilities"]["contractVersion"] == 1
 
 
 @pytest.mark.asyncio
@@ -3136,6 +3136,73 @@ async def test_acp_preloads_matched_pptx_skill_for_deliverable(tmp_path):
     assert "# PPTX FULL RULES" in first_system_prompt
     assert prompt_capture.parent_system_prompt == first_system_prompt
     assert agent._sessions[session.sessionId].preloaded_skill_names == ["pptx"]
+
+
+@pytest.mark.asyncio
+async def test_acp_does_not_use_partially_discovered_skill_before_catalog_ready(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr("box_agent.acp._SKILL_DISCOVERY_WAIT_SECONDS", 0.01)
+    skills_dir = tmp_path / "skills"
+    roadmap_dir = skills_dir / "roadmap"
+    roadmap_dir.mkdir(parents=True)
+    roadmap_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        "name: roadmap\n"
+        "description: Generate editable HTML roadmaps.\n"
+        "keywords: [roadmap]\n"
+        "---\n"
+        "# ROADMAP FULL RULES\n",
+        encoding="utf-8",
+    )
+    skill_loader = SkillLoader(skills_dir)
+    skill_loader.discover_skills()
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=1, workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(),
+    )
+    agent = BoxACPAgent(
+        DummyConn(),
+        config,
+        DoneLLM(),
+        [],
+        f"system\n\n{SKILL_SLOT_SENTINEL}",
+        skill_loader=skill_loader,
+        skill_task=skill_task,
+    )
+    session = await agent.newSession(
+        SimpleNamespace(cwd=None, field_meta={"session_mode": "general"})
+    )
+
+    async def capture_run_turn(state_arg, session_id, **kwargs):
+        return "end_turn"
+
+    agent._run_turn = capture_run_turn  # type: ignore[method-assign]
+    await agent.prompt(
+        SimpleNamespace(
+            sessionId=session.sessionId,
+            prompt=[{"text": "请使用 /roadmap 生成路线图"}],
+        )
+    )
+
+    state = agent._sessions[session.sessionId]
+    assert state.preloaded_skill_names == []
+    assert "# ROADMAP FULL RULES" not in state.agent.system_prompt
+
+    discovery_gate.set()
+    await agent.prompt(
+        SimpleNamespace(
+            sessionId=session.sessionId,
+            prompt=[{"text": "请使用 /roadmap 生成路线图"}],
+        )
+    )
+
+    assert state.preloaded_skill_names == ["roadmap"]
+    assert "# ROADMAP FULL RULES" in state.agent.system_prompt
 
 
 @pytest.mark.asyncio
@@ -4172,7 +4239,8 @@ async def test_acp_new_session_injects_core_memory_without_returning_it(tmp_path
         SimpleNamespace(cwd=None, field_meta={"session_mode": "general"})
     )
 
-    assert session.field_meta is None
+    assert session.field_meta["runtime_capabilities"]["contractVersion"] == 1
+    assert "memory" not in session.field_meta
     assert "--- MEMORY START ---" in agent._sessions[session.sessionId].agent.system_prompt
     assert "User prefers concise Chinese responses" in agent._sessions[session.sessionId].agent.system_prompt
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import json
+import os
+import shutil
+import subprocess
 import threading
 from pathlib import Path
 from time import monotonic
@@ -6062,6 +6065,128 @@ def test_artifact_envelope_shape(tmp_path):
     assert "mime_type" not in env
     assert "size_bytes" not in env
     assert "sandbox_workspace" not in env
+
+
+def test_roadmap_artifact_envelope_includes_controlled_metadata(tmp_path):
+    from box_agent.acp import _artifact_envelope
+    from box_agent.core import _make_artifact
+
+    output = tmp_path / "output"
+    output.mkdir()
+    html = output / "roadmap.html"
+    skill_root = (
+        Path(__file__).resolve().parents[1] / "box_agent" / "skills" / "roadmap"
+    )
+    node = os.environ.get("BOX_AGENT_NODE") or shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required to render a trusted Roadmap artifact")
+    rendered = subprocess.run(
+        [
+            node,
+            str(skill_root / "scripts" / "render_roadmap_html.js"),
+            str(skill_root / "examples" / "roadmap-spec-v1.json"),
+            "--out",
+            str(html),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert rendered.returncode == 0, rendered.stderr
+
+    env = _artifact_envelope(_make_artifact("tc-roadmap", html, tmp_path), str(output))
+
+    assert env["layout_id"] == "roadmap-swimlane-v1"
+    assert "artifact_version" not in env
+    assert "diagnostics" not in env
+
+    trusted_html = html.read_text(encoding="utf-8")
+    html.write_text(
+        trusted_html.replace(
+            'data-roadmap-runtime="editor">',
+            'data-roadmap-runtime="editor">window.tampered=true;',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    tampered = _artifact_envelope(
+        _make_artifact("tc-roadmap-tampered", html, tmp_path), str(output)
+    )
+    assert "layout_id" not in tampered
+
+    html.write_text(
+        trusted_html.replace("</main>", '<a href="https://example.test">link</a></main>'),
+        encoding="utf-8",
+    )
+    navigable = _artifact_envelope(
+        _make_artifact("tc-roadmap-navigable", html, tmp_path), str(output)
+    )
+    assert "layout_id" not in navigable
+
+
+def test_roadmap_artifact_layout_rejects_self_declared_metadata(tmp_path):
+    from box_agent.acp import _artifact_envelope
+    from box_agent.core import _make_artifact
+
+    output = tmp_path / "output"
+    output.mkdir()
+    html = output / "roadmap.html"
+    spec = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "box_agent"
+            / "skills"
+            / "roadmap"
+            / "examples"
+            / "roadmap-spec-v1.json"
+        ).read_text(encoding="utf-8")
+    )
+    html.write_text(
+        "<!doctype html>\n"
+        '<meta name="generator" content="Box Agent Roadmap Artifact v1">\n'
+        '<meta name="box-agent-artifact-layout-id" content="roadmap-swimlane-v1">\n'
+        '<script id="deck-document" type="application/json">\n'
+        f"{json.dumps(spec)}\n"
+        "</script>\n",
+        encoding="utf-8",
+    )
+
+    env = _artifact_envelope(_make_artifact("tc-roadmap", html, tmp_path), str(output))
+
+    assert "layout_id" not in env
+
+
+def test_roadmap_artifact_layout_rejects_spoofed_or_invalid_html(tmp_path):
+    from box_agent.acp import _artifact_envelope
+    from box_agent.core import _make_artifact
+
+    output = tmp_path / "output"
+    output.mkdir()
+    spoofed = output / "spoofed.html"
+    spoofed.write_text(
+        "<!doctype html>\n"
+        '<meta name="box-agent-artifact-layout-id" content="roadmap-swimlane-v1">\n'
+        "<script>alert(1)</script>\n",
+        encoding="utf-8",
+    )
+    invalid = output / "invalid.html"
+    invalid.write_text(
+        "<!doctype html>\n"
+        '<meta name="generator" content="Box Agent Roadmap Artifact v1">\n'
+        '<meta name="box-agent-artifact-layout-id" content="roadmap-swimlane-v1">\n'
+        '<script id="deck-document" type="application/json">{}</script>\n',
+        encoding="utf-8",
+    )
+
+    spoofed_env = _artifact_envelope(
+        _make_artifact("tc-spoofed", spoofed, tmp_path), str(output)
+    )
+    invalid_env = _artifact_envelope(
+        _make_artifact("tc-invalid", invalid, tmp_path), str(output)
+    )
+
+    assert "layout_id" not in spoofed_env
+    assert "layout_id" not in invalid_env
 
 
 # ── Summarization (_maybe_summarize / _create_summary) ───────

--- a/tests/test_generate_skills_manifest.py
+++ b/tests/test_generate_skills_manifest.py
@@ -38,3 +38,9 @@ def test_dev_code_init_is_builtin_and_matches_slash_init():
     assert skill is not None
     assert "Create or update" in skill.description
     assert "root `AGENTS.md`" in skill.content
+
+
+def test_roadmap_is_a_top_level_builtin_skill():
+    entries = dict(_collect_skills())
+
+    assert entries["roadmap"] == "roadmap/SKILL.md"

--- a/tests/test_image_generation_tool.py
+++ b/tests/test_image_generation_tool.py
@@ -1048,6 +1048,10 @@ async def test_output_mode_tools_share_artifact_relative_root(
     assert by_name["bash"].workspace_dir == str(artifact_root)
     assert by_name["bash"].scope_root_dir == str(workspace)
     assert by_name["bash"]._subprocess_env["BOX_AGENT_OUTPUT_DIR"] == str(artifact_root)
+    assert by_name["bash"]._subprocess_env["BOX_AGENT_SCRATCH_DIR"] == str(
+        workspace / ".box-agent-scratch"
+    )
+    assert (workspace / ".box-agent-scratch").is_dir()
 
     node = shutil.which("node")
     if node is None:

--- a/tests/test_roadmap_builtin_skill.py
+++ b/tests/test_roadmap_builtin_skill.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+import pytest
+
+from box_agent.tools.skill_loader import SkillLoader
+from box_agent.tools.skill_preload import (
+    build_auto_loaded_skills_prompt,
+    has_roadmap_artifact_intent,
+    roadmap_artifact_intent_signals,
+    semantic_artifact_preload_skill_names,
+    turn_preload_skill_names,
+)
+
+
+SKILLS_ROOT = Path(__file__).resolve().parents[1] / "box_agent" / "skills"
+
+
+def _loader() -> SkillLoader:
+    loader = SkillLoader(sources=[(SKILLS_ROOT, "builtin")])
+    loader.discover_skills()
+    return loader
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "帮我做未来三个月的产品路线图，按团队分泳道",
+        "生成项目排期泳道图，按月份刻度展示",
+        "create a roadmap schedule with swimlanes for each team",
+        "I want a 6-month roadmap schedule with milestones and swimlanes",
+        "做三个月排期泳道图并标出里程碑",
+    ],
+)
+def test_ordinary_chat_routes_and_preloads_roadmap_skill(query: str) -> None:
+    loader = _loader()
+    matched_names = tuple(skill.name for skill in loader.filter_by_query(query))
+
+    assert "roadmap" in matched_names
+    assert has_roadmap_artifact_intent(query) is True
+    preload = semantic_artifact_preload_skill_names(
+        matched_names,
+        query,
+    )
+    assert preload == ["roadmap"]
+
+    rendered = build_auto_loaded_skills_prompt(loader, "base system", preload)
+    assert rendered.loaded_names == ("roadmap",)
+    assert "# Roadmap Skill" in rendered.system_prompt
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "制作三阶段工作流程",
+        "帮我做一个单张甘特表",
+        "帮我做一个三个月的单张排期甘特表，按月份刻度展示",
+        "解释 roadmap 排期有什么区别",
+        "帮我解释 roadmap 排期有什么区别",
+        "我想了解未来三个月路线图按团队分泳道是什么意思",
+        "不要生成三个月路线图泳道，只说明排期原则",
+        "do not create a 6-month roadmap with swimlanes; explain the idea",
+        "给我未来三个月项目计划的建议，按月分析",
+        "帮我做 PPT",
+    ],
+)
+def test_non_roadmap_artifact_requests_do_not_preload_roadmap(query: str) -> None:
+    loader = _loader()
+    matched_names = tuple(skill.name for skill in loader.filter_by_query(query))
+
+    preload = semantic_artifact_preload_skill_names(
+        matched_names,
+        query,
+    )
+    assert "roadmap" not in preload
+
+
+def test_roadmap_intent_reports_stable_ordered_signals() -> None:
+    assert roadmap_artifact_intent_signals(
+        "生成三个月路线图，按团队泳道和按月刻度做甘特排期并标记里程碑"
+    ) == (
+        "roadmap",
+        "schedule",
+        "swimlane",
+        "calendar-scale",
+        "gantt",
+        "milestone",
+    )
+
+
+def test_negated_adapter_request_keeps_later_positive_roadmap_request() -> None:
+    assert has_roadmap_artifact_intent(
+        "不要生成 PPT，改为生成三个月路线图并按团队分泳道"
+    ) is True
+
+
+def test_turn_preload_uses_semantic_roadmap_route_without_a_document_gate() -> None:
+    assert turn_preload_skill_names(
+        ("roadmap",),
+        None,
+        None,
+        "生成未来三个月路线图，按团队分泳道",
+    ) == ["roadmap"]
+
+
+def test_plain_ppt_query_does_not_match_roadmap_metadata() -> None:
+    loader = _loader()
+
+    matched_names = tuple(
+        skill.name for skill in loader.filter_by_query("帮我做 PPT")
+    )
+
+    assert "roadmap" not in matched_names
+
+
+def test_roadmap_is_a_top_level_builtin_skill() -> None:
+    loader = _loader()
+    skill = loader.get_skill("roadmap")
+
+    assert skill is not None
+    assert skill.skill_path == SKILLS_ROOT / "roadmap" / "SKILL.md"
+    assert "document-skills" not in skill.skill_path.parts
+
+
+def test_roadmap_skill_keeps_output_directory_deliverable_only() -> None:
+    skill = _loader().get_skill("roadmap")
+
+    assert skill is not None
+    assert "Treat `output/` as a deliverables-only boundary" in skill.content
+    assert "Never create generator scripts" in skill.content
+    assert "`--consume-input` removes only the supplied" in skill.content
+    assert "under `output/` is a versioned HTML" in skill.content

--- a/tests/test_roadmap_builtin_skill.py
+++ b/tests/test_roadmap_builtin_skill.py
@@ -127,5 +127,7 @@ def test_roadmap_skill_keeps_output_directory_deliverable_only() -> None:
     assert skill is not None
     assert "Treat `output/` as a deliverables-only boundary" in skill.content
     assert "Never create generator scripts" in skill.content
-    assert "`--consume-input` removes only the supplied" in skill.content
+    assert "unique task\ndirectory below `$BOX_AGENT_SCRATCH_DIR`" in skill.content
+    assert "after either success or failure" in skill.content
+    assert "session runtime clears any residue" in skill.content
     assert "under `output/` is a versioned HTML" in skill.content

--- a/tests/test_roadmap_core.py
+++ b/tests/test_roadmap_core.py
@@ -656,6 +656,140 @@ def test_unified_builder_leaves_only_versioned_html_and_consumes_draft(tmp_path)
     assert 'data-generation-version="1"' in html
 
 
+def test_unified_builder_consumes_external_task_scratch_and_cleans_directory(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output"
+    scratch_root = tmp_path / ".box-agent-scratch"
+    task_scratch = scratch_root / "roadmap-task"
+    output_dir.mkdir()
+    task_scratch.mkdir(parents=True)
+    draft = task_scratch / "roadmap-draft.json"
+    helper = task_scratch / "helper.js"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", draft)
+    helper.write_text("// temporary helper", encoding="utf-8")
+    env = {
+        **os.environ,
+        "BOX_AGENT_OUTPUT_DIR": str(output_dir),
+        "BOX_AGENT_SCRATCH_DIR": str(scratch_root),
+    }
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(draft),
+        "--out",
+        "roadmap.html",
+        "--consume-input",
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (output_dir / "roadmap-v1.html").is_file()
+    assert list(output_dir.iterdir()) == [output_dir / "roadmap-v1.html"]
+    assert not task_scratch.exists()
+    assert scratch_root.is_dir()
+    assert not list(scratch_root.iterdir())
+
+
+def test_unified_builder_cleans_task_scratch_after_build_failure(tmp_path) -> None:
+    output_dir = tmp_path / "output"
+    scratch_root = tmp_path / ".box-agent-scratch"
+    task_scratch = scratch_root / "roadmap-task"
+    output_dir.mkdir()
+    task_scratch.mkdir(parents=True)
+    draft = task_scratch / "roadmap-draft.json"
+    draft.write_text('{"kind":"roadmap-draft"}', encoding="utf-8")
+    env = {
+        **os.environ,
+        "BOX_AGENT_OUTPUT_DIR": str(output_dir),
+        "BOX_AGENT_SCRATCH_DIR": str(scratch_root),
+    }
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(draft),
+        "--out",
+        "roadmap.html",
+        "--consume-input",
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert not task_scratch.exists()
+    assert not list(output_dir.iterdir())
+
+
+def test_unified_builder_rejects_consumed_input_outside_configured_scratch(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output"
+    scratch_root = tmp_path / ".box-agent-scratch"
+    outside_dir = tmp_path / "outside"
+    output_dir.mkdir()
+    scratch_root.mkdir()
+    outside_dir.mkdir()
+    draft = outside_dir / "roadmap-draft.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", draft)
+    env = {
+        **os.environ,
+        "BOX_AGENT_OUTPUT_DIR": str(output_dir),
+        "BOX_AGENT_SCRATCH_DIR": str(scratch_root),
+    }
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(draft),
+        "--out",
+        "roadmap.html",
+        "--consume-input",
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert "must stay within BOX_AGENT_SCRATCH_DIR" in result.stderr
+    assert draft.is_file()
+    assert not list(output_dir.iterdir())
+
+
+def test_unified_builder_rejects_scratch_input_symlink_and_cleans_task(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output"
+    scratch_root = tmp_path / ".box-agent-scratch"
+    task_scratch = scratch_root / "roadmap-task"
+    outside_dir = tmp_path / "outside"
+    output_dir.mkdir()
+    task_scratch.mkdir(parents=True)
+    outside_dir.mkdir()
+    outside_draft = outside_dir / "roadmap-draft.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", outside_draft)
+    linked_draft = task_scratch / "roadmap-draft.json"
+    try:
+        linked_draft.symlink_to(outside_draft)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlinks are unavailable in this environment: {error}")
+    env = {
+        **os.environ,
+        "BOX_AGENT_OUTPUT_DIR": str(output_dir),
+        "BOX_AGENT_SCRATCH_DIR": str(scratch_root),
+    }
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(linked_draft),
+        "--out",
+        "roadmap.html",
+        "--consume-input",
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert "input path must not contain a symlink or reparse point" in result.stderr
+    assert outside_draft.is_file()
+    assert not task_scratch.exists()
+    assert not list(output_dir.iterdir())
+
+
 def test_unified_builder_rejects_unsafe_existing_version_without_retrying(tmp_path) -> None:
     unsafe_version = tmp_path / "product-roadmap-v9007199254740992.html"
     unsafe_version.write_text("existing", encoding="utf-8")
@@ -1025,6 +1159,56 @@ try {
     assert result.returncode == 1
     assert "consumed input changed before deletion" in result.stderr
     assert source.read_text(encoding="utf-8") == "replacement"
+
+
+def test_scratch_cleanup_rejects_replaced_task_directory(tmp_path) -> None:
+    if NODE is None:
+        pytest.skip("Node.js is required to test Roadmap scratch cleanup")
+    scratch_root = tmp_path / ".box-agent-scratch"
+    task_dir = scratch_root / "roadmap-task"
+    moved_dir = scratch_root / "moved-task"
+    task_dir.mkdir(parents=True)
+    source = task_dir / "draft.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", source)
+    script = """
+const fs = require('fs');
+const path = require('path');
+const io = require(process.argv[1]);
+const source = process.argv[2];
+const taskDir = path.dirname(source);
+const movedDir = process.argv[3];
+const snapshot = io.snapshotConsumedInputFileSync(source);
+fs.renameSync(taskDir, movedDir);
+fs.mkdirSync(taskDir);
+fs.writeFileSync(path.join(taskDir, 'keep.txt'), 'keep');
+try {
+  io.cleanupScratchTaskDirectorySync(source, snapshot);
+  process.exitCode = 2;
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+"""
+
+    result = subprocess.run(
+        [
+            str(NODE),
+            "-e",
+            script,
+            str(SCRIPTS_DIR / "roadmap_io.js"),
+            str(source),
+            str(moved_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=SKILL_DIR,
+        env={**os.environ, "BOX_AGENT_SCRATCH_DIR": str(scratch_root)},
+    )
+
+    assert result.returncode == 1
+    assert "scratch task directory changed before cleanup" in result.stderr
+    assert (task_dir / "keep.txt").read_text(encoding="utf-8") == "keep"
 
 
 def test_roadmap_output_replacement_is_atomic_and_leaves_no_temporary_file(

--- a/tests/test_roadmap_core.py
+++ b/tests/test_roadmap_core.py
@@ -1,0 +1,1263 @@
+"""Contract and golden coverage for the renderer-neutral roadmap core."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "box_agent"
+    / "skills"
+    / "roadmap"
+)
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+FIXTURES_DIR = SKILL_DIR / "examples"
+NODE = os.environ.get("BOX_AGENT_NODE") or shutil.which("node")
+
+
+def _run(
+    script: str,
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if NODE is None:
+        pytest.skip("Node.js is required to test the roadmap compiler")
+    return subprocess.run(
+        [str(NODE), str(SCRIPTS_DIR / script), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=SKILL_DIR,
+        env=env,
+    )
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _schema_validator(name: str) -> Draft202012Validator:
+    references = SKILL_DIR / "references"
+    draft_schema = json.loads(
+        (references / "roadmap-draft.schema.json").read_text(encoding="utf-8")
+    )
+    schema = json.loads((references / name).read_text(encoding="utf-8"))
+    registry = Registry().with_resource(
+        draft_schema["$id"], Resource.from_contents(draft_schema)
+    )
+    return Draft202012Validator(schema, registry=registry)
+
+
+def _runtime_validation(
+    tmp_path: Path, value: dict, function_name: str
+) -> dict:
+    if NODE is None:
+        pytest.skip("Node.js is required to test the roadmap validator")
+    source = tmp_path / f"{function_name}.json"
+    _write_json(source, value)
+    script = """
+const fs = require('fs');
+const core = require(process.argv[1]);
+const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+console.log(JSON.stringify(core[process.argv[3]](value)));
+"""
+    result = subprocess.run(
+        [
+            str(NODE),
+            "-e",
+            script,
+            str(SCRIPTS_DIR / "roadmap_contract_core.js"),
+            str(source),
+            function_name,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=SKILL_DIR,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_roadmap_core_has_no_pptx_or_deck_dependency() -> None:
+    for script in SCRIPTS_DIR.glob("*.js"):
+        source = script.read_text(encoding="utf-8")
+        assert "document-skills/pptx" not in source, script
+        assert "deck_spec_core" not in source, script
+
+
+def _compile(tmp_path: Path, fixture: str) -> tuple[subprocess.CompletedProcess[str], dict, Path]:
+    output = tmp_path / f"{Path(fixture).stem}-spec.json"
+    report = tmp_path / f"{Path(fixture).stem}-report.json"
+    result = _run(
+        "compile_roadmap_spec.js",
+        str(FIXTURES_DIR / fixture),
+        "--out",
+        str(output),
+        "--report",
+        str(report),
+    )
+    return result, json.loads(report.read_text(encoding="utf-8")), output
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "draft-natural-language.json",
+        "draft-table.json",
+        "draft-image.json",
+        "roadmap-spec-v1.json",
+    ],
+)
+def test_supported_inputs_compile_to_roadmap_spec_v1(tmp_path, fixture) -> None:
+    result, report, output = _compile(tmp_path, fixture)
+
+    assert result.returncode == 0, result.stderr
+    assert report["ok"] is True
+    assert report["issues"] == []
+    spec = json.loads(output.read_text(encoding="utf-8"))
+    assert spec["schema_version"] == 1
+    assert spec["kind"] == "roadmap-spec"
+
+
+def test_v1_spec_migrator_is_lossless_and_rejects_unknown_future_versions(tmp_path) -> None:
+    source = FIXTURES_DIR / "roadmap-spec-v1.json"
+    output = tmp_path / "migrated.json"
+
+    result = _run("migrate_roadmap_spec.js", str(source), "--out", str(output))
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(output.read_text(encoding="utf-8")) == _read_fixture("roadmap-spec-v1.json")
+
+    future = _read_fixture("roadmap-spec-v1.json")
+    future["schema_version"] = 2
+    future_path = tmp_path / "future.json"
+    _write_json(future_path, future)
+    rejected = _run(
+        "migrate_roadmap_spec.js",
+        str(future_path),
+        "--out",
+        str(tmp_path / "must-not-exist.json"),
+    )
+
+    assert rejected.returncode == 1
+    assert "schema_version: unsupported 2" in rejected.stderr
+
+
+def test_low_confidence_image_dates_stay_tentative_and_request_confirmation(tmp_path) -> None:
+    result, report, output = _compile(tmp_path, "draft-image.json")
+
+    assert result.returncode == 0, result.stderr
+    spec = json.loads(output.read_text(encoding="utf-8"))
+    assert spec["items"][0]["certainty"] == "tentative"
+    assert report["pending_questions"] == [
+        {
+            "field_path": "items.0.start",
+            "prompt": "请确认“预览集成”的起止日期。",
+            "reason": "date confidence is below 0.8",
+        }
+    ]
+    assert "normalized to tentative" in report["warnings"][0]
+
+
+@pytest.mark.parametrize(
+    ("fixture", "schema_name", "function_name"),
+    [
+        (
+            "draft-natural-language.json",
+            "roadmap-draft.schema.json",
+            "validateAndNormalizeRoadmapDraft",
+        ),
+        (
+            "roadmap-spec-v1.json",
+            "roadmap-spec.schema.json",
+            "validateAndNormalizeRoadmapSpec",
+        ),
+    ],
+)
+def test_frozen_schemas_and_runtime_validators_accept_the_same_examples(
+    tmp_path, fixture, schema_name, function_name
+) -> None:
+    value = _read_fixture(fixture)
+
+    assert list(_schema_validator(schema_name).iter_errors(value)) == []
+    assert _runtime_validation(tmp_path, value, function_name)["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "draft-missing-pending-questions",
+        "draft-missing-lane-order",
+        "draft-missing-item-progress",
+        "draft-image-missing-region",
+        "draft-lane-id-alias",
+        "draft-string-confidence",
+        "draft-invalid-calendar-date",
+        "spec-legend-extra-field",
+        "spec-bar-missing-end",
+        "spec-milestone-with-end",
+        "spec-invalid-calendar-date",
+    ],
+)
+def test_frozen_schemas_and_runtime_validators_reject_the_same_structural_errors(
+    tmp_path, mutation
+) -> None:
+    if mutation.startswith("draft-"):
+        fixture = (
+            "draft-image.json"
+            if mutation == "draft-image-missing-region"
+            else "draft-natural-language.json"
+        )
+        value = _read_fixture(fixture)
+        schema_name = "roadmap-draft.schema.json"
+        function_name = "validateAndNormalizeRoadmapDraft"
+        if mutation == "draft-missing-pending-questions":
+            del value["pending_questions"]
+        elif mutation == "draft-missing-lane-order":
+            del value["lanes"][0]["order"]
+        elif mutation == "draft-image-missing-region":
+            del value["items"][0]["source"]["region"]
+        elif mutation == "draft-lane-id-alias":
+            value["items"][0]["lane_id"] = value["items"][0].pop("lane_ref")
+        elif mutation == "draft-string-confidence":
+            value["items"][0]["source"]["confidence"] = "0.9"
+        elif mutation == "draft-invalid-calendar-date":
+            value["items"][0]["start"] = "2026-02-30"
+        else:
+            del value["items"][0]["progress"]
+    else:
+        value = _read_fixture("roadmap-spec-v1.json")
+        schema_name = "roadmap-spec.schema.json"
+        function_name = "validateAndNormalizeRoadmapSpec"
+        if mutation == "spec-legend-extra-field":
+            value["legend"][0]["extra"] = True
+        elif mutation == "spec-bar-missing-end":
+            del value["items"][0]["end"]
+        elif mutation == "spec-invalid-calendar-date":
+            value["items"][0]["start"] = "2026-02-30"
+        else:
+            milestone = next(item for item in value["items"] if item["kind"] == "milestone")
+            milestone["end"] = "2026-09-17"
+
+    assert list(_schema_validator(schema_name).iter_errors(value))
+    runtime = _runtime_validation(tmp_path, value, function_name)
+    assert runtime["ok"] is False
+    assert runtime["issues"]
+
+
+def test_missing_date_blocks_spec_without_inventing_a_value(tmp_path) -> None:
+    draft = _read_fixture("draft-natural-language.json")
+    del draft["items"][0]["end"]
+    source = tmp_path / "missing-date.json"
+    output = tmp_path / "should-not-exist.json"
+    report = tmp_path / "missing-date-report.json"
+    _write_json(source, draft)
+
+    result = _run(
+        "compile_roadmap_spec.js",
+        str(source),
+        "--out",
+        str(output),
+        "--report",
+        str(report),
+    )
+
+    assert result.returncode == 1
+    assert not output.exists()
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert "items.0.end: required for bar item" in payload["issues"]
+    assert payload["pending_questions"] == [
+        {
+            "field_path": "items.0.end",
+            "prompt": "“Roadmap 数据契约”在哪一天结束（结束日不包含）？",
+            "reason": "bar interval uses [start, end)",
+        }
+    ]
+
+
+def test_source_provenance_requires_image_region(tmp_path) -> None:
+    draft = _read_fixture("draft-image.json")
+    del draft["items"][0]["source"]["region"]
+    source = tmp_path / "missing-image-region.json"
+    report = tmp_path / "missing-image-region-report.json"
+    _write_json(source, draft)
+
+    result = _run(
+        "compile_roadmap_spec.js",
+        str(source),
+        "--out",
+        str(tmp_path / "spec.json"),
+        "--report",
+        str(report),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert "items.0.source.region: required for image source" in payload["issues"]
+
+
+def test_generated_ids_are_stable_across_repeated_compilation(tmp_path) -> None:
+    first_result, _, first_output = _compile(tmp_path / "first", "draft-table.json")
+    second_result, _, second_output = _compile(tmp_path / "second", "draft-table.json")
+
+    assert first_result.returncode == second_result.returncode == 0
+    first = json.loads(first_output.read_text(encoding="utf-8"))
+    second = json.loads(second_output.read_text(encoding="utf-8"))
+    assert first == second
+    assert first["lanes"][0]["id"].startswith("lane-agent-box-")
+    assert first["items"][0]["id"].startswith("item-")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "issue"),
+    [
+        ("timezone", "range.start: expected valid YYYY-MM-DD"),
+        ("unknown-lane", "items.0.lane_id: unknown lane"),
+        ("milestone-end", "items.2.end: milestone uses start only"),
+        ("range-order", "range: expected [start, end) with start before end"),
+        ("invalid-continuation", "continuation.before: item must start at range.start"),
+        ("too-many-items", "items: expected at most 80"),
+    ],
+)
+def test_roadmap_spec_rejects_contract_violations(tmp_path, mutation, issue) -> None:
+    spec = _read_fixture("roadmap-spec-v1.json")
+    if mutation == "timezone":
+        spec["range"]["start"] = "2026-08-01T00:00:00Z"
+    elif mutation == "unknown-lane":
+        spec["items"][0]["lane_id"] = "missing"
+    elif mutation == "milestone-end":
+        spec["items"][2]["end"] = "2026-09-17"
+    elif mutation == "range-order":
+        spec["range"]["end"] = spec["range"]["start"]
+    elif mutation == "invalid-continuation":
+        spec["items"][1]["continuation"] = {"before": True}
+    elif mutation == "too-many-items":
+        template = spec["items"][0]
+        spec["items"] = []
+        for index in range(81):
+            item = deepcopy(template)
+            item["id"] = f"item-{index + 1}"
+            spec["items"].append(item)
+    source = tmp_path / f"invalid-{mutation}.json"
+    report = tmp_path / f"invalid-{mutation}-report.json"
+    _write_json(source, spec)
+
+    result = _run(
+        "compile_roadmap_spec.js",
+        str(source),
+        "--out",
+        str(tmp_path / "spec.json"),
+        "--report",
+        str(report),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert any(issue in entry for entry in payload["issues"])
+
+
+def test_geometry_matches_committed_golden_and_assigns_non_overlapping_tracks(tmp_path) -> None:
+    output = tmp_path / "roadmap-geometry.json"
+    result = _run(
+        "layout_roadmap.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--viewport",
+        "1440x900",
+        "--out",
+        str(output),
+    )
+
+    assert result.returncode == 0, result.stderr
+    geometry = json.loads(output.read_text(encoding="utf-8"))
+    golden = _read_fixture("roadmap-geometry-1440x900.json")
+    assert geometry == golden
+    assert len(geometry["lanes"]) == 4
+    tracks = {bar["id"]: bar["track"] for bar in geometry["bars"]}
+    assert tracks["contract-core"] != tracks["geometry-core"]
+    assert tracks["qa-window"] != next(
+        milestone["track"]
+        for milestone in geometry["milestones"]
+        if milestone["id"] == "qa-signoff"
+    )
+    assert geometry["lanes"][0]["track_count"] == 2
+    assert {bar["line_style"] for bar in geometry["bars"]} == {"solid", "dashed"}
+    assert [marker["direction"] for marker in geometry["continuations"]] == [
+        "before",
+        "after",
+    ]
+    assert geometry["bars"][0]["start"] == geometry["headers"][0]["start"]
+    assert geometry["bars"][-1]["end"] == geometry["headers"][2]["end"]
+    for label in geometry["labels"]:
+        assert label["x"] >= geometry["canvas"]["plot_left"]
+        assert label["x"] + label["width"] <= geometry["canvas"]["plot_right"]
+
+
+def test_geometry_rejects_viewports_below_minimum(tmp_path) -> None:
+    result = _run(
+        "layout_roadmap.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--viewport",
+        "639x360",
+        "--out",
+        str(tmp_path / "roadmap-geometry.json"),
+    )
+
+    assert result.returncode == 1
+    assert "viewport: expected at least 640x360" in result.stderr
+
+
+def test_html_renderer_emits_controlled_editable_artifact_metadata(tmp_path) -> None:
+    output = tmp_path / "roadmap.html"
+    result = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(output),
+    )
+
+    assert result.returncode == 0, result.stderr
+    metadata = json.loads(result.stdout)
+    assert metadata["mime_type"] == "text/html"
+    assert metadata["layout_id"] == "roadmap-swimlane-v1"
+    assert metadata["renderer_version"] == 1
+    assert metadata["editable"] is True
+    html = output.read_text(encoding="utf-8")
+    assert '<meta name="generator" content="Box Agent Roadmap Artifact v1"' in html
+    assert '<meta name="box-agent-artifact-layout-id" content="roadmap-swimlane-v1"' in html
+    assert 'id="deck-document"' in html
+    assert 'id="roadmap-geometry"' in html
+    assert 'id="roadmap-palette"' in html
+    assert 'data-palette-id="roadmap-default-v1"' in html
+    assert 'class="roadmap-actions" data-role="roadmap-actions" hidden' in html
+    assert '"id": "roadmap-default-v1"' in html
+    assert '"#8e6bf2"' in html
+    assert 'data-roadmap-runtime="editor"' in html
+    assert "roadmap-swimlane-v1" in html
+    assert html.count('class="roadmap-lane"') == 4
+    assert html.count('class="roadmap-bar"') == 6
+    assert html.count('class="roadmap-milestone"') == 3
+    assert 'data-role="editor-backdrop" hidden' in html
+    assert 'data-progress="doing"' in html
+    assert "document-skills/pptx" not in html
+
+    editor_source = (SKILL_DIR / "runtime" / "roadmap-editor.js").read_text(
+        encoding="utf-8"
+    )
+    assert "actions.hidden = !hostEditAvailable" in editor_source
+    assert "clone.querySelector('[data-role=\"roadmap-actions\"]').hidden = true" in editor_source
+
+
+def test_default_palette_is_registered_once_and_shared_with_editor_runtime() -> None:
+    registry = json.loads(
+        (SKILL_DIR / "runtime" / "registry.json").read_text(encoding="utf-8")
+    )
+    assert registry["default_palette_id"] == "roadmap-default-v1"
+    palette = next(
+        entry for entry in registry["palettes"] if entry["id"] == "roadmap-default-v1"
+    )
+    assert palette["colors"] == [
+        "#8e6bf2",
+        "#7092fa",
+        "#56d9b6",
+        "#ebaf78",
+        "#f96565",
+        "#96dee8",
+        "#9f5f8f",
+        "#78d3f8",
+        "#21d3c5",
+        "#f9c955",
+        "#ff9999",
+    ]
+    editor_source = (SKILL_DIR / "runtime" / "roadmap-editor.js").read_text(
+        encoding="utf-8"
+    )
+    assert "#8e6bf2" not in editor_source
+    assert '#roadmap-palette' in editor_source
+
+
+def test_editor_localizes_progress_and_explains_milestone_end_date() -> None:
+    editor_source = (SKILL_DIR / "runtime" / "roadmap-editor.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert '{ value: "planned", label: "计划中" }' in editor_source
+    assert '{ value: "doing", label: "进行中" }' in editor_source
+    assert '{ value: "done", label: "已完成" }' in editor_source
+    assert '{ value: "blocked", label: "受阻" }' in editor_source
+    assert 'input.value = isMilestone ? "无需结束日期"' in editor_source
+    assert "input.disabled = isMilestone" in editor_source
+
+
+def test_editor_uses_icon_actions_and_closes_from_the_backdrop() -> None:
+    editor_source = (SKILL_DIR / "runtime" / "roadmap-editor.js").read_text(
+        encoding="utf-8"
+    )
+    editor_css = (SKILL_DIR / "runtime" / "roadmap.css").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'icon: "close", iconOnly: true' in editor_source
+    assert 'icon: "plus", variant: "primary"' in editor_source
+    assert 'icon: "trash", iconOnly: true, variant: "danger"' in editor_source
+    assert 'editorBackdrop.addEventListener("click", () => setEditorOpen(false))' in editor_source
+    assert 'node.dataset.progress = item.progress' in editor_source
+    assert 'font-size: 12px;' in editor_css
+    assert 'font-weight: 540;' in editor_css
+    assert '.roadmap-button[data-variant="primary"] svg { width: 14px; height: 14px; }' in editor_css
+
+
+def test_editor_custom_select_opens_away_from_the_trigger_and_escapes_table_clipping() -> None:
+    editor_source = (SKILL_DIR / "runtime" / "roadmap-editor.js").read_text(
+        encoding="utf-8"
+    )
+    editor_css = (SKILL_DIR / "runtime" / "roadmap.css").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'menu.setAttribute("popover", "manual")' in editor_source
+    assert 'menu.style.top = `${rect.bottom + 4}px`' in editor_source
+    assert 'menu.style.top = `${rect.top - menuRect.height - 4}px`' in editor_source
+    assert 'trigger.setAttribute("role", "combobox")' in editor_source
+    assert 'menu.setAttribute("role", "listbox")' in editor_source
+    assert 'if (event.defaultPrevented || event.key !== "Escape"' in editor_source
+    assert '.roadmap-select-menu {' in editor_css
+    assert 'position: fixed;' in editor_css
+
+
+def test_html_renderer_marks_blocked_bars_with_a_full_status_layer(tmp_path) -> None:
+    spec = _read_fixture("roadmap-spec-v1.json")
+    blocked_item = next(item for item in spec["items"] if item["kind"] == "bar")
+    blocked_item["progress"] = "blocked"
+    source = tmp_path / "blocked.json"
+    output = tmp_path / "blocked.html"
+    _write_json(source, spec)
+
+    result = _run("render_roadmap_html.js", str(source), "--out", str(output))
+
+    assert result.returncode == 0, result.stderr
+    html = output.read_text(encoding="utf-8")
+    marker = html.index(f'data-item-id="{blocked_item["id"]}"')
+    tag_start = html.rfind("<div", 0, marker)
+    progress_end = html.index("</div>", marker)
+    blocked_markup = html[tag_start:progress_end]
+    assert 'data-progress="blocked"' in blocked_markup
+    assert "· 受阻" in blocked_markup
+    assert 'class="roadmap-bar-progress" style="width:100%"' in blocked_markup
+
+
+def test_html_renderer_compacts_partial_half_month_header(tmp_path) -> None:
+    spec = _read_fixture("roadmap-spec-v1.json")
+    spec["range"]["end"] = "2026-11-03"
+    release = next(item for item in spec["items"] if item["id"] == "release-candidate")
+    release["end"] = "2026-11-03"
+    source = tmp_path / "partial-half-month.json"
+    output = tmp_path / "partial-half-month.html"
+    _write_json(source, spec)
+
+    result = _run("render_roadmap_html.js", str(source), "--out", str(output))
+
+    assert result.returncode == 0, result.stderr
+    html = output.read_text(encoding="utf-8")
+    assert 'data-kind="half-month" title="上半月"' in html
+    assert ">上</div>" in html
+
+
+def test_html_renderer_escapes_user_text_and_rejects_over_capacity(tmp_path) -> None:
+    spec = _read_fixture("roadmap-spec-v1.json")
+    spec["title"] = '<img src=x onerror="alert(1)">'
+    spec["items"][0]["title"] = "</script><script>alert(2)</script>"
+    source = tmp_path / "unsafe.json"
+    output = tmp_path / "safe.html"
+    _write_json(source, spec)
+
+    result = _run("render_roadmap_html.js", str(source), "--out", str(output))
+
+    assert result.returncode == 0, result.stderr
+    html = output.read_text(encoding="utf-8")
+    assert '<img src=x onerror="alert(1)">' not in html
+    assert "</script><script>alert(2)</script>" not in html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
+    assert "\\u003c/script>\\u003cscript>alert(2)\\u003c/script>" in html
+
+    over_capacity = _read_fixture("roadmap-spec-v1.json")
+    template = over_capacity["items"][0]
+    over_capacity["items"] = []
+    for index in range(81):
+        item = deepcopy(template)
+        item["id"] = f"capacity-{index + 1}"
+        over_capacity["items"].append(item)
+    over_capacity_path = tmp_path / "over-capacity.json"
+    _write_json(over_capacity_path, over_capacity)
+    rejected = _run(
+        "render_roadmap_html.js",
+        str(over_capacity_path),
+        "--out",
+        str(tmp_path / "must-not-exist.html"),
+    )
+    assert rejected.returncode == 1
+    assert "items: expected at most 80" in rejected.stderr
+
+
+def test_html_runtime_scripts_are_valid_javascript() -> None:
+    for script in [
+        SCRIPTS_DIR / "build_roadmap_artifact.js",
+        SCRIPTS_DIR / "roadmap_html_core.js",
+        SCRIPTS_DIR / "render_roadmap_html.js",
+        SCRIPTS_DIR / "extract_roadmap_spec.js",
+        SKILL_DIR / "runtime" / "roadmap-editor.js",
+    ]:
+        result = subprocess.run(
+            [str(NODE), "--check", str(script)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"{script}: {result.stderr}"
+
+
+def test_unified_builder_leaves_only_versioned_html_and_consumes_draft(tmp_path) -> None:
+    draft = tmp_path / "roadmap-draft.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", draft)
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(draft),
+        "--out",
+        str(tmp_path / "product-roadmap.html"),
+        "--consume-input",
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["filename"] == "product-roadmap-v1.html"
+    assert report["generation_version"] == 1
+    assert not draft.exists()
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["product-roadmap-v1.html"]
+    html = (tmp_path / "product-roadmap-v1.html").read_text(encoding="utf-8")
+    assert 'name="box-agent-roadmap-generation-version" content="1"' in html
+    assert 'data-generation-version="1"' in html
+
+
+def test_unified_builder_rejects_unsafe_existing_version_without_retrying(tmp_path) -> None:
+    unsafe_version = tmp_path / "product-roadmap-v9007199254740992.html"
+    unsafe_version.write_text("existing", encoding="utf-8")
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(tmp_path / "product-roadmap.html"),
+    )
+
+    assert result.returncode != 0
+    assert "outside the supported range" in result.stderr
+    assert unsafe_version.read_text(encoding="utf-8") == "existing"
+
+
+def test_unified_builder_reports_low_confidence_confirmation_questions(tmp_path) -> None:
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(FIXTURES_DIR / "draft-image.json"),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["pending_questions"] == [
+        {
+            "field_path": "items.0.start",
+            "prompt": "请确认“预览集成”的起止日期。",
+            "reason": "date confidence is below 0.8",
+        }
+    ]
+    assert report["status"] == "preview"
+
+
+def test_unified_builder_preserves_confirmation_gate_across_html_versions(tmp_path) -> None:
+    draft = tmp_path / "draft-image.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-image.json", draft)
+    first = _run(
+        "build_roadmap_artifact.js",
+        str(draft),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+        "--consume-input",
+    )
+    assert first.returncode == 0, first.stderr
+    assert not draft.exists()
+
+    second = _run(
+        "build_roadmap_artifact.js",
+        json.loads(first.stdout)["path"],
+        "--out",
+        str(tmp_path / "roadmap.html"),
+    )
+
+    assert second.returncode == 0, second.stderr
+    report = json.loads(second.stdout)
+    assert report["status"] == "preview"
+    assert report["pending_questions"][0]["field_path"] == "items.0.start"
+    html = Path(report["path"]).read_text(encoding="utf-8")
+    assert 'id="roadmap-pending-questions"' in html
+
+
+def test_unified_builder_clears_confirmation_gate_for_confirmed_spec(tmp_path) -> None:
+    spec = _read_fixture("roadmap-spec-v1.json")
+    for item in spec["items"]:
+        item["certainty"] = "confirmed"
+    spec["items"][0]["certainty"] = "tentative"
+    source = tmp_path / "tentative.json"
+    _write_json(source, spec)
+    preview = _run(
+        "build_roadmap_artifact.js",
+        str(source),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+    )
+    assert json.loads(preview.stdout)["status"] == "preview"
+
+    spec["items"][0]["certainty"] = "confirmed"
+    _write_json(source, spec)
+    final = _run(
+        "build_roadmap_artifact.js",
+        str(source),
+        "--out",
+        str(tmp_path / "confirmed.html"),
+    )
+
+    assert final.returncode == 0, final.stderr
+    assert json.loads(final.stdout)["status"] == "final"
+    assert json.loads(final.stdout)["pending_questions"] == []
+
+
+def test_saved_html_confirmation_clears_persisted_pending_question(tmp_path) -> None:
+    first = _run(
+        "build_roadmap_artifact.js",
+        str(FIXTURES_DIR / "draft-image.json"),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+    )
+    html_path = Path(json.loads(first.stdout)["path"])
+    html = html_path.read_text(encoding="utf-8")
+    start_marker = '<script type="application/json" id="deck-document">'
+    start = html.index(start_marker) + len(start_marker)
+    end = html.index("</script>", start)
+    spec = json.loads(html[start:end])
+    for item in spec["items"]:
+        item["certainty"] = "confirmed"
+    html_path.write_text(
+        html[:start]
+        + "\n"
+        + json.dumps(spec, ensure_ascii=False, indent=2).replace("<", "\\u003c")
+        + "\n  "
+        + html[end:],
+        encoding="utf-8",
+    )
+
+    follow_up = _run(
+        "build_roadmap_artifact.js",
+        str(html_path),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+    )
+
+    assert follow_up.returncode == 0, follow_up.stderr
+    report = json.loads(follow_up.stdout)
+    assert report["status"] == "final"
+    assert report["pending_questions"] == []
+
+
+def test_unified_builder_emits_structured_error_report(tmp_path) -> None:
+    draft = _read_fixture("draft-natural-language.json")
+    del draft["items"][0]["end"]
+    source = tmp_path / "missing-date.json"
+    _write_json(source, draft)
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(source),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+    )
+
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["ok"] is False
+    assert "items.0.end: required for bar item" in report["issues"]
+    assert report["pending_questions"][0]["field_path"] == "items.0.end"
+
+
+def test_roadmap_outputs_cannot_escape_configured_artifact_root(tmp_path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    env = {**os.environ, "BOX_AGENT_OUTPUT_DIR": str(output_dir)}
+
+    traversal = _run(
+        "build_roadmap_artifact.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        "../escaped.html",
+        env=env,
+    )
+    absolute = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(tmp_path / "absolute.html"),
+        env=env,
+    )
+
+    assert traversal.returncode == 1
+    assert "must stay within BOX_AGENT_OUTPUT_DIR" in traversal.stderr
+    assert absolute.returncode == 1
+    assert "must stay within BOX_AGENT_OUTPUT_DIR" in absolute.stderr
+    assert not (tmp_path / "escaped-v1.html").exists()
+    assert not (tmp_path / "absolute.html").exists()
+
+
+def test_roadmap_outputs_reject_symlink_targets_and_parent_segments(tmp_path) -> None:
+    output_dir = tmp_path / "output"
+    outside_dir = tmp_path / "outside"
+    output_dir.mkdir()
+    outside_dir.mkdir()
+    outside_file = outside_dir / "original.html"
+    outside_file.write_text("do not replace", encoding="utf-8")
+    target_link = output_dir / "link.html"
+    parent_link = output_dir / "linked-directory"
+    try:
+        target_link.symlink_to(outside_file)
+        parent_link.symlink_to(outside_dir, target_is_directory=True)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlinks are unavailable in this environment: {error}")
+    env = {**os.environ, "BOX_AGENT_OUTPUT_DIR": str(output_dir)}
+
+    target_result = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        "link.html",
+        env=env,
+    )
+    parent_result = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        "linked-directory/roadmap.html",
+        env=env,
+    )
+
+    assert target_result.returncode == 1
+    assert "symlink or reparse point" in target_result.stderr
+    assert parent_result.returncode == 1
+    assert (
+        "symlink or reparse point" in parent_result.stderr
+        or "resolves outside BOX_AGENT_OUTPUT_DIR" in parent_result.stderr
+    )
+    assert outside_file.read_text(encoding="utf-8") == "do not replace"
+    assert not (outside_dir / "roadmap.html").exists()
+
+
+def test_roadmap_output_rolls_back_when_parent_changes_during_publication(
+    tmp_path,
+) -> None:
+    if NODE is None:
+        pytest.skip("Node.js is required to test Roadmap output publication")
+    output_dir = tmp_path / "output"
+    nested_dir = output_dir / "nested"
+    outside_dir = tmp_path / "outside"
+    moved_dir = outside_dir / "moved"
+    nested_dir.mkdir(parents=True)
+    outside_dir.mkdir()
+    script = """
+const fs = require('fs');
+const path = require('path');
+const io = require(process.argv[1]);
+const outputRoot = process.argv[2];
+const nested = path.join(outputRoot, 'nested');
+const moved = process.argv[3];
+const originalRename = fs.renameSync;
+let swapped = false;
+fs.renameSync = (source, target) => {
+  if (!swapped && path.basename(source).endsWith('.tmp')) {
+    swapped = true;
+    originalRename(nested, moved);
+    fs.symlinkSync(moved, nested, 'dir');
+  }
+  return originalRename(source, target);
+};
+try {
+  io.writeOutputFileSync('nested/roadmap.html', '<html></html>');
+  process.exitCode = 2;
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+"""
+
+    result = subprocess.run(
+        [
+            str(NODE),
+            "-e",
+            script,
+            str(SCRIPTS_DIR / "roadmap_io.js"),
+            str(output_dir),
+            str(moved_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=SKILL_DIR,
+        env={**os.environ, "BOX_AGENT_OUTPUT_DIR": str(output_dir)},
+    )
+
+    assert result.returncode == 1
+    assert "output path must not contain a symlink or reparse point" in result.stderr
+    assert not (moved_dir / "roadmap.html").exists()
+
+
+def test_unified_builder_rejects_consuming_symlink_targets_and_parent_segments(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output"
+    outside_dir = tmp_path / "outside"
+    output_dir.mkdir()
+    outside_dir.mkdir()
+    outside_draft = outside_dir / "draft.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", outside_draft)
+    target_link = output_dir / "draft-link.json"
+    parent_link = output_dir / "linked-directory"
+    try:
+        target_link.symlink_to(outside_draft)
+        parent_link.symlink_to(outside_dir, target_is_directory=True)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlinks are unavailable in this environment: {error}")
+    env = {**os.environ, "BOX_AGENT_OUTPUT_DIR": str(output_dir)}
+
+    target_result = _run(
+        "build_roadmap_artifact.js",
+        "draft-link.json",
+        "--out",
+        "target-roadmap.html",
+        "--consume-input",
+        env=env,
+    )
+    parent_result = _run(
+        "build_roadmap_artifact.js",
+        "linked-directory/draft.json",
+        "--out",
+        "parent-roadmap.html",
+        "--consume-input",
+        env=env,
+    )
+
+    assert target_result.returncode == 1
+    assert (
+        "input path must not contain a symlink or reparse point"
+        in target_result.stderr
+    )
+    assert parent_result.returncode == 1
+    assert (
+        "input path must not contain a symlink or reparse point"
+        in parent_result.stderr
+    )
+    assert outside_draft.exists()
+    assert not list(output_dir.glob("*-roadmap-v*.html"))
+
+
+def test_consumed_input_identity_is_rechecked_before_deletion(tmp_path) -> None:
+    if NODE is None:
+        pytest.skip("Node.js is required to test Roadmap input consumption")
+    source = tmp_path / "draft.json"
+    replacement = tmp_path / "replacement.json"
+    shutil.copyfile(FIXTURES_DIR / "draft-natural-language.json", source)
+    replacement.write_text("replacement", encoding="utf-8")
+    script = """
+const fs = require('fs');
+const io = require(process.argv[1]);
+const source = process.argv[2];
+const replacement = process.argv[3];
+const snapshot = io.snapshotArtifactFileSync(source);
+fs.unlinkSync(source);
+fs.renameSync(replacement, source);
+try {
+  io.consumeArtifactFileSync(source, snapshot.identity);
+  process.exitCode = 2;
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+"""
+
+    result = subprocess.run(
+        [
+            str(NODE),
+            "-e",
+            script,
+            str(SCRIPTS_DIR / "roadmap_io.js"),
+            str(source),
+            str(replacement),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=SKILL_DIR,
+    )
+
+    assert result.returncode == 1
+    assert "consumed input changed before deletion" in result.stderr
+    assert source.read_text(encoding="utf-8") == "replacement"
+
+
+def test_roadmap_output_replacement_is_atomic_and_leaves_no_temporary_file(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    output = output_dir / "roadmap.html"
+    output.write_text("old content", encoding="utf-8")
+    env = {**os.environ, "BOX_AGENT_OUTPUT_DIR": str(output_dir)}
+
+    result = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        "roadmap.html",
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "old content" not in output.read_text(encoding="utf-8")
+    assert not list(output_dir.glob(".roadmap.html.*.tmp"))
+
+
+def test_unified_builder_rejects_consuming_persisted_spec(tmp_path) -> None:
+    source = tmp_path / "roadmap-spec.json"
+    shutil.copyfile(FIXTURES_DIR / "roadmap-spec-v1.json", source)
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(source),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+        "--consume-input",
+    )
+
+    assert result.returncode == 1
+    assert "--consume-input is only allowed for RoadmapDraft input" in result.stderr
+    assert source.exists()
+    assert not list(tmp_path.glob("roadmap-v*.html"))
+
+
+def test_unified_builder_preserves_every_generated_html_version(tmp_path) -> None:
+    source = FIXTURES_DIR / "roadmap-spec-v1.json"
+    first = _run(
+        "build_roadmap_artifact.js",
+        str(source),
+        "--out",
+        str(tmp_path / "product-roadmap.html"),
+    )
+    assert first.returncode == 0, first.stderr
+    first_path = tmp_path / "product-roadmap-v1.html"
+    first_bytes = first_path.read_bytes()
+
+    second = _run(
+        "build_roadmap_artifact.js",
+        str(first_path),
+        "--out",
+        str(tmp_path / "product-roadmap.html"),
+    )
+
+    assert second.returncode == 0, second.stderr
+    report = json.loads(second.stdout)
+    assert report["filename"] == "product-roadmap-v2.html"
+    assert report["generation_version"] == 2
+    assert first_path.read_bytes() == first_bytes
+    assert (tmp_path / "product-roadmap-v2.html").exists()
+    assert not (tmp_path / "product-roadmap.html").exists()
+
+
+def test_unified_builder_treats_legacy_unversioned_html_as_v1(tmp_path) -> None:
+    (tmp_path / "product-roadmap.html").write_text("legacy", encoding="utf-8")
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(tmp_path / "product-roadmap.html"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["filename"] == "product-roadmap-v2.html"
+    assert (tmp_path / "product-roadmap.html").read_text(encoding="utf-8") == "legacy"
+
+
+def test_unified_builder_keeps_json_only_when_debug_is_explicit(tmp_path) -> None:
+    debug_dir = tmp_path / "debug"
+
+    result = _run(
+        "build_roadmap_artifact.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(tmp_path / "roadmap.html"),
+        "--debug-dir",
+        str(debug_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert sorted(path.name for path in debug_dir.iterdir()) == [
+        "roadmap-build-report.json",
+        "roadmap-geometry.json",
+        "roadmap-spec-v1.json",
+    ]
+
+
+def test_saved_html_embedded_spec_is_the_follow_up_source_of_truth(tmp_path) -> None:
+    html_path = tmp_path / "roadmap.html"
+    rendered = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(html_path),
+    )
+    assert rendered.returncode == 0, rendered.stderr
+
+    stale_sidecar = _read_fixture("roadmap-spec-v1.json")
+    stale_sidecar["title"] = "旧 sidecar 标题"
+    _write_json(tmp_path / "roadmap-spec.json", stale_sidecar)
+
+    latest = _read_fixture("roadmap-spec-v1.json")
+    latest["title"] = "保存后的最新标题"
+    html = html_path.read_text(encoding="utf-8")
+    start_marker = '<script type="application/json" id="deck-document">'
+    start = html.index(start_marker) + len(start_marker)
+    end = html.index("</script>", start)
+    html_path.write_text(
+        html[:start]
+        + "\n"
+        + json.dumps(latest, ensure_ascii=False, indent=2).replace("<", "\\u003c")
+        + "\n  "
+        + html[end:],
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "latest.json"
+    extracted = _run(
+        "extract_roadmap_spec.js",
+        str(html_path),
+        "--out",
+        str(output),
+    )
+
+    assert extracted.returncode == 0, extracted.stderr
+    assert json.loads(output.read_text(encoding="utf-8"))["title"] == "保存后的最新标题"
+    assert json.loads(extracted.stdout)["source_of_truth"] == "#deck-document"
+
+
+def test_artifact_event_reads_roadmap_html_metadata(tmp_path) -> None:
+    from box_agent.artifacts import make_artifact
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    output = output_dir / "roadmap.html"
+    result = _run(
+        "render_roadmap_html.js",
+        str(FIXTURES_DIR / "roadmap-spec-v1.json"),
+        "--out",
+        str(output),
+    )
+    assert result.returncode == 0, result.stderr
+
+    artifact = make_artifact("tool-1", output, tmp_path)
+    assert artifact.mime == "text/html"
+    assert artifact.layout_id == "roadmap-swimlane-v1"
+
+
+@pytest.mark.parametrize(
+    ("item_count", "diagnostic_code"),
+    [(30, "capacity.dense"), (80, "capacity.items-at-limit")],
+)
+def test_dense_capacity_cases_render_with_structured_diagnostics(
+    tmp_path, item_count, diagnostic_code
+) -> None:
+    cases = _read_fixture("capacity-cases.json")
+    assert any(case["items"] == item_count for case in cases["cases"])
+    spec = _read_fixture("roadmap-spec-v1.json")
+    template = spec["items"][0]
+    spec["items"] = []
+    for index in range(item_count):
+        item = deepcopy(template)
+        item["id"] = f"dense-{index + 1}"
+        spec["items"].append(item)
+    source = tmp_path / f"dense-{item_count}.json"
+    output = tmp_path / f"dense-{item_count}.html"
+    _write_json(source, spec)
+
+    result = _run("render_roadmap_html.js", str(source), "--out", str(output))
+
+    assert result.returncode == 0, result.stderr
+    metadata = json.loads(result.stdout)
+    assert diagnostic_code in {entry["code"] for entry in metadata["diagnostics"]}
+    assert output.exists()
+
+
+def test_eighty_item_renderer_stays_below_interaction_budget(tmp_path) -> None:
+    spec = _read_fixture("roadmap-spec-v1.json")
+    template = spec["items"][0]
+    spec["items"] = []
+    for index in range(80):
+        item = deepcopy(template)
+        item["id"] = f"performance-{index + 1}"
+        spec["items"].append(item)
+    source = tmp_path / "performance-80.json"
+    _write_json(source, spec)
+    script = """
+const fs = require('fs');
+const { performance } = require('perf_hooks');
+const { renderRoadmapHtml } = require(process.argv[1]);
+const spec = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+renderRoadmapHtml(spec);
+const samples = [];
+for (let index = 0; index < 7; index += 1) {
+  const started = performance.now();
+  renderRoadmapHtml(spec);
+  samples.push(performance.now() - started);
+}
+samples.sort((left, right) => left - right);
+console.log(JSON.stringify({ p90: samples[5], max: samples[6] }));
+"""
+    result = subprocess.run(
+        [
+            str(NODE),
+            "-e",
+            script,
+            str(SCRIPTS_DIR / "roadmap_html_core.js"),
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=SKILL_DIR,
+    )
+
+    assert result.returncode == 0, result.stderr
+    timings = json.loads(result.stdout)
+    assert timings["p90"] < 100, timings

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -1,0 +1,530 @@
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from box_agent.acp import BoxACPAgent
+from box_agent.config import AgentConfig, Config, LLMConfig, ToolsConfig
+from box_agent.runtime_capabilities import _REQUIRED_ROADMAP_RESOURCES, runtime_capabilities
+from box_agent.tools.runtime import SkillRuntime, SkillRuntimeContext
+
+
+class _DummyConn:
+    def __init__(self) -> None:
+        self.ext_notifications = []
+
+    async def sessionUpdate(self, _payload) -> None:
+        return None
+
+    async def extNotification(self, method, params) -> None:
+        self.ext_notifications.append((method, params))
+
+
+def _config(tmp_path, *, enable_skills: bool = True) -> Config:
+    return Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(
+            workspace_dir=str(tmp_path),
+            enable_memory_extraction=False,
+        ),
+        tools=ToolsConfig(
+            enable_todo=False,
+            enable_sub_agent=False,
+            enable_skills=enable_skills,
+        ),
+    )
+
+
+def _copy_roadmap_skill_tree(tmp_path: Path) -> Path:
+    source = Path(__file__).resolve().parents[1] / "box_agent" / "skills" / "roadmap"
+    skills_root = tmp_path / "skills"
+    copied_root = skills_root / "roadmap"
+    shutil.copytree(source, copied_root)
+    shutil.copy2(source.parent / "_manifest.json", skills_root / "_manifest.json")
+    return copied_root
+
+
+def test_runtime_capabilities_advertise_independent_html_renderer() -> None:
+    capabilities = runtime_capabilities(
+        node_available=True,
+    )
+
+    assert capabilities == {
+        "contract": "box-agent.runtime-capabilities",
+        "contractVersion": 1,
+        "deckProtocolVersion": 1,
+        "roadmap": {
+            "schemaVersion": 1,
+            "geometryVersion": 1,
+            "rendererVersion": 1,
+            "capabilities": [
+                "roadmap.generate.html",
+                "roadmap.preview",
+                "roadmap.edit",
+            ],
+        },
+    }
+
+
+def test_runtime_capabilities_match_frozen_cross_repo_fixture() -> None:
+    references = (
+        Path(__file__).resolve().parents[1]
+        / "box_agent"
+        / "skills"
+        / "roadmap"
+        / "references"
+    )
+    fixture = references / "runtime-capabilities-v1.json"
+    schema = json.loads(
+        (references / "runtime-capabilities-v1.schema.json").read_text(encoding="utf-8")
+    )
+    validator = Draft202012Validator(schema)
+
+    frozen = json.loads(fixture.read_text(encoding="utf-8"))
+    validator.validate(frozen)
+    assert runtime_capabilities(
+        node_available=True,
+    ) == frozen
+
+    invalid = json.loads(fixture.read_text(encoding="utf-8"))
+    invalid["roadmap"]["rendererVersion"] = None
+    with pytest.raises(ValidationError, match="None is not of type 'integer'"):
+        validator.validate(invalid)
+
+
+def test_runtime_capabilities_returns_an_isolated_copy() -> None:
+    capabilities = runtime_capabilities(
+        node_available=True,
+    )
+    capabilities["roadmap"]["capabilities"].append("roadmap.future")
+
+    fresh_capabilities = runtime_capabilities(
+        node_available=True,
+    )
+    assert "roadmap.future" not in fresh_capabilities["roadmap"]["capabilities"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"skills_enabled": False, "node_available": True},
+        {"skills_enabled": True, "node_available": False},
+    ],
+)
+def test_runtime_capabilities_fail_closed_when_runtime_requirements_are_missing(kwargs) -> None:
+    capabilities = runtime_capabilities(**kwargs)
+    references = (
+        Path(__file__).resolve().parents[1]
+        / "box_agent"
+        / "skills"
+        / "roadmap"
+        / "references"
+    )
+    schema = json.loads(
+        (references / "runtime-capabilities-v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    Draft202012Validator(schema).validate(capabilities)
+    assert capabilities["roadmap"]["rendererVersion"] is None
+    assert capabilities["roadmap"]["capabilities"] == []
+
+
+def test_runtime_capabilities_fail_closed_when_resources_or_manifest_are_missing(
+    tmp_path,
+) -> None:
+    missing_resources = runtime_capabilities(
+        node_available=True,
+        skill_root=tmp_path / "missing-skill",
+    )
+    missing_manifest = runtime_capabilities(
+        node_available=True,
+        capabilities_path=tmp_path / "missing-capabilities.json",
+    )
+
+    assert missing_resources["roadmap"]["capabilities"] == []
+    assert missing_manifest["roadmap"]["capabilities"] == []
+
+
+@pytest.mark.parametrize(
+    "missing_resource",
+    _REQUIRED_ROADMAP_RESOURCES,
+)
+def test_runtime_capabilities_require_every_declared_runtime_resource(
+    tmp_path, missing_resource
+) -> None:
+    copied_root = _copy_roadmap_skill_tree(tmp_path)
+    (copied_root / missing_resource).unlink()
+
+    capabilities = runtime_capabilities(node_available=True, skill_root=copied_root)
+
+    assert capabilities["roadmap"]["capabilities"] == []
+
+
+def test_runtime_capabilities_require_roadmap_in_authoritative_builtin_manifest(
+    tmp_path,
+) -> None:
+    copied_root = _copy_roadmap_skill_tree(tmp_path)
+    manifest_path = copied_root.parent / "_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["skills"] = [
+        entry for entry in manifest["skills"] if entry.get("name") != "roadmap"
+    ]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    capabilities = runtime_capabilities(node_available=True, skill_root=copied_root)
+
+    assert capabilities["roadmap"]["rendererVersion"] is None
+    assert capabilities["roadmap"]["capabilities"] == []
+
+
+def test_runtime_capabilities_fail_closed_for_invalid_manifest_contract(tmp_path) -> None:
+    manifest = tmp_path / "runtime-capabilities.json"
+    manifest.write_text(
+        json.dumps({"roadmap": {"capabilities": ["roadmap.evil"]}}),
+        encoding="utf-8",
+    )
+
+    capabilities = runtime_capabilities(
+        node_available=True,
+        capabilities_path=manifest,
+    )
+
+    assert capabilities["roadmap"]["rendererVersion"] is None
+    assert capabilities["roadmap"]["capabilities"] == []
+
+
+@pytest.mark.asyncio
+async def test_acp_initialize_exposes_runtime_capabilities(tmp_path, monkeypatch) -> None:
+    expected = runtime_capabilities(
+        node_available=True,
+    )
+    calls = []
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: calls.append(kwargs) or expected,
+    )
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [{"name": "roadmap"}],
+        get_skill=lambda name: object() if name == "roadmap" else None,
+    )
+    agent = BoxACPAgent(
+        _DummyConn(),
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+    )
+
+    response = await agent.initialize(SimpleNamespace(field_meta={}))
+
+    assert response.field_meta["runtime_capabilities"] == expected
+    assert calls == [
+        {"skills_enabled": True, "roadmap_skill_available": True}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_acp_initialize_capabilities_fail_closed_for_empty_skill_catalog(
+    tmp_path, monkeypatch
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: calls.append(kwargs) or {"roadmap": {"capabilities": []}},
+    )
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [],
+        get_skill=lambda _name: None,
+    )
+    agent = BoxACPAgent(
+        _DummyConn(),
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+    )
+
+    await agent.initialize(SimpleNamespace(field_meta={}))
+
+    assert calls == [
+        {"skills_enabled": True, "roadmap_skill_available": False}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_acp_initialize_capabilities_fail_closed_without_skill_loader(
+    tmp_path, monkeypatch
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: calls.append(kwargs) or {"roadmap": {"capabilities": []}},
+    )
+    agent = BoxACPAgent(_DummyConn(), _config(tmp_path), object(), [], "system")
+
+    await agent.initialize(SimpleNamespace(field_meta={}))
+
+    assert calls == [
+        {"skills_enabled": True, "roadmap_skill_available": False}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_acp_initialize_does_not_wait_for_pending_skill_discovery(
+    tmp_path, monkeypatch
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: calls.append(kwargs) or {"roadmap": {"capabilities": []}},
+    )
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [{"name": "roadmap"}],
+        get_skill=lambda _name: object(),
+    )
+    agent = BoxACPAgent(
+        _DummyConn(),
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+        skill_task=skill_task,
+    )
+
+    response = await asyncio.wait_for(
+        agent.initialize(SimpleNamespace(field_meta={})),
+        timeout=1.0,
+    )
+
+    assert response.field_meta["runtime_capabilities"] == {
+        "roadmap": {"capabilities": []}
+    }
+    assert "skills" not in response.field_meta
+    assert calls == [
+        {"skills_enabled": True, "roadmap_skill_available": False}
+    ]
+    skill_task.cancel()
+    await asyncio.gather(skill_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_acp_new_session_publishes_final_runtime_capabilities(
+    tmp_path, monkeypatch
+) -> None:
+    expected = {"roadmap": {"capabilities": ["roadmap.preview"]}}
+    calls = []
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: calls.append(kwargs) or expected,
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.build_skill_runtime_context",
+        lambda **_kwargs: SkillRuntimeContext(
+            runtimes={
+                "python": SkillRuntime("python", "available", "box_agent"),
+                "node": SkillRuntime("node", "available", "box_agent"),
+            }
+        ),
+    )
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [{"name": "roadmap"}],
+        get_skill=lambda name: object() if name == "roadmap" else None,
+    )
+    agent = BoxACPAgent(
+        _DummyConn(),
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+    )
+
+    response = await agent.newSession(
+        SimpleNamespace(cwd=str(tmp_path), field_meta={})
+    )
+
+    assert response.field_meta["runtime_capabilities"] == expected
+    assert calls == [
+        {
+            "skills_enabled": True,
+            "node_available": True,
+            "roadmap_skill_available": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_acp_new_session_bounds_pending_skill_discovery_and_fails_closed(
+    tmp_path, monkeypatch
+) -> None:
+    calls = []
+    monkeypatch.setattr("box_agent.acp._SKILL_DISCOVERY_WAIT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: calls.append(kwargs) or {"roadmap": {"capabilities": []}},
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.build_skill_runtime_context",
+        lambda **_kwargs: SkillRuntimeContext(
+            runtimes={
+                "python": SkillRuntime("python", "available", "box_agent"),
+                "node": SkillRuntime("node", "available", "box_agent"),
+            }
+        ),
+    )
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [{"name": "roadmap"}],
+        get_skill=lambda name: object() if name == "roadmap" else None,
+    )
+    agent = BoxACPAgent(
+        _DummyConn(),
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+        skill_task=skill_task,
+    )
+
+    response = await asyncio.wait_for(
+        agent.newSession(SimpleNamespace(cwd=str(tmp_path), field_meta={})),
+        timeout=1.0,
+    )
+
+    assert response.sessionId
+    assert "skills" not in response.field_meta
+    assert calls[-1] == {
+        "skills_enabled": True,
+        "node_available": True,
+        "roadmap_skill_available": False,
+    }
+    assert agent._skills_loaded is False
+    assert skill_task.cancelled() is False
+    skill_task.cancel()
+    await asyncio.gather(skill_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_skill_wait_does_not_cancel_or_poison_discovery(
+    tmp_path,
+) -> None:
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [{"name": "roadmap"}],
+        get_skill=lambda name: object() if name == "roadmap" else None,
+    )
+    agent = BoxACPAgent(
+        _DummyConn(),
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+        skill_task=skill_task,
+    )
+
+    waiting = asyncio.create_task(agent._ensure_skills_loaded())
+    await asyncio.sleep(0)
+    waiting.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiting
+
+    assert skill_task.cancelled() is False
+    assert agent._skills_loaded is False
+    discovery_gate.set()
+    assert await agent._ensure_skills_loaded() is True
+    assert agent._skills_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_late_skill_discovery_publishes_session_capability_update(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("box_agent.acp._SKILL_DISCOVERY_WAIT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        "box_agent.acp.runtime_capabilities",
+        lambda **kwargs: {
+            "roadmap": {
+                "capabilities": (
+                    ["roadmap.generate.html"]
+                    if kwargs["roadmap_skill_available"]
+                    else []
+                )
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.build_skill_runtime_context",
+        lambda **_kwargs: SkillRuntimeContext(
+            runtimes={
+                "python": SkillRuntime("python", "available", "box_agent"),
+                "node": SkillRuntime("node", "available", "box_agent"),
+            }
+        ),
+    )
+    discovery_gate = asyncio.Event()
+    skill_task = asyncio.create_task(discovery_gate.wait())
+    skill_loader = SimpleNamespace(
+        maybe_reload=lambda: None,
+        list_skills_metadata=lambda: [{"name": "roadmap"}],
+        get_skill=lambda name: object() if name == "roadmap" else None,
+    )
+    conn = _DummyConn()
+    agent = BoxACPAgent(
+        conn,
+        _config(tmp_path),
+        object(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+        skill_task=skill_task,
+    )
+
+    response = await agent.newSession(
+        SimpleNamespace(cwd=str(tmp_path), field_meta={})
+    )
+    assert response.field_meta["runtime_capabilities"]["roadmap"]["capabilities"] == []
+
+    discovery_gate.set()
+    assert await agent._ensure_skills_loaded() is True
+    state = agent._sessions[response.sessionId]
+    await agent._publish_runtime_capabilities_if_changed(response.sessionId, state)
+
+    assert conn.ext_notifications == [
+        (
+            "box-agent/runtime-capabilities-update",
+            {
+                "contract": "box-agent.runtime-capabilities-update",
+                "contractVersion": 1,
+                "sessionId": response.sessionId,
+                "runtime_capabilities": {
+                    "roadmap": {"capabilities": ["roadmap.generate.html"]}
+                },
+            },
+        )
+    ]
+    assert state.runtime_capabilities == {
+        "roadmap": {"capabilities": ["roadmap.generate.html"]}
+    }

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -480,6 +480,34 @@ def test_user_source_not_filtered_by_manifest():
         assert loader.get_skill("builtin-orphan") is None
 
 
+def test_user_skill_cannot_override_reserved_roadmap_runtime():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        builtin_dir = root / "builtin"
+        user_dir = root / "user"
+        builtin_dir.mkdir()
+        user_dir.mkdir()
+
+        builtin_skill = builtin_dir / "roadmap"
+        builtin_skill.mkdir()
+        create_test_skill(
+            builtin_skill, "roadmap", "builtin roadmap", "trusted builtin content"
+        )
+        _write_manifest(builtin_dir, ["roadmap"])
+
+        user_skill = user_dir / "roadmap"
+        user_skill.mkdir()
+        create_test_skill(user_skill, "roadmap", "user roadmap", "override content")
+
+        loader = SkillLoader(sources=[(user_dir, "user"), (builtin_dir, "builtin")])
+        loader.discover_skills()
+
+        roadmap = loader.get_skill("roadmap")
+        assert roadmap is not None
+        assert roadmap.source == "builtin"
+        assert roadmap.content == "trusted builtin content"
+
+
 def test_skill_settings_disable_filters_loaded_skills():
     """officev3 disabled skills must not be listed or loadable via get_skill."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_skill_scratch.py
+++ b/tests/test_skill_scratch.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from box_agent.tools.skill_scratch import (
+    SKILL_SCRATCH_DIR_NAME,
+    cleanup_skill_scratch_dir,
+    prepare_skill_scratch_dir,
+)
+
+
+def test_prepare_and_cleanup_skill_scratch_dir(tmp_path: Path) -> None:
+    scratch = prepare_skill_scratch_dir(tmp_path)
+    scratch_dir = scratch.path
+    task_dir = scratch_dir / "roadmap-task"
+    task_dir.mkdir()
+    (task_dir / "draft.json").write_text("{}", encoding="utf-8")
+    link = scratch_dir / "external-link"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("keep", encoding="utf-8")
+    try:
+        link.symlink_to(outside)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlinks are unavailable in this environment: {error}")
+
+    removed = cleanup_skill_scratch_dir(scratch)
+
+    assert sorted(Path(item).name for item in removed) == [
+        "external-link",
+        "roadmap-task",
+    ]
+    assert scratch_dir.is_dir()
+    assert not list(scratch_dir.iterdir())
+    assert outside.read_text(encoding="utf-8") == "keep"
+
+
+def test_prepare_skill_scratch_dir_rejects_reserved_path_symlink(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    scratch_dir = tmp_path / SKILL_SCRATCH_DIR_NAME
+    try:
+        scratch_dir.symlink_to(outside, target_is_directory=True)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlinks are unavailable in this environment: {error}")
+
+    with pytest.raises(RuntimeError, match="must be a real directory"):
+        prepare_skill_scratch_dir(tmp_path)
+
+
+def test_cleanup_skill_scratch_dir_rejects_replaced_root(tmp_path: Path) -> None:
+    scratch = prepare_skill_scratch_dir(tmp_path)
+    moved = tmp_path / "moved-scratch"
+    scratch.path.rename(moved)
+    scratch.path.mkdir()
+    replacement = scratch.path / "keep.txt"
+    replacement.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="must be a real directory"):
+        cleanup_skill_scratch_dir(scratch)
+
+    assert replacement.read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
## TPR

### Task

- What changed: Added a built-in Roadmap skill with Draft/Spec schemas, deterministic layout, editable HTML rendering, extraction/migration, controlled artifact publication, and versioned runtime-capability negotiation. Skill discovery now uses a bounded wait, publishes session-scoped capability updates, and exposes a read-only `_runtime/capabilities` query so hosts can recover a stable snapshot without creating a conversation session. Roadmap temporary Drafts now use a reserved session scratch root (`BOX_AGENT_SCRATCH_DIR`) outside the deliverables-only output directory.
- Why: Enable the local agent to generate structured, editable Roadmap artifacts while giving desktop hosts an explicit, fail-closed capability and artifact contract. The scratch boundary resolves the conflict between `output/` being deliverables-only and `--consume-input` previously requiring Drafts to remain under `BOX_AGENT_OUTPUT_DIR`.
- Affected entry points: ACP `initialize`, `session/new`, `_runtime/capabilities`, CLI/ACP workspace-tool setup and turn cleanup, built-in skill discovery/preload, artifact publication, Roadmap build/render/extract/migrate scripts, and the embedded Roadmap editor runtime.
- Out of scope: Office v3 workspace-tree filtering and packaged-runtime installation/live-task integration, general-purpose HTML editing, and cloud execution paths.

### Proof

- Tests or checks run: On `main` at `4842ab64b23ef0015cb3729e73e2f36e28ca42d3`, `bash general_review/ci/preflight.sh` passed on Head `29198c5cfd1158a0991e406d1d8824d4e760b7cc` with `2874 passed, 17 skipped, 1 deselected`; source and wheel distributions built successfully. ACP/runtime-capability focused regression coverage passed with `146 passed`. Scratch/Roadmap focused regression coverage passed with `72 passed`, including success/failure cleanup, outside-root rejection, symlink rejection, and directory/file identity replacement checks. `git diff --check origin/main...HEAD` and Node syntax checks passed.
- Logs, screenshots, probes, or manifests: Regenerated `box_agent/skills/_manifest.json`; Roadmap Draft/Spec, runtime-capability schemas, fixtures, geometry examples, and scratch lifecycle tests are included in the branch.
- Not run, with reason: Packaged-runtime archive/install probe, Office v3 restart, and a fresh live Roadmap task remain release/integration gates.

### Risk

- Compatibility: Existing clients can ignore the additive runtime-capability metadata/events/query. Older runtimes return `unknown_method` to new hosts, which must keep the conservative initialize snapshot. `BOX_AGENT_SCRATCH_DIR` is additive and is configured for output-mode sessions; standalone callers without it retain the previous input behavior. Capability use fails closed while discovery is pending or invalid.
- Security and cleanup: Consumed Drafts must be regular files under a unique task directory inside the reserved scratch root. Root, task-directory, and file identities are rechecked before deletion; symlink/reparse-point and replacement attempts fail closed. The builder removes task scratch after success or failure, and CLI/ACP turn cleanup removes residue without following links.
- Packaging/runtime impact: Adds built-in Skill scripts, schemas, examples, CSS, editor JavaScript, and a shared scratch helper that must be present in packaged runtime resources. Packaging/install/live-host verification remains outstanding.
- Config, secrets, or migration: No secrets added. Published output remains governed by `BOX_AGENT_OUTPUT_DIR`; temporary input is governed independently by `BOX_AGENT_SCRATCH_DIR`. Roadmap Spec migration is explicit and versioned.
- Rollback: Revert commits `29198c5`, `0931f18`, `2bcc61d`, and `5d688eb`.
- Cross-repository follow-up: Office v3 should hide the reserved `.box-agent-scratch` directory from workspace browsing/reference resolution, rebuild/install the Box-Agent runtime, restart the host, and verify a fresh live Roadmap task.

### Design and architecture impact

- Affected layers and owners: Box-Agent owns Roadmap Draft/Spec validation, geometry, rendering/editing, temporary-input/output boundaries, Skill discovery, and ACP capability publication; Office v3 owns capability consumption, workspace presentation, preview/save security boundaries, and packaged Electron runtime integration.
- Contract, schema, or protocol impact: Adds versioned Roadmap Draft/Spec schemas, runtime-capabilities v1 schema/data, controlled artifact metadata, a session-scoped capability-update event, the read-only `box-agent.runtime-capabilities-query` contract, and the `BOX_AGENT_SCRATCH_DIR` subprocess environment contract.
- Documentation updated: Updated the built-in Roadmap `SKILL.md` and `docs/ARTIFACT_PROTOCOL.md`; included capability-query lifecycle and fallback rules, reference schemas, runtime registry, representative examples/fixtures, and scratch behavior tests.

### Target branch consistency

- Base branch and reviewed Head SHA: `Raccoon-Office/Box-Agent:main` at `4842ab64b23ef0015cb3729e73e2f36e28ca42d3`; Head `29198c5cfd1158a0991e406d1d8824d4e760b7cc`.
- Relevant target-branch changes considered: Rebased over the browser namespace fix, SSRF-safe web extraction, and the same-session multi-turn file-isolation changes. The overlapping ACP/core/test changes replayed without conflict; the generated skill manifest was regenerated with the repository script.
- Rebase, compatibility, or historical-fix risk: `origin/main...HEAD` is `0 behind / 4 ahead`; no merge commit from `main` is present.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [x] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior, including security and cleanup failure paths.
- [x] Broader tests were run for shared core, tools, CLI, ACP, skills, and packaging changes.
- [x] Documentation was updated for user-facing behavior changes.
- [x] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [x] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [x] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [x] This branch was rebased onto the latest base `main` before this PR was updated; `main` was not merged into the feature branch.
- [x] Design and target-branch consistency evidence is included above.
- [x] GitHub Actions (Python 3.10/3.11/3.12), GitGuardian, and `teamwork/local-ci` passed for Head `29198c5cfd1158a0991e406d1d8824d4e760b7cc`. The equivalent local `bash general_review/ci/preflight.sh` passed with `2874 passed, 17 skipped, 1 deselected` and successful sdist/wheel builds.
