### PR TITLE
feat(runtime): bundle web extract MCP for desktop

### DIFF
--- a/box_agent/acp/runtime_entry.py
+++ b/box_agent/acp/runtime_entry.py
@@ -5,10 +5,41 @@ anything at module level that prints to stdout — the ACP protocol owns
 stdout exclusively.
 """
 
+import os
 import sys
 
 
+WEB_EXTRACT_MCP_ARG = "--web-extract-mcp"
+
+
+class _McpStdoutProxy:
+    """Give MCP an owned stdout buffer without closing the launcher stream."""
+
+    def __init__(self, stream: object) -> None:
+        self._stream = stream
+        self.buffer = os.fdopen(os.dup(stream.fileno()), "wb")
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._stream, name)
+
+
 def main() -> None:
+    if sys.argv[1:] == [WEB_EXTRACT_MCP_ARG]:
+        # Reuse the frozen runtime binary for the bundled stdio MCP server.
+        # This keeps desktop packaging to one PyInstaller payload while still
+        # giving hosts a stable command they can advertise in mcp.json.
+        from box_agent.mcp_servers.web_extract_server import main as run_web_extract_mcp
+
+        protocol_stdout = sys.stdout
+        sys.stdout = _McpStdoutProxy(protocol_stdout)
+        try:
+            run_web_extract_mcp()
+        finally:
+            # MCP owns and may close the duplicate buffer. Restore the original
+            # stream before PyInstaller performs its final stdout flush.
+            sys.stdout = protocol_stdout
+        return
+
     # Ensure stdout is only used for ACP protocol — redirect any stray
     # stdlib print() calls to stderr before importing anything else.
     # Use sys.stderr directly (NOT TextIOWrapper(sys.stderr.buffer))

--- a/docs/PRODUCTION_GUIDE.md
+++ b/docs/PRODUCTION_GUIDE.md
@@ -84,6 +84,23 @@ box-agent-runtime/
     └── node/         # Bundled macOS Node.js runtime for skill scripts
 ```
 
+`manifest.json` declares both the default ACP entry and bundled stdio MCP
+servers. Hosts should resolve each relative `entry` from the runtime directory
+instead of assuming a second executable exists:
+
+```json
+{
+  "entry": "bin/box-agent-acp",
+  "mcp_servers": {
+    "box-agent-web-extract": {
+      "entry": "bin/box-agent-acp",
+      "args": ["--web-extract-mcp"],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
 #### Spawning from Host Process
 
 ```typescript
@@ -102,6 +119,11 @@ const proc = spawn('build-resources/box-agent-runtime/bin/box-agent-acp', [], {
 // stdin/stdout: ACP JSON-RPC protocol (pure, no stray bytes)
 // stderr: diagnostic logs (safe to pipe to host logger)
 ```
+
+To launch the bundled web extractor, spawn the declared MCP `entry` with its
+declared `args` and keep stdin/stdout reserved for the MCP stdio protocol. This
+reuses the same frozen binary and does not require the source-install-only
+`box-agent-web-extract-mcp` console script.
 
 #### Key Constraints
 

--- a/docs/PRODUCTION_GUIDE_CN.md
+++ b/docs/PRODUCTION_GUIDE_CN.md
@@ -68,6 +68,26 @@ gh release download --repo Raccoon-Office/Box-Agent \
 [发布状态](RELEASE_STATE.md)；除非对应 tag 和 asset 已真实存在，不要用开发版本号
 拼接下载地址。
 
+runtime 的 `manifest.json` 同时声明默认 ACP 入口和内置 stdio MCP。宿主应以
+runtime 根目录解析相对 `entry`，不要假设存在第二个可执行文件：
+
+```json
+{
+  "entry": "bin/box-agent-acp",
+  "mcp_servers": {
+    "box-agent-web-extract": {
+      "entry": "bin/box-agent-acp",
+      "args": ["--web-extract-mcp"],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+启动内置网页提取器时，使用该 MCP 声明的 `entry` 和 `args`，并将 stdin/stdout
+保留给 MCP stdio 协议。它复用同一个 frozen binary，不依赖只在源码安装环境中存在的
+`box-agent-web-extract-mcp` console script。
+
 #### 从源码构建
 
 ```bash

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -67,6 +67,26 @@ Release, provider API, and ACP compatibility have their own sources under
 
 ## Pending material changes
 
+### 2026-08-21 — bundled web-extract MCP runtime dispatch (PR #64)
+
+- Change: [PR #64](https://github.com/Raccoon-Office/Box-Agent/pull/64),
+  implementation on `codex/client-web-extract-runtime`; no merge or release
+  reference exists yet.
+- Runtime contract: `manifest.json` advertises `box-agent-web-extract` as a
+  stdio MCP that reuses the packaged `box-agent-acp` entry with
+  `--web-extract-mcp`. Source installs may continue to use the existing
+  `box-agent-web-extract-mcp` console script.
+- Compatibility: the manifest field and runtime argument are additive. Desktop
+  hosts must read the relative MCP entry and arguments before the bundled
+  extractor becomes available; hosts that only launch ACP remain unchanged.
+- Proof anchors: `tests/test_runtime_entry.py`, `tests/test_build_runtime.py`,
+  the packaged runtime manifest, and an MCP initialize/list/call probe against
+  the built binary.
+- Runtime boundary: the PR records build and local binary probe evidence
+  separately from officev3 install, host restart, and fresh live-task checks.
+- Rollback: revert the implementation commit and rebuild the prior runtime; no
+  user data or configuration migration is required.
+
 ### 2026-08-19 — flattened sub-agent contract with derived policy
 
 - Change: implementation on `codex/simplify-subagent-contract`; no merge or

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -176,6 +176,9 @@ def pyinstaller_hidden_imports(*, external_python_sandbox: bool = False) -> list
         "box_agent.llm.openai_client",
         "box_agent.llm.llm_wrapper",
         "box_agent.logger",
+        "box_agent.mcp_servers",
+        "box_agent.mcp_servers.web_extract",
+        "box_agent.mcp_servers.web_extract_server",
         "box_agent.retry",
         "box_agent.schema",
         "box_agent.tools",
@@ -399,6 +402,35 @@ def bundled_stable_runtime_components(
     return ()
 
 
+def build_runtime_manifest(
+    *,
+    version: str,
+    plat: str,
+    arch: str,
+    entry_path: str,
+    external_python_sandbox: bool,
+    bundled_components: tuple[str, ...],
+) -> dict[str, object]:
+    """Return the host-facing manifest for a packaged runtime."""
+    return {
+        "name": "box-agent",
+        "version": version,
+        "platform": plat,
+        "arch": arch,
+        "entry": entry_path,
+        "mode": "standalone",
+        "external_python_sandbox": external_python_sandbox,
+        "bundled_stable_runtimes": list(bundled_components),
+        "mcp_servers": {
+            "box-agent-web-extract": {
+                "entry": entry_path,
+                "args": ["--web-extract-mcp"],
+                "transport": "stdio",
+            }
+        },
+    }
+
+
 # ── Build ────────────────────────────────────────────────────
 
 
@@ -611,16 +643,14 @@ def build_runtime(
         arch=arch,
         external_python_sandbox=external_python_sandbox,
     )
-    manifest = {
-        "name": "box-agent",
-        "version": version,
-        "platform": plat,
-        "arch": arch,
-        "entry": entry_path,
-        "mode": "standalone",
-        "external_python_sandbox": external_python_sandbox,
-        "bundled_stable_runtimes": list(bundled_components),
-    }
+    manifest = build_runtime_manifest(
+        version=version,
+        plat=plat,
+        arch=arch,
+        entry_path=entry_path,
+        external_python_sandbox=external_python_sandbox,
+        bundled_components=bundled_components,
+    )
     (runtime_dir / "manifest.json").write_text(
         json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
     )

--- a/tests/test_build_runtime.py
+++ b/tests/test_build_runtime.py
@@ -112,6 +112,26 @@ def test_bundled_stable_runtime_components_empty_for_external_python_mode() -> N
     ) == ()
 
 
+def test_runtime_manifest_advertises_bundled_web_extract_mcp() -> None:
+    manifest = build_runtime.build_runtime_manifest(
+        version="0.8.87",
+        plat="darwin",
+        arch="arm64",
+        entry_path="bin/box-agent-acp",
+        external_python_sandbox=False,
+        bundled_components=(),
+    )
+
+    assert manifest["entry"] == "bin/box-agent-acp"
+    assert manifest["mcp_servers"] == {
+        "box-agent-web-extract": {
+            "entry": "bin/box-agent-acp",
+            "args": ["--web-extract-mcp"],
+            "transport": "stdio",
+        }
+    }
+
+
 @pytest.mark.parametrize("arch", ["arm64", "x64"])
 def test_linux_uses_host_stable_runtimes_in_external_sandbox_mode(arch: str) -> None:
     assert build_runtime.bundled_stable_runtime_components(
@@ -150,6 +170,7 @@ def test_pyinstaller_args_keep_bundled_sandbox_by_default() -> None:
     assert "ipykernel" in hidden
     assert "pandas" in hidden
     assert "pip._internal.cli.main" in hidden
+    assert "box_agent.mcp_servers.web_extract_server" in hidden
     assert ("--collect-all", "ipykernel") in collect_pairs
     assert ("--collect-submodules", "pandas") in collect_pairs
     assert ("--collect-submodules", "pip") in collect_pairs
@@ -168,6 +189,7 @@ def test_pyinstaller_args_drop_sandbox_stack_for_external_python_mode() -> None:
     assert "jupyter_core" in hidden
     assert "dateutil" in hidden
     assert "dateutil.parser" in hidden
+    assert "box_agent.mcp_servers.web_extract_server" in hidden
     assert "ipykernel" not in hidden
     assert "pandas" not in hidden
     assert "pip._internal.cli.main" not in hidden

--- a/tests/test_runtime_entry.py
+++ b/tests/test_runtime_entry.py
@@ -1,0 +1,32 @@
+"""Tests for the frozen runtime's multi-service entry point."""
+
+from __future__ import annotations
+
+import io
+import sys
+
+from box_agent.acp import runtime_entry
+from box_agent.mcp_servers import web_extract_server
+
+
+def test_runtime_entry_dispatches_web_extract_mcp(monkeypatch, tmp_path) -> None:
+    called: list[bool] = []
+    diagnostic_stderr = io.StringIO()
+    with monkeypatch.context() as context:
+        stdout_path = tmp_path / "protocol.stdout"
+        with stdout_path.open("w+", encoding="utf-8") as protocol_stdout:
+            context.setattr(sys, "argv", ["box-agent-acp", "--web-extract-mcp"])
+            context.setattr(sys, "stdout", protocol_stdout)
+            context.setattr(sys, "stderr", diagnostic_stderr)
+
+            def close_owned_stdout() -> None:
+                called.append(True)
+                sys.stdout.buffer.close()
+
+            context.setattr(web_extract_server, "main", close_owned_stdout)
+
+            runtime_entry.main()
+
+            assert called == [True]
+            assert sys.stdout is protocol_stdout
+            assert protocol_stdout.closed is False


