### PR TITLE
feat(tools): add compatible aliases and safe path recovery

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1922,8 +1922,14 @@ class BoxACPAgent:
             f"{scope_line}\n"
             "- Allowed filesystem roots for this session include:\n"
             + "\n".join(root_lines)
+            + "\n- These are currently pre-authorized roots, not the complete set of paths that may be requested."
+            + "\n- When the task requires it, you may try a specific, narrow path outside these roots; "
+            "the runtime will request permission when appropriate."
+            + "\n- A permission denial applies only to the requested path. "
+            "Do not generalize it to other specific candidate paths."
             + "\n- Prefer absolute paths when the user names a location such as ~/Documents."
-            + "\n- Do not claim you can only access the workspace unless a tool call actually returns a permission denial."
+            + "\n- Do not claim you can only access the workspace based only on the listed "
+            "roots or a denial for another path."
         )
 
     def _build_action_hints_prompt(self, env_context: EnvContext | None = None) -> str:

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -547,8 +547,9 @@ class Agent:
             workspace_info = (
                 f"\n\n## Current Workspace\n"
                 f"You are currently working in: `{self.workspace_dir.absolute()}`\n"
-                "This directory is the session workspace and filesystem safety "
-                "boundary. Relative tool paths resolve from each tool's active "
+                "This directory is the session workspace and default working root; "
+                "it does not by itself define every path the runtime may allow. "
+                "Relative tool paths resolve from each tool's active "
                 "project/artifact root; in output mode, prefer the artifact-relative "
                 "paths named by the active Skill or checkpoint instead of deriving "
                 "absolute paths from this workspace."

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -47,7 +47,7 @@ from .logger import AgentLogger
 from .loop_guards import CompletionGate
 from .runtime import run_agent_loop
 from .schema import Message
-from .tools.base import Tool, ToolResult
+from .tools.base import Tool, ToolResult, build_tool_name_index
 from .tools.mcp_tool_catalog import get_mcp_tool_catalog
 from .tools.mcp_tool_search import (
     ActivatedMCPTool,
@@ -523,7 +523,9 @@ class Agent:
             self.tools["tool_search"] = ToolSearchTool(
                 catalog,
                 self.activated_mcp_tools,
-                protected_names_provider=lambda: frozenset(self.tools),
+                protected_names_provider=lambda: frozenset(
+                    build_tool_name_index(self.tools.values())
+                ),
             )
         self.tool_result_storage = ToolResultStorage(
             Path.home() / ".box-agent" / "sessions"

--- a/box_agent/config/system_prompt.md
+++ b/box_agent/config/system_prompt.md
@@ -23,7 +23,7 @@
 
 ### File & Bash Operations
 
-- 使用绝对路径或相对 workspace 的路径，写文件前先确认父目录存在。
+- 路径语义：相对路径由工具从当前 active project/artifact root 解析，不要假定始终相对 workspace；使用绝对路径时应基于用户已知位置或模型合理推断出的范围明确候选。写文件前先确认父目录存在。
 - Bash 命令在执行前先说明，特别是涉及删改的命令；检查命令输出并处理异常。
 - 读取普通文本正文使用 `read_file`；读取 JSONL/NDJSON 日志，尤其是需要按事件筛选或记录可能很大时，使用 `query_jsonl` 做字段投影和游标分页；列目录、按名称找文件或搜索文件内容使用 `search_files`。不要用 bash 的 `cat/head/tail`、`grep/rg/find/ls` 拼接实现这些操作，也不要因 JSONL 超长记录改用 `execute_code` 整体读取。
 
@@ -51,7 +51,7 @@
 
 - **Dangerous commands** (rm, rmdir, kill, sudo, chmod 等) 会触发用户确认。**用户拒绝即停**——不要换 `rmdir` / `find -delete` / `mv /dev/null` 等等价命令重试；通知用户已取消并询问下一步。
 - **Filesystem scope**：safety 启用时工具访问受 runtime policy 限制（含 workspace、session root、host 允许目录）。不要预设只能访问 workspace；遇权限错误尊重该错误。
-- 定位 workspace 外的模糊路径时，先尝试具体候选路径（例如 `~/Downloads/...`）；不要以用户主目录为根递归搜索。具体候选均失败后再询问用户。
+- 定位 workspace 外的模糊路径时，由模型自行推断并尝试范围明确的具体候选路径；不要通过递归搜索整个用户主目录来定位文件。合理候选均失败后再询问用户。
 
 <safety_guardrails>
 **安全与隐私**：
@@ -87,7 +87,7 @@
 ## Attention
 
 1. 今天日期：`{{.CurrentDate}}`，用户提问中的模糊时间按此推算。
-2. 若上下文无任何文件标记或文件元信息，所有文件相关请求一律视为缺失输入——直接中止并请求用户补充。
+2. 若任务明确依赖用户尚未提供的附件，且上下文无对应文件标记或文件元信息，再请求用户补充。用户已经给出路径或位置时，先按当前路径与权限语义调用工具验证；不要仅因缺少附件元信息就把请求判定为缺失输入。
 3. 不清楚的内容可以询问用户。
 
 {SKILLS_METADATA}

--- a/box_agent/config/system_prompt.md
+++ b/box_agent/config/system_prompt.md
@@ -51,6 +51,7 @@
 
 - **Dangerous commands** (rm, rmdir, kill, sudo, chmod 等) 会触发用户确认。**用户拒绝即停**——不要换 `rmdir` / `find -delete` / `mv /dev/null` 等等价命令重试；通知用户已取消并询问下一步。
 - **Filesystem scope**：safety 启用时工具访问受 runtime policy 限制（含 workspace、session root、host 允许目录）。不要预设只能访问 workspace；遇权限错误尊重该错误。
+- 定位 workspace 外的模糊路径时，先尝试具体候选路径（例如 `~/Downloads/...`）；不要以用户主目录为根递归搜索。具体候选均失败后再询问用户。
 
 <safety_guardrails>
 **安全与隐私**：

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -184,6 +184,7 @@ from .tools.base import (
     Tool,
     ToolInvocationContext,
     ToolResult,
+    build_tool_name_index,
 )
 from .tools.argument_limits import RECOMMENDED_GENERATED_BODY_CHARS
 from .tools.browser_intent import BrowserToolIntentPolicy
@@ -3691,6 +3692,7 @@ async def run_agent_loop(
                     )
                 ]
         offered_tools_by_name = {tool.name: tool for tool in tool_list}
+        offered_tools_by_call_name = build_tool_name_index(tool_list)
         offered_tool_names = frozenset(offered_tools_by_name)
 
         def _tool_target_identity(tool_name: str) -> tuple[str | None, str | None]:
@@ -4685,15 +4687,28 @@ async def run_agent_loop(
             yield DoneEvent(stop_reason=StopReason.CANCELLED, final_content="Task cancelled by user.")
             return
 
+        # Resolve backwards-compatible aliases only against tools offered in
+        # this model step. Keep the persisted assistant turn unchanged, while
+        # all execution policy sees the canonical tool name.
+        execution_tool_calls = []
+        for tool_call in response.tool_calls:
+            execution_call = tool_call.model_copy(deep=True)
+            resolved_tool = offered_tools_by_call_name.get(
+                execution_call.function.name
+            )
+            if resolved_tool is not None:
+                execution_call.function.name = resolved_tool.name
+            execution_tool_calls.append(execution_call)
+
         # ── Execute tool calls ──────────────────────────────
         # Loop-guard: bail out if the model emits the same all-empty-args
         # tool_call set as the previous turn. This is the signature of an
         # upstream protocol bug (e.g. relay truncation) where empty args
         # come back, error responses get fed back, and the model just
         # repeats — without this check the loop runs to max_steps.
-        all_empty = all(not tc.function.arguments for tc in response.tool_calls)
+        all_empty = all(not tc.function.arguments for tc in execution_tool_calls)
         if all_empty:
-            sig = tuple(sorted(tc.function.name for tc in response.tool_calls))
+            sig = tuple(sorted(tc.function.name for tc in execution_tool_calls))
             if sig == empty_args_signature:
                 empty_args_repeats += 1
             else:
@@ -4727,7 +4742,7 @@ async def run_agent_loop(
         duplicate_tool_calls = []
         first_tool_call_by_signature: dict[tuple[str, str], Any] = {}
         duplicate_source_by_id: dict[str, str] = {}
-        for tc in response.tool_calls:
+        for tc in execution_tool_calls:
             signature = (
                 tc.function.name,
                 json.dumps(

--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -18,6 +18,7 @@ from ..tools.argument_limits import (
     TOOL_ARGUMENT_ACTIVITY_BUCKET_CHARS,
     streamed_argument_limit,
 )
+from ..tools.base import tool_call_name_variants
 from .base import LLMClientBase
 from .error_messages import is_retryable_llm_error
 from .debug_logging import (
@@ -80,7 +81,9 @@ def _apply_thinking_params(
 
 def _tool_parameter_types(
     openai_tools: list[dict[str, Any]] | None,
+    source_tools: list[Any] | None = None,
 ) -> dict[str, dict[str, str]]:
+    canonical_names = _canonical_tool_names(openai_tools, source_tools)
     parameter_types: dict[str, dict[str, str]] = {}
     for tool in openai_tools or []:
         function = tool.get("function")
@@ -93,12 +96,88 @@ def _tool_parameter_types(
         properties = parameters.get("properties")
         if not isinstance(properties, dict):
             properties = {}
-        parameter_types[name] = {
+        types = {
             key: value.get("type", "string")
             for key, value in properties.items()
             if isinstance(key, str) and isinstance(value, dict)
         }
+        for call_name in tool_call_name_variants(name):
+            if canonical_names.get(call_name) == name:
+                parameter_types[call_name] = types
+
+    # Aliases are execution-only compatibility names: accept them when
+    # recovering SenseNova pseudo tool calls, but never add them to the
+    # provider-facing schema above.
+    for tool in source_tools or []:
+        if isinstance(tool, dict):
+            continue
+        canonical_name = getattr(tool, "name", None)
+        canonical_types = parameter_types.get(canonical_name)
+        if canonical_types is None:
+            continue
+        for alias in getattr(tool, "aliases", ()):
+            if isinstance(alias, str) and alias:
+                for call_name in tool_call_name_variants(alias):
+                    if canonical_names.get(call_name) == canonical_name:
+                        parameter_types[call_name] = canonical_types
     return parameter_types
+
+
+def _canonical_tool_names(
+    openai_tools: list[dict[str, Any]] | None,
+    source_tools: list[Any] | None,
+) -> dict[str, str]:
+    """Map declared aliases to canonical names for provider-side limits."""
+
+    names: dict[str, str] = {}
+    declared_schema_names: set[str] = set()
+
+    def register(call_name: str, canonical_name: str) -> None:
+        existing = names.get(call_name)
+        if existing is not None and existing != canonical_name:
+            raise ValueError(
+                f"Tool call name '{call_name}' for '{canonical_name}' conflicts "
+                f"with tool '{existing}'"
+            )
+        names[call_name] = canonical_name
+
+    for tool in openai_tools or []:
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        canonical_name = function.get("name")
+        if not isinstance(canonical_name, str) or not canonical_name:
+            continue
+        if canonical_name in declared_schema_names:
+            raise ValueError(f"Duplicate tool schema name '{canonical_name}'")
+        declared_schema_names.add(canonical_name)
+        for call_name in tool_call_name_variants(canonical_name):
+            register(call_name, canonical_name)
+
+    for tool in source_tools or []:
+        if isinstance(tool, dict):
+            continue
+        canonical_name = getattr(tool, "name", None)
+        if not isinstance(canonical_name, str) or not canonical_name:
+            continue
+        for declared_name in (canonical_name, *getattr(tool, "aliases", ())):
+            if isinstance(declared_name, str) and declared_name:
+                for call_name in tool_call_name_variants(declared_name):
+                    register(call_name, canonical_name)
+    return names
+
+
+def _is_sensenova_tool_only_content(content: str) -> bool:
+    """Return whether visible content consists only of pseudo tool calls."""
+
+    cursor = 0
+    found = False
+    for match in _SENSENOVA_PSEUDO_TOOL_CALL_RE.finditer(content):
+        if content[cursor : match.start()].strip():
+            return False
+        found = True
+        cursor = match.end()
+    return found and not content[cursor:].strip()
 
 
 def _coerce_pseudo_parameter(raw: str, expected_type: str) -> Any:
@@ -124,17 +203,19 @@ def _coerce_pseudo_parameter(raw: str, expected_type: str) -> Any:
     return value
 
 
-def _recover_sensenova_tool_calls_from_thinking(
-    thinking: str,
+def _recover_sensenova_pseudo_tool_calls(
+    source: str,
     openai_tools: list[dict[str, Any]] | None,
+    source_tools: list[Any] | None = None,
 ) -> list[ToolCall]:
-    """Recover SenseNova's XML-like tool dialect when native tool_calls is empty."""
-    parameter_types = _tool_parameter_types(openai_tools)
+    """Recover SenseNova's XML-like dialect when native tool_calls is empty."""
+    parameter_types = _tool_parameter_types(openai_tools, source_tools)
+    canonical_names = _canonical_tool_names(openai_tools, source_tools)
     if not parameter_types:
         return []
 
     recovered: list[ToolCall] = []
-    for match in _SENSENOVA_PSEUDO_TOOL_CALL_RE.finditer(thinking):
+    for match in _SENSENOVA_PSEUDO_TOOL_CALL_RE.finditer(source):
         if len(recovered) >= _MAX_RECOVERED_SENSENOVA_TOOL_CALLS:
             break
         name, body = match.groups()
@@ -150,10 +231,10 @@ def _recover_sensenova_tool_calls_from_thinking(
                 parameter_types[name][parameter_name],
             )
         arguments_len = len(json.dumps(arguments, ensure_ascii=False))
-        limit = streamed_argument_limit(name)
+        limit = streamed_argument_limit(canonical_names.get(name, name))
         if limit is not None and arguments_len > limit:
             logger.warning(
-                "Ignored oversized SenseNova tool call recovered from thinking: "
+                "Ignored oversized recovered SenseNova pseudo tool call: "
                 "name=%s arguments_len=%d limit=%d",
                 name,
                 arguments_len,
@@ -635,21 +716,27 @@ class OpenAIClient(LLMClientBase):
                 )
 
         finish_reason = getattr(response.choices[0], "finish_reason", None) or "stop"
-        if (
-            not tool_calls
-            and not text_content.strip()
-            and thinking_content
-            and _is_sensenova_model(self.model)
-        ):
+        pseudo_tool_source = ""
+        pseudo_tool_source_is_text = False
+        if not tool_calls and _is_sensenova_model(self.model):
+            if not text_content.strip() and thinking_content:
+                pseudo_tool_source = thinking_content
+            elif _is_sensenova_tool_only_content(text_content):
+                pseudo_tool_source = text_content
+                pseudo_tool_source_is_text = True
+        if pseudo_tool_source:
             openai_tools = self._convert_tools(tools) if tools else None
-            tool_calls = _recover_sensenova_tool_calls_from_thinking(
-                thinking_content,
+            tool_calls = _recover_sensenova_pseudo_tool_calls(
+                pseudo_tool_source,
                 openai_tools,
+                tools,
             )
             if tool_calls:
                 finish_reason = "tool_calls"
+                if pseudo_tool_source_is_text:
+                    text_content = ""
                 logger.warning(
-                    "Recovered %d SenseNova tool call(s) from thinking output",
+                    "Recovered %d SenseNova pseudo tool call(s)",
                     len(tool_calls),
                 )
 
@@ -768,6 +855,10 @@ class OpenAIClient(LLMClientBase):
             thinking_enabled=thinking_enabled,
         )
 
+        should_buffer_sensenova_tool_markup = bool(
+            request_params["tools"] and _is_sensenova_model(self.model)
+        )
+
         auth_headers = self._auth_headers(
             self._request_headers(session_id, turn_id, title, call_kind)
         )
@@ -826,6 +917,8 @@ class OpenAIClient(LLMClientBase):
             oversized_info = []
             provider_response_id = None
             last_provider_activity_at: float | None = None
+            buffer_sensenova_tool_markup = should_buffer_sensenova_tool_markup
+            pending_sensenova_text = ""
 
             try:
                 response_stream = await _open_stream()
@@ -899,8 +992,25 @@ class OpenAIClient(LLMClientBase):
                     # Text content
                     if delta.content:
                         text_content += delta.content
-                        any_user_yield = True
-                        yield StreamEvent(type="text", delta=delta.content)
+                        if buffer_sensenova_tool_markup:
+                            pending_sensenova_text += delta.content
+                            stripped_pending = pending_sensenova_text.lstrip()
+                            could_be_tool_markup = (
+                                not stripped_pending
+                                or "<tool_call>".startswith(stripped_pending)
+                                or stripped_pending.startswith("<tool_call>")
+                            )
+                            if not could_be_tool_markup:
+                                buffer_sensenova_tool_markup = False
+                                any_user_yield = True
+                                yield StreamEvent(
+                                    type="text",
+                                    delta=pending_sensenova_text,
+                                )
+                                pending_sensenova_text = ""
+                        else:
+                            any_user_yield = True
+                            yield StreamEvent(type="text", delta=delta.content)
 
                     # Tool call deltas
                     if delta.tool_calls:
@@ -1073,23 +1183,32 @@ class OpenAIClient(LLMClientBase):
         # diagnostics distinguish "gateway clipped tool args" (length, set here)
         # from "gateway ended a text turn" (stop / end_turn / None from upstream).
         raw_finish_reason = finish_reason
-        if (
-            not truncated_tool
-            and not tool_calls
-            and not text_content.strip()
-            and thinking_content
-            and _is_sensenova_model(self.model)
-        ):
-            tool_calls = _recover_sensenova_tool_calls_from_thinking(
-                thinking_content,
+        pseudo_tool_source = ""
+        pseudo_tool_source_is_text = False
+        if not truncated_tool and not tool_calls and _is_sensenova_model(self.model):
+            if not text_content.strip() and thinking_content:
+                pseudo_tool_source = thinking_content
+            elif _is_sensenova_tool_only_content(text_content):
+                pseudo_tool_source = text_content
+                pseudo_tool_source_is_text = True
+        if pseudo_tool_source:
+            tool_calls = _recover_sensenova_pseudo_tool_calls(
+                pseudo_tool_source,
                 params.get("tools"),
+                tools,
             )
             if tool_calls:
                 finish_reason = "tool_calls"
+                if pseudo_tool_source_is_text:
+                    text_content = ""
+                    pending_sensenova_text = ""
                 logger.warning(
-                    "Recovered %d SenseNova tool call(s) from streamed thinking output",
+                    "Recovered %d SenseNova pseudo tool call(s) from stream",
                     len(tool_calls),
                 )
+        if pending_sensenova_text:
+            any_user_yield = True
+            yield StreamEvent(type="text", delta=pending_sensenova_text)
         stream_dropped_mid_tool = truncated_tool and raw_finish_reason is None
         if truncated_tool:
             finish_reason = "length"

--- a/box_agent/tools/base.py
+++ b/box_agent/tools/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -42,6 +43,7 @@ class ToolInvocationContext:
 class Tool:
     """Base class for all tools."""
 
+    aliases: tuple[str, ...] = ()
     parallel_safe: bool = False
     # Model-facing results above this size are persisted by the shared agent
     # loop. Tools that already self-bound output may opt out with ``math.inf``;
@@ -150,6 +152,44 @@ class Tool:
                 "parameters": self.parameters,
             },
         }
+
+
+def tool_call_name_variants(name: str) -> tuple[str, ...]:
+    """Return a declared tool name and its underscore-to-hyphen variant."""
+
+    hyphenated = name.replace("_", "-")
+    return (name,) if hyphenated == name else (name, hyphenated)
+
+
+def build_tool_name_index(tools: Iterable[Tool]) -> dict[str, Tool]:
+    """Index offered tools by canonical and compatible call names."""
+
+    offered_tools = list(tools)
+    index: dict[str, Tool] = {}
+
+    for tool in offered_tools:
+        index[tool.name] = tool
+
+    for tool in offered_tools:
+        seen_aliases: set[str] = set()
+        for alias in tool.aliases:
+            if not alias:
+                raise ValueError(f"Tool '{tool.name}' has an empty alias")
+            if alias == tool.name or alias in seen_aliases:
+                raise ValueError(f"Tool '{tool.name}' repeats alias '{alias}'")
+            seen_aliases.add(alias)
+
+        for declared_name in (tool.name, *tool.aliases):
+            for call_name in tool_call_name_variants(declared_name):
+                existing = index.get(call_name)
+                if existing is not None and existing is not tool:
+                    raise ValueError(
+                        f"Tool alias '{call_name}' for '{tool.name}' conflicts with "
+                        f"tool '{existing.name}'"
+                    )
+                index[call_name] = tool
+
+    return index
 
 
 class EventEmittingTool(Tool):

--- a/box_agent/tools/bash_tool.py
+++ b/box_agent/tools/bash_tool.py
@@ -770,6 +770,8 @@ class BashTool(Tool):
     - Unix/Linux/macOS: bash
     """
 
+    aliases = ("exec", "terminal")
+
     max_result_size_chars = math.inf
 
     def __init__(

--- a/box_agent/tools/file/jsonl_tool.py
+++ b/box_agent/tools/file/jsonl_tool.py
@@ -190,6 +190,7 @@ def _read_bounded_jsonl_line(stream) -> tuple[bytes, bool]:
 class JsonlQueryTool(ReadTool):
     """Stream, filter, and project JSONL records without exposing raw large lines."""
 
+    aliases = ()
     parallel_safe = True
     max_result_size_chars = math.inf
 

--- a/box_agent/tools/file/path_candidates.py
+++ b/box_agent/tools/file/path_candidates.py
@@ -1,0 +1,73 @@
+"""Bounded structural candidates for unresolved user paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MAX_HOME_PATH_CANDIDATES = 3
+
+
+def home_relative_path_candidates(
+    raw_path: str,
+    *,
+    home_dir: Path | None = None,
+    active_roots: tuple[Path, ...] = (),
+) -> list[dict[str, object]]:
+    """Return existing paths whose first component matches a Home child.
+
+    Matching is structural and case-insensitive. Only Home's immediate
+    children are inspected; candidates are never executed or authorized here.
+    """
+    stripped = raw_path.strip()
+    supplied = Path(stripped)
+    if not stripped or stripped.startswith("~") or ".." in supplied.parts:
+        return []
+
+    unresolved_paths: list[Path] = []
+    if supplied.is_absolute():
+        for root in active_roots:
+            try:
+                unresolved_paths.append(supplied.relative_to(root.expanduser().absolute()))
+            except ValueError:
+                continue
+    else:
+        unresolved_paths.append(supplied)
+    if not unresolved_paths:
+        return []
+
+    home = (home_dir or Path.home()).expanduser().absolute()
+    try:
+        children = sorted(home.iterdir(), key=lambda child: child.name.casefold())
+    except OSError:
+        return []
+
+    candidates: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for unresolved in unresolved_paths:
+        if not unresolved.parts:
+            continue
+        first_component = unresolved.parts[0].casefold()
+        remaining = unresolved.parts[1:]
+        for child in children:
+            if child.name.casefold() != first_component:
+                continue
+            candidate = child.joinpath(*remaining)
+            try:
+                exists = candidate.exists()
+            except OSError:
+                continue
+            candidate_key = str(candidate)
+            if not exists or candidate_key in seen:
+                continue
+            seen.add(candidate_key)
+            candidates.append(
+                {
+                    "path": candidate_key,
+                    "basis": "home_child_case_insensitive_match",
+                    "exists": True,
+                }
+            )
+            if len(candidates) >= MAX_HOME_PATH_CANDIDATES:
+                return candidates
+    return candidates

--- a/box_agent/tools/file/read_tool.py
+++ b/box_agent/tools/file/read_tool.py
@@ -87,6 +87,7 @@ def _similar_file_suggestions(file_path: Path, limit: int = 5) -> list[str]:
 class ReadTool(Tool):
     """Read file content."""
 
+    aliases = ("read",)
     max_result_size_chars = math.inf
 
     def __init__(

--- a/box_agent/tools/file_tools.py
+++ b/box_agent/tools/file_tools.py
@@ -19,6 +19,7 @@ from ..events import ProgressEvent
 from ..model_history import is_model_history_placeholder
 from .base import EventEmittingTool, Tool, ToolResult
 from .argument_limits import MAX_GENERATED_BODY_CHARS
+from .file.path_candidates import home_relative_path_candidates
 from .pptx_safety import detect_pptx_self_check_bypass
 from .safety import backup_file, validate_path_in_workspace
 
@@ -505,7 +506,31 @@ class SearchFilesTool(EventEmittingTool):
             if denied:
                 return denied
             if not search_path.exists():
-                return ToolResult(success=False, error=f"Search path not found: {path}")
+                candidates = home_relative_path_candidates(
+                    path,
+                    active_roots=(self.relative_root_dir, self.workspace_dir),
+                )
+                error = f"Search path not found: {path}"
+                if candidates:
+                    rendered = "\n".join(
+                        f"- `{candidate['path']}` ({candidate['basis']})"
+                        for candidate in candidates
+                    )
+                    error += (
+                        "\nStructurally matching existing path candidate(s):\n"
+                        f"{rendered}\n"
+                        "If a candidate matches the user's intent, retry search_files "
+                        "with this absolute path. Permissions will be checked on that call."
+                    )
+                return ToolResult(
+                    success=False,
+                    error=error,
+                    raw_output={
+                        "code": "PATH_NOT_FOUND",
+                        "path": path,
+                        "path_candidates": candidates,
+                    },
+                )
 
             if target == "content":
                 try:

--- a/box_agent/tools/file_tools.py
+++ b/box_agent/tools/file_tools.py
@@ -76,7 +76,7 @@ def _resolve_from_active_root(
     relative_root_dir: Path,
 ) -> Path:
     """Resolve canonical artifact paths and legacy workspace-relative paths."""
-    file_path = Path(path)
+    file_path = Path(path).expanduser()
     if file_path.is_absolute():
         return file_path
 
@@ -488,6 +488,19 @@ class SearchFilesTool(EventEmittingTool):
             offset, limit = _normalize_search_pagination(offset, limit)
             context = max(0, min(context if isinstance(context, int) else 0, 10))
             search_path = self._resolve_path(path)
+            user_home = Path.home().resolve()
+            if (
+                search_path.resolve() == user_home
+                and self.workspace_dir.resolve() != user_home
+            ):
+                return ToolResult(
+                    success=False,
+                    error=(
+                        "BROAD_HOME_SEARCH_BLOCKED: Recursive search from the entire user "
+                        "home is not allowed. Choose a specific likely directory such as "
+                        "~/Downloads or ~/Documents, or ask the user for the location."
+                    ),
+                )
             denied = self._permission_error(search_path)
             if denied:
                 return denied

--- a/box_agent/tools/file_tools.py
+++ b/box_agent/tools/file_tools.py
@@ -686,6 +686,8 @@ class _CommittedTextWrite:
 class WriteTool(Tool):
     """Atomically write a UTF-8 file in one call or ordered chunks."""
 
+    aliases = ("write",)
+
     def __init__(
         self,
         workspace_dir: str = ".",
@@ -1145,6 +1147,8 @@ class AppendTool(Tool):
 
 class EditTool(Tool):
     """Edit file by replacing text."""
+
+    aliases = ("edit",)
 
     def __init__(
         self,

--- a/box_agent/tools/file_tools.py
+++ b/box_agent/tools/file_tools.py
@@ -252,6 +252,11 @@ class SearchFilesTool(EventEmittingTool):
                 return ToolResult(success=False, error=error)
         return None
 
+    def _can_inspect_home_path_candidates(self) -> bool:
+        """Return whether the current policy already permits reading Home."""
+
+        return self._permission_error(Path.home().resolve()) is None
+
     async def execute_with_event_context(
         self,
         *,
@@ -506,9 +511,13 @@ class SearchFilesTool(EventEmittingTool):
             if denied:
                 return denied
             if not search_path.exists():
-                candidates = home_relative_path_candidates(
-                    path,
-                    active_roots=(self.relative_root_dir, self.workspace_dir),
+                candidates = (
+                    home_relative_path_candidates(
+                        path,
+                        active_roots=(self.relative_root_dir, self.workspace_dir),
+                    )
+                    if self._can_inspect_home_path_candidates()
+                    else []
                 )
                 error = f"Search path not found: {path}"
                 if candidates:

--- a/box_agent/tools/image_generation_tool.py
+++ b/box_agent/tools/image_generation_tool.py
@@ -347,6 +347,7 @@ def _derive_edit_endpoint(endpoint: str) -> str:
 class GenerateImageTool(Tool):
     """Generate an image through a configured HTTP service and save it locally."""
 
+    aliases = ("image_generate",)
     parallel_safe = True  # independent HTTP calls, output_path per call — no shared state
 
     def __init__(

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .base import Tool, ToolResult
+from .base import Tool, ToolResult, build_tool_name_index
 from .mcp_tool_catalog import MCPToolCatalog
 
 TOOL_SEARCH_NAME = "tool_search"
@@ -347,7 +347,7 @@ class MCPToolExposureManager:
         for tool in candidates:
             if getattr(tool, "mcp_tool_id", None) is None:
                 visible[tool.name] = tool
-        protected_names = frozenset(visible)
+        protected_names = frozenset(build_tool_name_index(visible.values()))
 
         for entry in self._catalog.snapshot():
             if (

--- a/box_agent/tools/request_user_input_tool.py
+++ b/box_agent/tools/request_user_input_tool.py
@@ -10,6 +10,8 @@ from .base import Tool, ToolResult
 class RequestUserInputTool(Tool):
     """Record one focused clarification request without discarding task state."""
 
+    aliases = ("clarify",)
+
     @property
     def name(self) -> str:
         return "request_user_input"

--- a/box_agent/tools/skill_tool.py
+++ b/box_agent/tools/skill_tool.py
@@ -17,6 +17,7 @@ SkillSource = Literal["builtin", "user"]
 class GetSkillTool(Tool):
     """Tool to get detailed information about a specific skill"""
 
+    aliases = ("skill_view",)
     loads_active_skill_instructions = True
 
     def __init__(

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -117,6 +117,10 @@ class _WriteScopedTool(Tool):
         return self._tool.name
 
     @property
+    def aliases(self) -> tuple[str, ...]:
+        return self._tool.aliases
+
+    @property
     def description(self) -> str:
         return self._tool.description
 

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -168,6 +168,10 @@ class _PermissionGatedBashTool(Tool):
         return self._tool.name
 
     @property
+    def aliases(self) -> tuple[str, ...]:
+        return self._tool.aliases
+
+    @property
     def description(self) -> str:
         return self._tool.description
 
@@ -238,6 +242,8 @@ class SubAgentTool(EventEmittingTool):
     model binding selected from the host allowlist; manual sessions keep the
     parent model. Only the final textual summary is returned to the parent.
     """
+
+    aliases = ("sessions_spawn", "delegate_task")
 
     parallel_safe = True
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -163,6 +163,28 @@ callers should use `invoke()` so they do not bypass argument validation.
 Malformed parameter schemas fail closed with `INVALID_TOOL_SCHEMA`; schema and
 argument values are omitted from that diagnostic.
 
+#### Tool Names and Aliases
+
+`Tool.name` is the canonical name serialized in the provider-facing tool
+schema. A tool may additionally declare execution-only compatibility names:
+
+```python
+class MyTool(Tool):
+    aliases = ("legacy_my_tool",)
+```
+
+For the canonical name and every declared alias, Box-Agent accepts the exact
+name and a generated variant with every underscore replaced by a hyphen. For
+example, the declaration above accepts `my_tool`, `my-tool`,
+`legacy_my_tool`, and `legacy-my-tool`. This conversion is one-way: a declared
+hyphenated name does not generate an underscore variant.
+
+Aliases are resolved only against the tools offered in the current model step
+and are converted back to the canonical name before permission checks, loop
+guards, deduplication, and execution. Aliases are not added to the provider
+schema. Empty, repeated, or conflicting canonical/alias/generated names fail
+closed with `ValueError` when the offered tool index is built.
+
 #### Example
 
 ```python

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -183,7 +183,9 @@ Aliases are resolved only against the tools offered in the current model step
 and are converted back to the canonical name before permission checks, loop
 guards, deduplication, and execution. Aliases are not added to the provider
 schema. Empty, repeated, or conflicting canonical/alias/generated names fail
-closed with `ValueError` when the offered tool index is built.
+closed. Deferred MCP tools whose canonical names conflict with this complete
+call-name namespace are rejected before activation; other conflicts raise
+`ValueError` when the offered tool index is built.
 
 Built-in tools accept these compatibility names from equivalent OpenClaw and
 Hermes capabilities:

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -185,6 +185,26 @@ guards, deduplication, and execution. Aliases are not added to the provider
 schema. Empty, repeated, or conflicting canonical/alias/generated names fail
 closed with `ValueError` when the offered tool index is built.
 
+Built-in tools accept these compatibility names from equivalent OpenClaw and
+Hermes capabilities:
+
+| Canonical Box-Agent name | Compatibility names |
+| --- | --- |
+| `read_file` | `read` (OpenClaw) |
+| `write_file` | `write` (OpenClaw) |
+| `edit_file` | `edit` (OpenClaw) |
+| `bash` | `exec` (OpenClaw), `terminal` (Hermes) |
+| `generate_image` | `image_generate` (OpenClaw and Hermes) |
+| `sub_agent` | `sessions_spawn` (OpenClaw), `delegate_task` (Hermes) |
+| `request_user_input` | `clarify` (Hermes) |
+| `get_skill` | `skill_view` (Hermes) |
+
+These are name-only compatibility mappings. Calls still use the canonical
+Box-Agent parameter schema advertised to the model; aliases do not translate
+another agent's argument format. Equivalent tools already named `read_file`,
+`write_file`, `search_files`, `execute_code`, or `memory_search` need no
+additional alias.
+
 #### Example
 
 ```python

--- a/docs/DEVELOPMENT_GUIDE_CN.md
+++ b/docs/DEVELOPMENT_GUIDE_CN.md
@@ -167,6 +167,23 @@ class MyTool(Tool):
 空别名、重复别名，以及 canonical/alias/自动生成名称之间的冲突，都会在构建
 当前工具索引时以 `ValueError` 失败关闭。
 
+内置工具接受下列来自 OpenClaw 和 Hermes 同等能力的兼容名称：
+
+| Box-Agent canonical name | 兼容名称 |
+| --- | --- |
+| `read_file` | `read`（OpenClaw） |
+| `write_file` | `write`（OpenClaw） |
+| `edit_file` | `edit`（OpenClaw） |
+| `bash` | `exec`（OpenClaw）、`terminal`（Hermes） |
+| `generate_image` | `image_generate`（OpenClaw、Hermes） |
+| `sub_agent` | `sessions_spawn`（OpenClaw）、`delegate_task`（Hermes） |
+| `request_user_input` | `clarify`（Hermes） |
+| `get_skill` | `skill_view`（Hermes） |
+
+这些映射只兼容工具名称。调用参数仍须符合模型实际收到的 Box-Agent canonical
+参数 Schema；别名不会转换其他 Agent 的参数格式。`read_file`、`write_file`、
+`search_files`、`execute_code`、`memory_search` 等已经同名的等价工具无需额外别名。
+
 #### 示例
 
 ```python

--- a/docs/DEVELOPMENT_GUIDE_CN.md
+++ b/docs/DEVELOPMENT_GUIDE_CN.md
@@ -165,7 +165,8 @@ class MyTool(Tool):
 别名仅在当前模型步骤实际开放的工具集合中解析，并在权限检查、循环保护、
 重复调用去重和执行前转换回 canonical name。别名不会加入 Provider Schema。
 空别名、重复别名，以及 canonical/alias/自动生成名称之间的冲突，都会在构建
-当前工具索引时以 `ValueError` 失败关闭。
+当前工具索引时失败关闭。canonical name 与完整调用名称空间冲突的 deferred MCP
+工具会在激活前被拒绝；其他冲突会在构建工具索引时抛出 `ValueError`。
 
 内置工具接受下列来自 OpenClaw 和 Hermes 同等能力的兼容名称：
 

--- a/docs/DEVELOPMENT_GUIDE_CN.md
+++ b/docs/DEVELOPMENT_GUIDE_CN.md
@@ -147,6 +147,26 @@ box-agent goal complete --evidence "uv run pytest tests/ -q passed"
 3.  在类中实现所需的属性和方法。
 4.  在 Agent 初始化时注册你的新工具。
 
+#### 工具名称与别名
+
+`Tool.name` 是 Provider 工具 Schema 中唯一暴露的 canonical name。工具还可以
+声明仅用于执行兼容的别名：
+
+```python
+class MyTool(Tool):
+    aliases = ("legacy_my_tool",)
+```
+
+对于 canonical name 和每个显式别名，Box-Agent 都接受原始名称，以及把所有
+下划线替换为连字符的变体。例如上面的声明接受 `my_tool`、`my-tool`、
+`legacy_my_tool` 和 `legacy-my-tool`。转换是单向的：显式声明的连字符名称
+不会反向生成下划线形式。
+
+别名仅在当前模型步骤实际开放的工具集合中解析，并在权限检查、循环保护、
+重复调用去重和执行前转换回 canonical name。别名不会加入 Provider Schema。
+空别名、重复别名，以及 canonical/alias/自动生成名称之间的冲突，都会在构建
+当前工具索引时以 `ValueError` 失败关闭。
+
 #### 示例
 
 ```python

--- a/docs/THIRD_PARTY_API_COMPATIBILITY.md
+++ b/docs/THIRD_PARTY_API_COMPATIBILITY.md
@@ -67,3 +67,24 @@ API 返回的事件顺序不符合 Anthropic 协议规范: Unexpected event orde
 ### 诊断工具
 
 运行 `box-agent doctor` 可以测试 API 连接性和基本兼容性。
+
+## SenseNova OpenAI 兼容模式
+
+当 `provider: openai` 且模型名以 `sensenova-` 或 `sn-sensenova-` 开头时，
+Box-Agent 会启用 SenseNova 协议兼容处理。使用 `--deep-think` 或 ACP 的
+`deep_think` 开关时，请求会附带：
+
+```json
+{
+  "chat_template_kwargs": {
+    "thinking": true,
+    "reasoning_effort": "high"
+  }
+}
+```
+
+部分 Flash-Lite 版本会把工具调用以 `<tool_call>` 标记输出到 reasoning，或
+输出到不含其他可见文本的 content。Box-Agent 会把这类标记恢复为标准工具调用，
+但仅接受当前步骤实际开放的 canonical tool name、显式 alias，以及它们的
+下划线转连字符兼容形式。未声明的工具名和夹杂普通可见文本的内容不会执行，
+仍作为文本返回。Provider-facing 工具 Schema 始终只包含 canonical name。

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -51,6 +51,7 @@ decision, read those entries together.
 
 | Area | Affected paths or keywords | Current effective decision | Relationship | Details |
 | --- | --- | --- | --- | --- |
+| Tool name aliases | `Tool.aliases`, `build_tool_name_index`, OpenClaw, Hermes | Compatibility names are execution-only, use canonical Box-Agent argument schemas, and fail closed on conflicts. | Built-in mappings complete the generic alias mechanism in `ba374f6`. | [2026-08-20 built-in aliases](#2026-08-20--built-in-tool-name-compatibility-aliases) |
 | Filesystem path resolution | `SearchFilesTool`, `path_candidates.py`, `PATH_NOT_FOUND`, ACP file-access prompt | Missing paths may return bounded structural candidates, but the model must retry a specific path and the permission engine remains final authority. | Hardens the broad-Home-search block without adding aliases or automatic authorization. | [2026-08-20 path candidates](#2026-08-20--bounded-structural-candidates-for-missing-filesystem-paths) |
 | File writes | `box_agent/tools/file_tools.py`, `write_file` | Ordered chunks commit atomically, with bounded transactions, replay protection, and whole-body safety checks. | PR #37 hardens PR #34; both remain relevant. | [PR #37](#2026-08-17--transactional-write-safety-follow-up-pr-37), [PR #34](#2026-08-17--unified-transactional-write_file-protocol-pr-34) |
 | Tool invocation | `box_agent/tools/base.py`, `schema_validation.py`, `Tool.invoke` | Tool schemas and arguments fail closed before `execute()` is called. | Current at this baseline. | [PR #33](#2026-08-17--validate-tool-arguments-before-execution-pr-33) |
@@ -67,6 +68,31 @@ Release, provider API, and ACP compatibility have their own sources under
 [long-lived release and compatibility history](#long-lived-release-and-compatibility-history).
 
 ## Pending material changes
+
+### 2026-08-20 — built-in tool-name compatibility aliases
+
+- Change: generic execution-only alias support is implemented by `ba374f6`;
+  the built-in compatibility mappings are a follow-up on
+  `syy/pr-review-standard`, with no merge or release reference yet.
+- Durable tool contract: `read_file`, `write_file`, `edit_file`, `bash`,
+  `generate_image`, `sub_agent`, `request_user_input`, and `get_skill` accept
+  the documented equivalent OpenClaw or Hermes names. Underscore names also
+  accept their generated hyphenated call form. Wrapped tools preserve the
+  aliases of the capability they gate.
+- Compatibility boundary: provider-facing schemas continue to advertise only
+  canonical Box-Agent names. Aliases select the same tool implementation and
+  canonical parameter schema; they do not translate foreign argument formats.
+  Empty, repeated, inherited-inapplicable, or conflicting names fail closed
+  when the offered-tool index is built.
+- Proof anchors: `tests/test_tool_aliases.py`, the provider pseudo-tool-call
+  tests in `tests/test_thinking.py`, and an ACP prompt regression that builds
+  the complete offered-tool index. `JsonlQueryTool` explicitly does not inherit
+  the distinct `read_file` compatibility name from its implementation base.
+- Runtime boundary: source tests do not prove packaged OfficeV3 adoption until
+  the runtime is rebuilt, installed, restarted, and exercised in a fresh task.
+- Rollback: remove the built-in alias declarations and wrapper forwarding while
+  retaining canonical names. No configuration or persistent-data rollback is
+  required.
 
 ### 2026-08-20 — bounded structural candidates for missing filesystem paths
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -51,7 +51,7 @@ decision, read those entries together.
 
 | Area | Affected paths or keywords | Current effective decision | Relationship | Details |
 | --- | --- | --- | --- | --- |
-| Tool name aliases | `Tool.aliases`, `build_tool_name_index`, OpenClaw, Hermes | Compatibility names are execution-only, use canonical Box-Agent argument schemas, and fail closed on conflicts. | Built-in mappings complete the generic alias mechanism in `ba374f6`. | [2026-08-20 built-in aliases](#2026-08-20--built-in-tool-name-compatibility-aliases) |
+| Tool name aliases | `Tool.aliases`, `build_tool_name_index`, OpenClaw, Hermes | Compatibility names are execution-only, use canonical Box-Agent argument schemas, and fail closed on conflicts. | Built-in mappings complete the generic alias mechanism in `fad2436`. | [2026-08-20 built-in aliases](#2026-08-20--built-in-tool-name-compatibility-aliases) |
 | Filesystem path resolution | `SearchFilesTool`, `path_candidates.py`, `PATH_NOT_FOUND`, ACP file-access prompt | Missing paths may return bounded structural candidates, but the model must retry a specific path and the permission engine remains final authority. | Hardens the broad-Home-search block without adding aliases or automatic authorization. | [2026-08-20 path candidates](#2026-08-20--bounded-structural-candidates-for-missing-filesystem-paths) |
 | File writes | `box_agent/tools/file_tools.py`, `write_file` | Ordered chunks commit atomically, with bounded transactions, replay protection, and whole-body safety checks. | PR #37 hardens PR #34; both remain relevant. | [PR #37](#2026-08-17--transactional-write-safety-follow-up-pr-37), [PR #34](#2026-08-17--unified-transactional-write_file-protocol-pr-34) |
 | Tool invocation | `box_agent/tools/base.py`, `schema_validation.py`, `Tool.invoke` | Tool schemas and arguments fail closed before `execute()` is called. | Current at this baseline. | [PR #33](#2026-08-17--validate-tool-arguments-before-execution-pr-33) |
@@ -71,9 +71,9 @@ Release, provider API, and ACP compatibility have their own sources under
 
 ### 2026-08-20 — built-in tool-name compatibility aliases
 
-- Change: generic execution-only alias support is implemented by `ba374f6`;
-  the built-in compatibility mappings are a follow-up on
-  `syy/pr-review-standard`, with no merge or release reference yet.
+- Change: generic execution-only alias support is implemented by `fad2436`;
+  the built-in compatibility mappings are implemented by `ab37daf`. No merge
+  or release reference exists yet.
 - Durable tool contract: `read_file`, `write_file`, `edit_file`, `bash`,
   `generate_image`, `sub_agent`, `request_user_input`, and `get_skill` accept
   the documented equivalent OpenClaw or Hermes names. Underscore names also
@@ -96,8 +96,8 @@ Release, provider API, and ACP compatibility have their own sources under
 
 ### 2026-08-20 — bounded structural candidates for missing filesystem paths
 
-- Change: implementation on `syy/pr-review-standard`; no merge or release
-  reference exists yet.
+- Change: implementation `46f8f73`, building on broad-Home-search guard
+  `0df1dec`; no merge or release reference exists yet.
 - Durable tool contract: when `search_files` cannot find a requested path, it
   may return `raw_output.code=PATH_NOT_FOUND` with up to three existing
   candidates derived from a case-insensitive match against an immediate Home

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -51,6 +51,7 @@ decision, read those entries together.
 
 | Area | Affected paths or keywords | Current effective decision | Relationship | Details |
 | --- | --- | --- | --- | --- |
+| Filesystem path resolution | `SearchFilesTool`, `path_candidates.py`, `PATH_NOT_FOUND`, ACP file-access prompt | Missing paths may return bounded structural candidates, but the model must retry a specific path and the permission engine remains final authority. | Hardens the broad-Home-search block without adding aliases or automatic authorization. | [2026-08-20 path candidates](#2026-08-20--bounded-structural-candidates-for-missing-filesystem-paths) |
 | File writes | `box_agent/tools/file_tools.py`, `write_file` | Ordered chunks commit atomically, with bounded transactions, replay protection, and whole-body safety checks. | PR #37 hardens PR #34; both remain relevant. | [PR #37](#2026-08-17--transactional-write-safety-follow-up-pr-37), [PR #34](#2026-08-17--unified-transactional-write_file-protocol-pr-34) |
 | Tool invocation | `box_agent/tools/base.py`, `schema_validation.py`, `Tool.invoke` | Tool schemas and arguments fail closed before `execute()` is called. | Current at this baseline. | [PR #33](#2026-08-17--validate-tool-arguments-before-execution-pr-33) |
 | Context compression | `box_agent/core.py`, tool-call arguments, history summarization | Normal unsummarized history retains exact tool-call arguments; whole-history summarization remains a separate boundary. | Current at this baseline. | [PR #35](#2026-08-17--preserve-tool-call-arguments-in-normal-history-pr-35) |
@@ -66,6 +67,31 @@ Release, provider API, and ACP compatibility have their own sources under
 [long-lived release and compatibility history](#long-lived-release-and-compatibility-history).
 
 ## Pending material changes
+
+### 2026-08-20 — bounded structural candidates for missing filesystem paths
+
+- Change: implementation on `syy/pr-review-standard`; no merge or release
+  reference exists yet.
+- Durable tool contract: when `search_files` cannot find a requested path, it
+  may return `raw_output.code=PATH_NOT_FOUND` with up to three existing
+  candidates derived from a case-insensitive match against an immediate Home
+  child. Relative paths and unresolved absolute paths beneath an active root
+  use the same bounded structural rule; fuzzy aliases and recursive Home
+  searches remain out of scope.
+- Security boundary: candidates are diagnostic only. The tool does not retry,
+  execute, or authorize them. The model must select and explicitly retry a
+  specific absolute path, after which the existing `PermissionEngine` remains
+  final authority. ACP-listed roots are pre-authorized roots rather than an
+  exhaustive declaration of every path that may be requested.
+- Compatibility: successful searches and file-only result enumeration are
+  unchanged. Missing-path failures gain structured diagnostic data and a
+  retry hint. There is no configuration or data migration.
+- Proof anchors: `tests/test_tools.py`, `tests/test_permission_negotiation.py`,
+  `tests/test_system_prompt_contract.py`, `tests/test_session_integration.py`,
+  and the ACP file-access-context tests. Source probes used both configured
+  SenseNova models; packaged runtime rebuild/install/restart remains separate.
+- Rollback: remove the candidate helper and missing-path augmentation, and
+  restore the prior prompt wording. No persistent data rollback is required.
 
 ### 2026-08-19 — flattened sub-agent contract with derived policy
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -83,7 +83,9 @@ Release, provider API, and ACP compatibility have their own sources under
   canonical Box-Agent names. Aliases select the same tool implementation and
   canonical parameter schema; they do not translate foreign argument formats.
   Empty, repeated, inherited-inapplicable, or conflicting names fail closed
-  when the offered-tool index is built.
+  when the offered-tool index is built. Deferred MCP activation reserves the
+  same canonical, alias, and generated call-name namespace so conflicts are
+  rejected before a later model step.
 - Proof anchors: `tests/test_tool_aliases.py`, the provider pseudo-tool-call
   tests in `tests/test_thinking.py`, and an ACP prompt regression that builds
   the complete offered-tool index. `JsonlQueryTool` explicitly does not inherit
@@ -104,11 +106,14 @@ Release, provider API, and ACP compatibility have their own sources under
   child. Relative paths and unresolved absolute paths beneath an active root
   use the same bounded structural rule; fuzzy aliases and recursive Home
   searches remain out of scope.
-- Security boundary: candidates are diagnostic only. The tool does not retry,
-  execute, or authorize them. The model must select and explicitly retry a
-  specific absolute path, after which the existing `PermissionEngine` remains
-  final authority. ACP-listed roots are pre-authorized roots rather than an
-  exhaustive declaration of every path that may be requested.
+- Security boundary: Home candidates are discovered only when the current
+  permission policy already allows reading Home; restricted sessions receive
+  an empty candidate list without Home enumeration or existence probes. The
+  tool does not retry, execute, or authorize candidates. The model must select
+  and explicitly retry a specific absolute path, after which the existing
+  `PermissionEngine` remains final authority. ACP-listed roots are
+  pre-authorized roots rather than an exhaustive declaration of every path
+  that may be requested.
 - Compatibility: successful searches and file-only result enumeration are
   unchanged. Missing-path failures gain structured diagnostic data and a
   retry hint. There is no configuration or data migration.

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -4220,7 +4220,18 @@ async def test_acp_prompt_lists_officev3_allowed_directories(tmp_path):
     assert "## File Access Context" in prompt
     assert "configured allowed directories are allowed" in prompt
     assert str(allowed) in prompt
-    assert "Do not claim you can only access the workspace" in prompt
+    assert "currently pre-authorized roots" in prompt
+    assert "not the complete set of paths that may be requested" in prompt
+    assert "try a specific, narrow path outside these roots" in prompt
+    assert "runtime will request permission when appropriate" in prompt
+    assert "A permission denial applies only to the requested path" in prompt
+    assert "Do not generalize it to other specific candidate paths" in prompt
+    assert "Prefer absolute paths when the user names a location such as ~/Documents" in prompt
+    assert (
+        "Do not claim you can only access the workspace based only on the listed "
+        "roots or a denial for another path"
+    ) in prompt
+    assert "unless a tool call actually returns a permission denial" not in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -75,8 +75,9 @@ class FakeMCPTool(Tool):
 
 
 class FakeCoreTool(Tool):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, aliases: tuple[str, ...] = ()) -> None:
         self._name = name
+        self.aliases = aliases
 
     @property
     def name(self) -> str:
@@ -619,6 +620,38 @@ async def test_mcp_tool_cannot_replace_same_named_stable_core_tool() -> None:
     assert activated == OrderedDict()
     assert exposure.tools == [core_bash]
     assert exposure.mcp_generations == {}
+
+
+@pytest.mark.asyncio
+async def test_agent_rejects_deferred_mcp_name_that_conflicts_with_core_alias(
+    tmp_path,
+) -> None:
+    catalog = get_mcp_tool_catalog()
+    catalog.clear()
+    core_read = FakeCoreTool("read_file", aliases=("read",))
+    remote_read = FakeMCPTool("read", "untrusted", always_load=True)
+    catalog.replace_server("untrusted", [remote_read])
+    try:
+        agent = Agent(
+            llm_client=object(),
+            system_prompt="test",
+            tools=[core_read, remote_read],
+            workspace_dir=str(tmp_path),
+            deferred_mcp_loading_enabled=True,
+        )
+
+        result = await agent.tools["tool_search"].execute(query="read")
+        payload = json.loads(result.content)
+
+        assert result.success is False
+        assert payload["activated"] == []
+        assert payload["conflicts"][0]["error"] == "conflicts with stable core tool"
+        assert agent.activated_mcp_tools == OrderedDict()
+        inherited = agent._inherited_tools()
+        assert inherited["read_file"] is core_read
+        assert "read" not in inherited
+    finally:
+        catalog.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_integration.py
+++ b/tests/test_session_integration.py
@@ -52,7 +52,12 @@ def test_multi_turn_conversation(mock_llm_client, temp_workspace):
     # Agent automatically adds workspace info to system prompt
     assert system_prompt in agent.messages[0].content
     assert "Current Workspace" in agent.messages[0].content
-    assert "filesystem safety boundary" in agent.messages[0].content
+    assert "session workspace and default working root" in agent.messages[0].content
+    assert (
+        "does not by itself define every path the runtime may allow"
+        in agent.messages[0].content
+    )
+    assert "filesystem safety boundary" not in agent.messages[0].content
     assert "Relative tool paths resolve from each tool's active" in agent.messages[0].content
     assert "All relative paths will be resolved relative to this directory" not in agent.messages[0].content
 

--- a/tests/test_system_prompt_contract.py
+++ b/tests/test_system_prompt_contract.py
@@ -1,6 +1,28 @@
 from pathlib import Path
 
 
+def test_system_prompt_leaves_ambiguous_path_resolution_to_the_model():
+    prompt = Path("box_agent/config/system_prompt.md").read_text(encoding="utf-8")
+
+    assert "相对路径由工具从当前 active project/artifact root 解析" in prompt
+    assert "不要假定始终相对 workspace" in prompt
+    assert "由模型自行推断并尝试范围明确的具体候选路径" in prompt
+    assert "不要通过递归搜索整个用户主目录来定位文件" in prompt
+    assert "合理候选均失败后再询问用户" in prompt
+    assert "使用绝对路径或相对 workspace 的路径" not in prompt
+    assert "例如 `~/Downloads/...`" not in prompt
+
+
+def test_system_prompt_distinguishes_missing_attachments_from_explicit_paths():
+    prompt = Path("box_agent/config/system_prompt.md").read_text(encoding="utf-8")
+
+    assert "任务明确依赖用户尚未提供的附件" in prompt
+    assert "用户已经给出路径或位置时" in prompt
+    assert "先按当前路径与权限语义调用工具验证" in prompt
+    assert "不要仅因缺少附件元信息就把请求判定为缺失输入" in prompt
+    assert "所有文件相关请求一律视为缺失输入" not in prompt
+
+
 def test_system_prompt_keeps_todo_separate_from_factual_evidence():
     prompt = Path("box_agent/config/system_prompt.md").read_text(encoding="utf-8")
 

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -13,11 +13,40 @@ from openai import AsyncOpenAI
 from box_agent.acp import BoxACPAgent
 from box_agent.config import AgentConfig, Config, LLMConfig, ToolsConfig
 from box_agent.llm.anthropic_client import AnthropicClient
-from box_agent.llm.openai_client import OpenAIClient
+from box_agent.llm.openai_client import OpenAIClient, _tool_parameter_types
 from box_agent.schema import Message, StreamEvent
+from box_agent.tools.base import Tool, ToolResult
 
 
 # ───────────────────────── Anthropic ─────────────────────────
+
+
+def test_sensenova_parameter_type_index_rejects_generated_alias_collision():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read-file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"count": {"type": "integer"}},
+                },
+            },
+        },
+    ]
+
+    with pytest.raises(ValueError, match="read-file.*read_file"):
+        _tool_parameter_types(tools)
 
 @pytest.mark.asyncio
 async def test_anthropic_request_has_thinking_when_enabled(monkeypatch):
@@ -226,15 +255,23 @@ async def test_openai_stream_request_maps_thinking_to_provider_dialect(
 
 
 @pytest.mark.asyncio
-async def test_sensenova_stream_recovers_allowed_tool_call_from_thinking(monkeypatch):
+@pytest.mark.parametrize(
+    "returned_name",
+    ["staged_file_write", "staged-file-write"],
+    ids=["canonical", "generated-hyphenated-alias"],
+)
+async def test_sensenova_stream_recovers_allowed_tool_call_from_thinking(
+    returned_name,
+    monkeypatch,
+):
     client = OpenAIClient(
         api_key="k",
         api_base="https://token.sensenova.cn/v1",
         model="sn-sensenova-6-8-flash-lite",
     )
-    pseudo_call = """
+    pseudo_call = f"""
 <tool_call>
-<function=staged_file_write>
+<function={returned_name}>
 <parameter=action>
 append_text
 </parameter>
@@ -300,12 +337,200 @@ append_text
     assert finish.raw_finish_reason == "stop"
     assert finish.finish_reason == "tool_calls"
     assert finish.tool_calls is not None
-    assert finish.tool_calls[0].function.name == "staged_file_write"
+    assert finish.tool_calls[0].function.name == returned_name
     assert finish.tool_calls[0].function.arguments == {
         "action": "append_text",
         "chunk_index": 0,
         "content": "<html>recovered</html>",
     }
+
+
+@pytest.mark.asyncio
+async def test_sensenova_stream_recovers_declared_alias_from_tool_only_content(
+    monkeypatch,
+):
+    client = OpenAIClient(
+        api_key="k",
+        api_base="https://token.sensenova.cn/v1",
+        model="SenseNova-Flash-Lite-test",
+    )
+    captured: dict = {}
+    pseudo_call = """
+<tool_call>
+<function=legacy_alias_probe>
+<parameter=value>
+flash-lite-live
+</parameter>
+</function>
+</tool_call>
+"""
+    delta = SimpleNamespace(
+        content=pseudo_call,
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    chunk = SimpleNamespace(
+        id="resp-alias-recovered",
+        usage=None,
+        choices=[SimpleNamespace(finish_reason="stop", delta=delta)],
+    )
+
+    async def response_stream():
+        yield chunk
+
+    async def fake_create(**params):
+        captured.update(params)
+        return SimpleNamespace(
+            request_id="req-alias-recovered",
+            headers={},
+            parse=response_stream,
+        )
+
+    monkeypatch.setattr(
+        client.client.chat.completions.with_raw_response,
+        "create",
+        fake_create,
+    )
+
+    class AliasProbeTool(Tool):
+        aliases = ("legacy_alias_probe",)
+
+        @property
+        def name(self) -> str:
+            return "alias_probe"
+
+        @property
+        def description(self) -> str:
+            return "Probe alias recovery."
+
+        @property
+        def parameters(self) -> dict:
+            return {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            }
+
+        async def execute(self, value: str) -> ToolResult:
+            return ToolResult(success=True, content=value)
+
+    events = [
+        event
+        async for event in client.generate_stream(
+            [Message(role="user", content="go")],
+            tools=[AliasProbeTool()],
+            thinking_enabled=True,
+        )
+    ]
+    finish = next(event for event in events if event.type == "finish")
+
+    offered_names = [tool["function"]["name"] for tool in captured["tools"]]
+    assert offered_names == ["alias_probe"]
+    assert [event for event in events if event.type == "text"] == []
+    assert finish.raw_finish_reason == "stop"
+    assert finish.finish_reason == "tool_calls"
+    assert finish.tool_calls is not None
+    assert finish.tool_calls[0].function.name == "legacy_alias_probe"
+    assert finish.tool_calls[0].function.arguments == {
+        "value": "flash-lite-live"
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("aliases", "prefix"),
+    [
+        ((), ""),
+        (("legacy_alias_probe",), "This is explanatory text, not a tool call.\n"),
+    ],
+    ids=["undeclared-alias", "mixed-visible-text"],
+)
+async def test_sensenova_stream_keeps_unsafe_pseudo_calls_as_visible_text(
+    aliases,
+    prefix,
+    monkeypatch,
+):
+    client = OpenAIClient(
+        api_key="k",
+        api_base="https://token.sensenova.cn/v1",
+        model="SenseNova-Flash-Lite-test",
+    )
+    pseudo_call = (
+        f"{prefix}<tool_call>\n"
+        "<function=legacy_alias_probe>\n"
+        "<parameter=value>flash-lite-live</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    delta = SimpleNamespace(
+        content=pseudo_call,
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    chunk = SimpleNamespace(
+        id="resp-unsafe-pseudo-call",
+        usage=None,
+        choices=[SimpleNamespace(finish_reason="stop", delta=delta)],
+    )
+
+    async def response_stream():
+        yield chunk
+
+    async def fake_create(**_params):
+        return SimpleNamespace(
+            request_id="req-unsafe-pseudo-call",
+            headers={},
+            parse=response_stream,
+        )
+
+    monkeypatch.setattr(
+        client.client.chat.completions.with_raw_response,
+        "create",
+        fake_create,
+    )
+
+    class AliasProbeTool(Tool):
+        def __init__(self) -> None:
+            self.aliases = aliases
+
+        @property
+        def name(self) -> str:
+            return "alias_probe"
+
+        @property
+        def description(self) -> str:
+            return "Probe alias recovery."
+
+        @property
+        def parameters(self) -> dict:
+            return {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+
+        async def execute(self, value: str) -> ToolResult:
+            return ToolResult(success=True, content=value)
+
+    events = [
+        event
+        async for event in client.generate_stream(
+            [Message(role="user", content="go")],
+            tools=[AliasProbeTool()],
+            thinking_enabled=True,
+        )
+    ]
+    finish = next(event for event in events if event.type == "finish")
+
+    streamed_text = "".join(
+        event.delta or "" for event in events if event.type == "text"
+    )
+    assert streamed_text == pseudo_call
+    assert finish.finish_reason == "stop"
+    assert finish.tool_calls is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_aliases.py
+++ b/tests/test_tool_aliases.py
@@ -8,8 +8,19 @@ from box_agent.events import ErrorEvent, ToolCallResult, ToolCallStart
 from box_agent.loop_guards import CompletionGate
 from box_agent.runtime import run_agent_loop
 from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
+from box_agent.tools.bash_tool import BashTool
 from box_agent.tools.base import Tool, ToolResult, build_tool_name_index
-from box_agent.tools.sub_agent_tool import _WriteScopedTool
+from box_agent.tools.file import ReadTool
+from box_agent.tools.file.jsonl_tool import JsonlQueryTool
+from box_agent.tools.file_tools import EditTool, WriteTool
+from box_agent.tools.image_generation_tool import GenerateImageTool
+from box_agent.tools.request_user_input_tool import RequestUserInputTool
+from box_agent.tools.skill_tool import GetSkillTool
+from box_agent.tools.sub_agent_tool import (
+    SubAgentTool,
+    _PermissionGatedBashTool,
+    _WriteScopedTool,
+)
 
 
 class SequenceLLM:
@@ -130,6 +141,66 @@ def test_write_scoped_tool_preserves_wrapped_tool_aliases(tmp_path) -> None:
     wrapped = _WriteScopedTool(RecordingTool(), str(tmp_path), (".",))
 
     assert build_tool_name_index([wrapped])["legacy_echo"] is wrapped
+
+
+def test_permission_gated_tool_preserves_wrapped_tool_aliases() -> None:
+    wrapped = _PermissionGatedBashTool(
+        RecordingTool(),
+        title=None,
+        scopes=None,
+    )
+
+    assert build_tool_name_index([wrapped])["legacy_echo"] is wrapped
+
+
+def test_builtin_compatibility_names_resolve_to_equivalent_tools() -> None:
+    tools = [
+        tool_class.__new__(tool_class)
+        for tool_class in (
+            ReadTool,
+            WriteTool,
+            EditTool,
+            BashTool,
+            GenerateImageTool,
+            SubAgentTool,
+            RequestUserInputTool,
+            GetSkillTool,
+        )
+    ]
+
+    index = build_tool_name_index(tools)
+
+    expected_canonical_names = {
+        "read": "read_file",
+        "write": "write_file",
+        "edit": "edit_file",
+        "exec": "bash",
+        "terminal": "bash",
+        "image_generate": "generate_image",
+        "image-generate": "generate_image",
+        "sessions_spawn": "sub_agent",
+        "sessions-spawn": "sub_agent",
+        "delegate_task": "sub_agent",
+        "delegate-task": "sub_agent",
+        "clarify": "request_user_input",
+        "skill_view": "get_skill",
+        "skill-view": "get_skill",
+    }
+    assert {
+        call_name: index[call_name].name
+        for call_name in expected_canonical_names
+    } == expected_canonical_names
+
+
+def test_distinct_read_subclass_does_not_inherit_read_file_alias() -> None:
+    read_tool = ReadTool.__new__(ReadTool)
+    jsonl_tool = JsonlQueryTool.__new__(JsonlQueryTool)
+
+    index = build_tool_name_index([read_tool, jsonl_tool])
+
+    assert index["read"] is read_tool
+    assert index["query_jsonl"] is jsonl_tool
+    assert jsonl_tool.aliases == ()
 
 
 def test_underscore_names_automatically_accept_hyphenated_calls() -> None:

--- a/tests/test_tool_aliases.py
+++ b/tests/test_tool_aliases.py
@@ -1,0 +1,375 @@
+"""Regression tests for backwards-compatible tool aliases."""
+
+from __future__ import annotations
+
+import pytest
+
+from box_agent.events import ErrorEvent, ToolCallResult, ToolCallStart
+from box_agent.loop_guards import CompletionGate
+from box_agent.runtime import run_agent_loop
+from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
+from box_agent.tools.base import Tool, ToolResult, build_tool_name_index
+from box_agent.tools.sub_agent_tool import _WriteScopedTool
+
+
+class SequenceLLM:
+    """Deterministic LLM that records the canonical tools offered per step."""
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = list(responses)
+        self.offered_names: list[list[str]] = []
+
+    async def generate_stream(self, messages, tools=None, **_):
+        self.offered_names.append([tool.name for tool in tools or []])
+        response = self._responses.pop(0)
+        if response.content:
+            yield StreamEvent(type="text", delta=response.content)
+        yield StreamEvent(
+            type="finish",
+            finish_reason=response.finish_reason,
+            tool_calls=response.tool_calls,
+            usage=response.usage,
+        )
+
+
+class RecordingTool(Tool):
+    aliases = ("legacy_echo",)
+
+    def __init__(self, name: str = "echo") -> None:
+        self._name = name
+        self.calls: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "Record a text value."
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        }
+
+    async def execute(self, text: str) -> ToolResult:
+        self.calls.append(text)
+        return ToolResult(success=True, content=f"echo:{text}")
+
+
+class NamedTool(Tool):
+    def __init__(self, name: str, aliases: tuple[str, ...] = ()) -> None:
+        self._name = name
+        self.aliases = aliases
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Test tool {self._name}."
+
+    @property
+    def parameters(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self) -> ToolResult:
+        return ToolResult(success=True, content=self._name)
+
+
+def _messages() -> list[Message]:
+    return [
+        Message(role="system", content="system"),
+        Message(role="user", content="run the tool"),
+    ]
+
+
+def _tool_call(call_id: str, name: str, text: str = "hello") -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        type="function",
+        function=FunctionCall(name=name, arguments={"text": text}),
+    )
+
+
+def _empty_tool_call(call_id: str, name: str) -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        type="function",
+        function=FunctionCall(name=name, arguments={}),
+    )
+
+
+async def _collect(generator) -> list:
+    return [event async for event in generator]
+
+
+def test_aliases_are_not_serialized_in_provider_tool_schemas() -> None:
+    tool = RecordingTool()
+
+    assert tool.to_schema() == {
+        "name": "echo",
+        "description": "Record a text value.",
+        "input_schema": tool.parameters,
+    }
+    assert tool.to_openai_schema() == {
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Record a text value.",
+            "parameters": tool.parameters,
+        },
+    }
+
+
+def test_write_scoped_tool_preserves_wrapped_tool_aliases(tmp_path) -> None:
+    wrapped = _WriteScopedTool(RecordingTool(), str(tmp_path), (".",))
+
+    assert build_tool_name_index([wrapped])["legacy_echo"] is wrapped
+
+
+def test_underscore_names_automatically_accept_hyphenated_calls() -> None:
+    tool = NamedTool("read_file", aliases=("legacy_reader_name",))
+
+    index = build_tool_name_index([tool])
+
+    assert index["read-file"] is tool
+    assert index["legacy-reader-name"] is tool
+
+
+@pytest.mark.asyncio
+async def test_alias_executes_canonical_tool_without_being_offered_to_model() -> None:
+    tool = RecordingTool()
+    messages = _messages()
+    llm = SequenceLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[_tool_call("alias-call", "legacy_echo")],
+                finish_reason="tool",
+            ),
+            LLMResponse(content="done", finish_reason="stop"),
+        ]
+    )
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=messages,
+            tools={tool.name: tool},
+            max_steps=3,
+        )
+    )
+
+    starts = [event for event in events if isinstance(event, ToolCallStart)]
+    results = [event for event in events if isinstance(event, ToolCallResult)]
+    assert llm.offered_names[0] == ["echo"]
+    assert tool.calls == ["hello"]
+    assert [event.tool_name for event in starts] == ["echo"]
+    assert [event.tool_name for event in results] == ["echo"]
+    assert messages[2].tool_calls[0].function.name == "legacy_echo"
+
+
+@pytest.mark.asyncio
+async def test_hyphenated_name_executes_underscore_canonical_tool() -> None:
+    tool = RecordingTool(name="echo_value")
+    llm = SequenceLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[_tool_call("hyphenated-call", "echo-value")],
+                finish_reason="tool",
+            ),
+            LLMResponse(content="done", finish_reason="stop"),
+        ]
+    )
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_messages(),
+            tools={tool.name: tool},
+            max_steps=3,
+        )
+    )
+
+    starts = [event for event in events if isinstance(event, ToolCallStart)]
+    assert llm.offered_names[0] == ["echo_value"]
+    assert tool.calls == ["hello"]
+    assert [event.tool_name for event in starts] == ["echo_value"]
+
+
+@pytest.mark.asyncio
+async def test_alias_is_canonicalized_before_duplicate_calls_are_removed() -> None:
+    tool = RecordingTool()
+    llm = SequenceLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    _tool_call("alias-call", "legacy_echo"),
+                    _tool_call("canonical-call", "echo"),
+                ],
+                finish_reason="tool",
+            ),
+            LLMResponse(content="done", finish_reason="stop"),
+        ]
+    )
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_messages(),
+            tools={tool.name: tool},
+            max_steps=3,
+        )
+    )
+
+    results = [event for event in events if isinstance(event, ToolCallResult)]
+    assert tool.calls == ["hello"]
+    assert [(event.tool_name, event.user_visible) for event in results] == [
+        ("echo", True),
+        ("echo", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_alias_is_canonicalized_before_empty_argument_loop_detection() -> None:
+    tool = RecordingTool()
+    llm = SequenceLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[_empty_tool_call("alias-call", "legacy_echo")],
+                finish_reason="tool",
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[_empty_tool_call("canonical-call", "echo")],
+                finish_reason="tool",
+            ),
+            LLMResponse(content="done", finish_reason="stop"),
+        ]
+    )
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_messages(),
+            tools={tool.name: tool},
+            max_steps=3,
+        )
+    )
+
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert "2x in a row" in error.message
+    assert "echo" in error.message
+
+
+@pytest.mark.asyncio
+async def test_alias_cannot_call_tool_hidden_from_current_step() -> None:
+    hidden = RecordingTool()
+    required = NamedTool("required")
+    llm = SequenceLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[_tool_call("hidden-alias", "legacy_echo")],
+                finish_reason="tool",
+            )
+        ]
+    )
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_messages(),
+            tools={hidden.name: hidden, required.name: required},
+            max_steps=1,
+            completion_gate=CompletionGate(
+                required_tools=frozenset({"required"}),
+                restrict_tools_until_required_succeed=True,
+            ),
+        )
+    )
+
+    result = next(event for event in events if isinstance(event, ToolCallResult))
+    assert llm.offered_names[0] == ["required"]
+    assert hidden.calls == []
+    assert result.tool_name == "legacy_echo"
+    assert result.success is False
+    assert result.error == "Unknown tool: legacy_echo"
+
+
+@pytest.mark.asyncio
+async def test_conflicting_aliases_fail_before_the_model_is_called() -> None:
+    first = NamedTool("first", aliases=("legacy",))
+    second = NamedTool("second", aliases=("legacy",))
+    llm = SequenceLLM([LLMResponse(content="done", finish_reason="stop")])
+
+    with pytest.raises(ValueError, match="legacy"):
+        await _collect(
+            run_agent_loop(
+                llm=llm,
+                messages=_messages(),
+                tools={first.name: first, second.name: second},
+                max_steps=1,
+            )
+        )
+
+    assert llm.offered_names == []
+
+
+@pytest.mark.asyncio
+async def test_generated_hyphenated_alias_conflict_fails_before_model_call() -> None:
+    underscored = NamedTool("read_file")
+    hyphenated = NamedTool("read-file")
+    llm = SequenceLLM([LLMResponse(content="done", finish_reason="stop")])
+
+    with pytest.raises(ValueError, match="read-file"):
+        await _collect(
+            run_agent_loop(
+                llm=llm,
+                messages=_messages(),
+                tools={
+                    underscored.name: underscored,
+                    hyphenated.name: hyphenated,
+                },
+                max_steps=1,
+            )
+        )
+
+    assert llm.offered_names == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "aliases",
+    [
+        ("",),
+        ("tool",),
+        ("legacy", "legacy"),
+    ],
+    ids=["empty", "canonical-name", "duplicate"],
+)
+async def test_invalid_alias_declarations_fail_before_the_model_is_called(
+    aliases: tuple[str, ...],
+) -> None:
+    tool = NamedTool("tool", aliases=aliases)
+    llm = SequenceLLM([LLMResponse(content="done", finish_reason="stop")])
+
+    with pytest.raises(ValueError, match="alias"):
+        await _collect(
+            run_agent_loop(
+                llm=llm,
+                messages=_messages(),
+                tools={tool.name: tool},
+                max_steps=1,
+            )
+        )
+
+    assert llm.offered_names == []

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -405,6 +405,48 @@ async def test_search_files_lists_and_searches_without_bash(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_search_files_expands_tilde_path(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    target = home / "Downloads" / "design2000"
+    target.mkdir(parents=True)
+    (target / "brief.txt").write_text("content", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    result = await SearchFilesTool(workspace_dir=str(workspace)).execute(
+        pattern="*.txt",
+        target="files",
+        path="~/Downloads/design2000",
+    )
+
+    assert result.success is True
+    assert result.content == "brief.txt"
+
+
+@pytest.mark.asyncio
+async def test_search_files_blocks_recursive_search_from_user_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / "Music").mkdir(parents=True)
+    (home / "Music" / "song.txt").write_text("content", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    result = await SearchFilesTool(workspace_dir=str(workspace)).execute(
+        pattern="*.txt",
+        target="files",
+        path="~",
+    )
+
+    assert result.success is False
+    assert result.error.startswith("BROAD_HOME_SEARCH_BLOCKED:")
+    assert result.permission_request is None
+
+
+@pytest.mark.asyncio
 async def test_search_files_paginates_results(tmp_path):
     for index in range(5):
         (tmp_path / f"file-{index}.txt").write_text("value", encoding="utf-8")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -405,6 +405,138 @@ async def test_search_files_lists_and_searches_without_bash(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_search_files_not_found_suggests_existing_home_child_path(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    target = home / "Pictures" / "project-assets"
+    target.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    result = await SearchFilesTool(workspace_dir=str(workspace)).execute(
+        pattern="*",
+        target="files",
+        path="pictures/project-assets",
+    )
+
+    assert result.success is False
+    assert result.permission_request is None
+    assert result.raw_output == {
+        "code": "PATH_NOT_FOUND",
+        "path": "pictures/project-assets",
+        "path_candidates": [
+            {
+                "path": str(target),
+                "basis": "home_child_case_insensitive_match",
+                "exists": True,
+            }
+        ],
+    }
+    assert str(target) in result.error
+    assert "retry search_files with this absolute path" in result.error
+
+
+@pytest.mark.asyncio
+async def test_search_files_not_found_uses_active_root_tail_for_home_candidate(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    target = home / "Pictures" / "project-assets"
+    target.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    unresolved = workspace / "pictures" / "project-assets"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    result = await SearchFilesTool(workspace_dir=str(workspace)).execute(
+        pattern="*",
+        target="files",
+        path=str(unresolved),
+    )
+
+    assert result.success is False
+    assert result.raw_output["path_candidates"] == [
+        {
+            "path": str(target),
+            "basis": "home_child_case_insensitive_match",
+            "exists": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_files_not_found_does_not_guess_unrelated_home_child(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    (home / "Pictures" / "project-assets").mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    result = await SearchFilesTool(workspace_dir=str(workspace)).execute(
+        pattern="*",
+        target="files",
+        path="photos/project-assets",
+    )
+
+    assert result.success is False
+    assert result.raw_output == {
+        "code": "PATH_NOT_FOUND",
+        "path": "photos/project-assets",
+        "path_candidates": [],
+    }
+    assert "Pictures" not in result.error
+
+
+@pytest.mark.asyncio
+async def test_search_files_path_candidate_does_not_bypass_permission_engine(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    target = home / "Pictures" / "project-assets"
+    target.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    engine = PermissionEngine(
+        CapabilityPolicy(
+            filesystem_scope="session_workspace",
+            session_workspace_root=str(workspace),
+        ),
+        workspace,
+    )
+    tool = SearchFilesTool(
+        workspace_dir=str(workspace),
+        permission_engine=engine,
+    )
+
+    unresolved = await tool.execute(
+        pattern="*",
+        target="files",
+        path="pictures/project-assets",
+    )
+    retried = await tool.execute(
+        pattern="*",
+        target="files",
+        path=str(target),
+    )
+
+    assert unresolved.success is False
+    assert unresolved.permission_request is None
+    assert unresolved.raw_output["path_candidates"][0]["path"] == str(target)
+    assert retried.success is False
+    assert retried.permission_request is not None
+    assert retried.permission_request["path"] == str(target)
+
+
+@pytest.mark.asyncio
 async def test_search_files_expands_tilde_path(tmp_path, monkeypatch):
     home = tmp_path / "home"
     target = home / "Downloads" / "design2000"
@@ -443,6 +575,7 @@ async def test_search_files_blocks_recursive_search_from_user_home(tmp_path, mon
 
     assert result.success is False
     assert result.error.startswith("BROAD_HOME_SEARCH_BLOCKED:")
+    assert "Choose a specific likely directory such as ~/Downloads or ~/Documents" in result.error
     assert result.permission_request is None
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -530,10 +530,54 @@ async def test_search_files_path_candidate_does_not_bypass_permission_engine(
 
     assert unresolved.success is False
     assert unresolved.permission_request is None
-    assert unresolved.raw_output["path_candidates"][0]["path"] == str(target)
+    assert unresolved.raw_output == {
+        "code": "PATH_NOT_FOUND",
+        "path": "pictures/project-assets",
+        "path_candidates": [],
+    }
+    assert str(target) not in unresolved.error
     assert retried.success is False
     assert retried.permission_request is not None
     assert retried.permission_request["path"] == str(target)
+
+
+@pytest.mark.asyncio
+async def test_search_files_path_candidate_is_returned_when_home_is_authorized(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    target = home / "Pictures" / "project-assets"
+    target.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    engine = PermissionEngine(
+        CapabilityPolicy(
+            filesystem_scope="user_home",
+            session_workspace_root=str(workspace),
+        ),
+        workspace,
+    )
+
+    result = await SearchFilesTool(
+        workspace_dir=str(workspace),
+        permission_engine=engine,
+    ).execute(
+        pattern="*",
+        target="files",
+        path="pictures/project-assets",
+    )
+
+    assert result.success is False
+    assert result.permission_request is None
+    assert result.raw_output["path_candidates"] == [
+        {
+            "path": str(target),
+            "basis": "home_child_case_insensitive_match",
+            "exists": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TPR

### 任务

- 变更内容：
  - 为模型工具调用添加了仅用于执行阶段的兼容性别名，包括常见的 OpenClaw 和 Hermes 工具名称。
  - 面向提供商的 Schema 仍保持规范名称；在分派、去重、守卫检查和执行过程中，允许使用别名及自动生成的连字符形式变体。
  - 当 `search_files` 无法解析用户路径时，新增数量受限的结构化候选路径。
  - 禁止从整个 Home 目录发起递归搜索，但允许模型通过常规权限流程重试某个具体候选路径。
  - 明确了工作区、ACP 文件系统根目录、显式路径和附件缺失情况下的提示词语义。
- 变更原因：
  - 模型可能会输出语义等价的外部工具名称，或将面向用户的路径理解为相对于当前活动工作区。
  - 运行时应帮助模型自行恢复，同时避免硬编码文件夹映射、递归搜索整个 Home 目录、自动授权或过早要求用户澄清。
  - 模型明确选择候选路径并重试后，`PermissionEngine` 必须仍是最终权限裁决者。
- 受影响的入口：
  - 共享工具分派：`box_agent/core.py`、`box_agent/tools/base.py`
  - SenseNova/OpenAI 兼容提供商处理：`box_agent/llm/openai_client.py`
  - 文件搜索和路径解析：`box_agent/tools/file_tools.py`、`box_agent/tools/file/path_candidates.py`
  - `box_agent/tools/` 下的内置工具和 SubAgent 包装器
  - Agent 和 ACP 提示词上下文：`box_agent/agent.py`、`box_agent/acp/__init__.py`、`box_agent/config/system_prompt.md`
- 不在本次范围内：
  - 转换 OpenClaw/Hermes 参数 Schema。
  - 模糊目录别名或类似 `Downloads -> ~/Downloads` 的硬编码映射。
  - 递归搜索整个 Home 目录。
  - 自动执行候选路径或为其授权。
  - 打包运行时的构建、安装、重启或 OfficeV3 部署。

### 验证证据

- 已运行的测试或检查：
  - `uv run pytest tests/test_tools.py -k "search_files" -q`
    - 19 项通过。
  - `uv run pytest tests/test_permission_negotiation.py tests/test_system_prompt_contract.py tests/test_session_integration.py -q`
    - 41 项通过。
  - `uv run pytest tests/test_tool_aliases.py tests/test_thinking.py -q`
    - 43 项通过。
  - `uv run pytest tests/test_agent.py tests/test_sub_agent_tool.py -q`
    - 56 项通过，2 项跳过。
  - `uv run pytest tests/test_acp.py -q`
    - 108 项通过，3 项失败。
    - 剩余失败涉及持久化的工作区注册表状态，以及本地 Python/Node 运行时路径预期：
      - `test_acp_workspace_config_methods_share_profiles`
      - `test_acp_prompt_includes_skill_runtime_context`
      - `test_acp_prompt_and_bash_env_include_self_managed_node_runtime`
  - `bash -lc 'cd /mnt/d/code/Box-Agent && ./general_review/ci/preflight.sh'`
    - G1.1 `uv sync --frozen --all-extras`：通过。
    - G1.2 `compileall`：通过。
    - G1.3 测试套件：2665 项通过，2 项失败，60 项跳过，1 项取消选择。
    - 失败项：
      - 过期的 PPTX 布局清单。
      - `box_agent/skills/zhihu/scripts/run.sh` 中已有的 POSIX 语法错误。
    - 当前分支未修改上述任何一个失败的 Skill 相关部分。
    - G1.4 `uv build`：未运行，因为预检流程会在首个失败阶段停止。
  - `git diff --check origin/main HEAD`：通过。
  - `git show --check --stat HEAD`：通过。
- 日志、截图、探针或清单：
  - 已使用配置中的 SenseNova Flash-Lite 和 Flash 端点运行真实模型源码探针。
  - 两个模型都至少产生过一次完整轨迹：路径缺失 → 返回数量受限的候选路径 → 使用显式绝对路径重试 → 权限协商 → 成功获取 `notes.txt` 结果。
  - 本地探针日志包括：
    - `agent_run_20260820_214606_542802.log`
    - `agent_run_20260820_214606_907726.log`
    - `agent_run_20260820_214607_275126.log`
    - `agent_run_20260820_214607_660582.log`
  - 验证完成后已删除探针测试数据。
  - 当前分支未修改任何内置 Skill 或生成的清单。
- 未运行的项目及原因：
  - G1.4 软件包构建未运行，因为确定性预检在 G1.3 阶段因两个基线问题而停止。
  - 未运行打包运行时构建、安装、宿主重启和全新的 OfficeV3 任务。
  - 当前 Head 的 GitHub `teamwork/local-ci` 未通过；上文已记录等效的本地预检结果。

### 风险

- 兼容性：
  - 提供商 Schema 仍只公开规范的 Box-Agent 工具名称。
  - 别名继续使用 Box-Agent 的规范参数，不转换外部工具的参数格式。
  - 空名称、重复名称、不适用的继承名称或存在冲突的名称均会以拒绝方式安全失败。
  - `JsonlQueryTool` 明确避免继承语义不同的 `read_file` 别名。
  - 成功的文件搜索和仅文件枚举行为保持不变。
  - 路径缺失错误新增附加的 `PATH_NOT_FOUND` 诊断数据。
  - 之前允许执行的 Home 目录递归搜索现在会被有意拒绝。
- 打包及运行时影响：
  - 打包运行时所使用的源码行为已发生变化。
  - 源码测试和模型探针无法证明已安装的 OfficeV3 运行时行为正确。
  - 在正式部署运行时之前，仍需重新构建、安装、重启宿主，并运行一个全新的实时任务。
- 配置、密钥或迁移：
  - 不涉及配置、密钥、凭据、持久化数据或 Schema 迁移。
  - 未包含本地日志、工作区文件或生成的图谱/缓存文件。
- 回滚：
  - 按以下逆序回滚：
    - `6b4f5dc` —— 协调变更历史中的引用
    - `ab37daf` —— 内置兼容性别名
    - `46f8f73` —— 数量受限的结构化候选路径
    - `fad2436` —— 通用别名分派及提供商支持
    - `0df1dec` —— 广泛 Home 目录搜索守卫
  - 无需回滚持久化数据。
- 跨仓库后续工作：