### PR DESCRIPTION
## Task

Bundle the existing `web_extract` stdio MCP into the standalone desktop runtime without adding a second PyInstaller payload.

- `box-agent-acp --web-extract-mcp` dispatches to the existing MCP server.
- The runtime build includes the MCP modules and advertises the entry, args, and stdio transport in `manifest.json`.
- The frozen entry protects protocol stdout from MCP wrapper shutdown so PyInstaller exits without a closed-stream traceback.
- Production guidance and the durable runtime contract are documented in English and Chinese.
- Affected architecture layers: ACP runtime adapter, runtime packaging, and host-facing runtime metadata.
- Out of scope: changing `web_extract` semantics, officev3 host implementation, installing/restarting the desktop app, and publishing runtime artifacts for other platforms.
- Target consistency: rebased directly on the latest upstream `main` (`4842ab6`); there are no target-branch commits after the merge base for the affected paths.

## Proof

Head: `4208484`

- `uv run pytest -q tests/test_runtime_entry.py tests/test_build_runtime.py tests/test_web_extract.py tests/test_mcp.py`
  - 107 passed, 3 skipped.
- `bash general_review/ci/preflight.sh`
  - 2705 passed, 60 skipped, 1 deselected.
  - Python compilation and wheel/sdist build succeeded.
- `uv run box-agent-build-runtime --version 0.8.87 --external-python-sandbox --output /private/tmp/box-agent-pr64-runtime-4208484`
  - darwin-arm64 archive built successfully (53.7 MB).
  - Generated manifest contains `box-agent-web-extract -> bin/box-agent-acp --web-extract-mcp` over stdio.
- Frozen-binary MCP probe:
  - initialize, `tools/list`, and `tools/call(web_extract, https://example.com/)` succeeded.
  - response IDs: 1, 2, 3; tool result was not an error.
  - stdout contained JSON-RPC only; exit code was 0.
  - no `I/O operation on closed file` shutdown error remained.
- `git diff --check origin/main...HEAD` passed.

Runtime boundary reached:

`source changed -> source tests passed -> runtime built -> binary/manifest probe passed`

Not verified:

- runtime installation into officev3;
- host restart and a fresh live desktop task;
- darwin-x64, Linux, Windows, or non-external-sandbox runtime artifacts.

## Risk

- Compatibility: additive argument and manifest field; existing ACP-only hosts remain unchanged.
- Host follow-up: officev3 must resolve the relative MCP entry/args from the runtime manifest before the bundled extractor becomes visible.
- Protocol: ACP and MCP continue to use separate process invocations; stdout remains protocol-only.
- Configuration/data/secrets: no config migration, persistent-data migration, or credentials are added.
- Packaging residual risk: only darwin-arm64 external-sandbox packaging was built and probed locally.
- Rollback: revert this commit and rebuild the previous runtime; no data migration is needed.