### PR TITLE
feat(vision-review): add native strategy alongside proxy

### DIFF
--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -3086,6 +3086,12 @@ async def run_agent_loop(
     delegated_tool_call_total = 0
     delegated_budget_guidance_injected = False
     completion_reserve_injected = False
+    # Multimodal follow-up content a tool asked to hand to the main model
+    # (e.g. vision_review in native strategy). Accumulated during tool
+    # execution and flushed as ONE user message at the next step boundary —
+    # after every tool result is appended, before the next model call — so
+    # tool-call/result closure is never interleaved with it.
+    pending_followup_user_content: list[dict] = []
     tool_budget_wrapup_injected: set[str] = set()
     visible_tool_call_total = 0
     final_summary_guidance_injected = False
@@ -3236,6 +3242,21 @@ async def run_agent_loop(
                     injection_id=injection_id,
                     user_visible=user_visible,
                 )
+
+        # Deliver any multimodal content a previous step's tool handed to the
+        # main model as a single follow-up user message before this step's
+        # model call. Runs after all prior tool results are already in
+        # ``messages`` so the assistant->tool_result->user ordering stays valid.
+        if pending_followup_user_content:
+            messages.append(
+                Message(role="user", content=pending_followup_user_content)
+            )
+            yield InjectedMessageEvent(
+                content="[vision_review] Image(s) attached for direct inspection.",
+                injection_id=None,
+                user_visible=False,
+            )
+            pending_followup_user_content = []
 
         has_plan_tool = "plan_write" in tools
         latest_user_text = _latest_user_text(messages)
@@ -5461,6 +5482,8 @@ async def run_agent_loop(
             )
             msg_content = tool_msg.content
             messages.append(tool_msg)
+            if result.followup_user_content:
+                pending_followup_user_content.extend(result.followup_user_content)
             _record_context_resource_history(
                 tool_call_id=tc_id,
                 decision=resource_decision,
@@ -6069,6 +6092,8 @@ async def run_agent_loop(
                 )
                 msg_content = tool_msg.content
                 messages.append(tool_msg)
+                if result.followup_user_content:
+                    pending_followup_user_content.extend(result.followup_user_content)
                 _record_context_resource_history(
                     tool_call_id=tc_id,
                     decision=resource_decision,

--- a/box_agent/tools/base.py
+++ b/box_agent/tools/base.py
@@ -29,6 +29,15 @@ class ToolResult(BaseModel):
     # object leaves the execution loop; excluding it avoids duplicating a large
     # payload in serialized host events.
     persistence_content: str | None = Field(default=None, exclude=True)
+    # Optional multimodal content a tool asks the loop to deliver to the MAIN
+    # model as a follow-up ``user`` message, appended once after the whole tool
+    # batch completes (before the next model call). Each entry is a provider-
+    # shaped content block (e.g. a text block plus ``image``/``image_url``
+    # blocks). This is how a tool hands real images to a vision-capable main
+    # model instead of proxying them to a side call. ``None`` (the default)
+    # means the loop behaves exactly as before. Excluded from serialization
+    # because image payloads must not bloat host events.
+    followup_user_content: list[dict] | None = Field(default=None, exclude=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/box_agent/tools/vision_review_tool.py
+++ b/box_agent/tools/vision_review_tool.py
@@ -81,7 +81,9 @@ class VisionReviewTool(Tool):
             "sending them as image content to the current multimodal LLM, writing "
             "the markdown report to visual_review.md beside the first input image by default, and returning "
             "per-image PASS/ISSUE findings. Use this when a skill requires real "
-            "visual QA; passing image paths in text is not enough."
+            "visual QA; passing image paths in text is not enough. Set strategy=native "
+            "to attach the images to your own context and inspect them directly instead "
+            "of proxying to a separate vision model."
         )
 
     @property
@@ -115,6 +117,20 @@ class VisionReviewTool(Tool):
                         "image understanding without writing visual_review.md."
                     ),
                 },
+                "strategy": {
+                    "type": "string",
+                    "enum": ["proxy", "native"],
+                    "default": "proxy",
+                    "description": (
+                        "proxy (default): a separate vision model inspects the images and "
+                        "returns a text review — use when you need a written QA report or "
+                        "the main model cannot see images. native: attach the images "
+                        "directly to your own (the main model's) context for the next turn "
+                        "and inspect them yourself — use when you are a vision-capable model "
+                        "and want to reason over the raw pixels. native ignores mode and "
+                        "writes no report."
+                    ),
+                },
             },
             "required": ["image_paths"],
         }
@@ -125,12 +141,39 @@ class VisionReviewTool(Tool):
         output_path: str | None = None,
         instructions: str | None = None,
         mode: str = "review",
+        strategy: str = "proxy",
     ) -> ToolResult:
         """Run visual review and write the markdown report."""
         if not image_paths:
             return ToolResult(success=False, error="image_paths must contain at least one image path")
+        if strategy not in {"proxy", "native"}:
+            return ToolResult(success=False, error="strategy must be 'proxy' or 'native'")
         if mode not in {"review", "describe"}:
             return ToolResult(success=False, error="mode must be 'review' or 'describe'")
+
+        # Native strategy: hand the raw images to the MAIN model instead of
+        # proxying them to a side vision call. The images are attached as a
+        # follow-up user message (see ToolResult.followup_user_content) so the
+        # main model inspects the pixels itself on its next turn. No report is
+        # written and no extra LLM call is made.
+        if strategy == "native":
+            try:
+                images = [self._load_image(path) for path in image_paths]
+            except ValueError as exc:
+                return ToolResult(success=False, error=str(exc))
+            blocks = self._build_native_blocks(images, instructions=instructions)
+            attached = ", ".join(image["path"] for image in images)
+            note = (
+                f"Attached {len(images)} image(s) to your context for direct visual "
+                f"inspection: {attached}. Inspect them yourself and continue the task; "
+                "do not call vision_review again for the same images."
+            )
+            return ToolResult(
+                success=True,
+                content=note,
+                followup_user_content=blocks,
+            )
+
         if self._terminal_error is not None:
             return ToolResult(success=False, error=self._terminal_error)
 
@@ -389,6 +432,46 @@ class VisionReviewTool(Tool):
         blocks: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
         for image in images:
             if "anthropic" in self._provider_hint():
+                blocks.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image["mime_type"],
+                            "data": image["base64"],
+                        },
+                    }
+                )
+            else:
+                blocks.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image["data_url"]},
+                    }
+                )
+        return blocks
+
+    def _build_native_blocks(
+        self,
+        images: list[dict[str, str]],
+        *,
+        instructions: str | None,
+    ) -> list[dict[str, Any]]:
+        """Provider-shaped blocks handed to the MAIN model for native review.
+
+        A leading text block frames the task, then each image is labeled and
+        attached in the current provider's wire format (Anthropic ``image`` vs
+        OpenAI ``image_url``). The main-model provider serializes these when the
+        loop appends them as a follow-up user message.
+        """
+        lead = (instructions or "").strip()
+        intro = "Inspect the following screenshot(s) directly and continue the task."
+        text = f"{intro} Extra criteria: {lead}" if lead else intro
+        blocks: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        provider = self._provider_hint()
+        for index, image in enumerate(images, start=1):
+            blocks.append({"type": "text", "text": f"Image {index}: {image['path']}"})
+            if "anthropic" in provider:
                 blocks.append(
                     {
                         "type": "image",

--- a/tests/test_tool_followup_user_content.py
+++ b/tests/test_tool_followup_user_content.py
@@ -1,0 +1,153 @@
+"""Tests for ToolResult.followup_user_content -> main-model injection.
+
+A tool can hand multimodal content (e.g. vision_review's native strategy) to
+the main model. The loop appends it as ONE follow-up user message at the next
+step boundary — after every tool result is in place, before the next model
+call — so tool-call/result closure is never interleaved with it.
+"""
+
+import asyncio
+
+import pytest
+
+from box_agent.core import run_agent_loop
+from box_agent.events import DoneEvent, InjectedMessageEvent
+from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
+from box_agent.tools.base import Tool, ToolResult
+
+
+class MockLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._idx = 0
+        self.seen_messages = []
+
+    async def generate_stream(self, messages, tools=None, **_):
+        # Snapshot a shallow copy of history at each call for later assertions.
+        self.seen_messages.append(list(messages))
+        resp = self._responses[self._idx]
+        self._idx += 1
+        if resp.content:
+            yield StreamEvent(type="text", delta=resp.content)
+        yield StreamEvent(
+            type="finish",
+            finish_reason=resp.finish_reason,
+            usage=resp.usage,
+            tool_calls=resp.tool_calls,
+        )
+
+
+_IMAGE_BLOCKS = [
+    {"type": "text", "text": "Inspect the following screenshot(s)."},
+    {"type": "text", "text": "Image 1: slide.png"},
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+]
+
+
+class AttachTool(Tool):
+    @property
+    def name(self):
+        return "attach"
+
+    @property
+    def description(self):
+        return "Attaches images to the main model"
+
+    @property
+    def parameters(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self):
+        return ToolResult(
+            success=True,
+            content="Attached 1 image(s) for direct inspection.",
+            followup_user_content=list(_IMAGE_BLOCKS),
+        )
+
+
+class PlainTool(Tool):
+    @property
+    def name(self):
+        return "plain"
+
+    @property
+    def description(self):
+        return "Returns text only"
+
+    @property
+    def parameters(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self):
+        return ToolResult(success=True, content="ok")
+
+
+def _msgs():
+    return [
+        Message(role="system", content="sys"),
+        Message(role="user", content="hi"),
+    ]
+
+
+async def _collect(gen):
+    return [ev async for ev in gen]
+
+
+def _call(name):
+    return LLMResponse(
+        content="",
+        tool_calls=[
+            ToolCall(id="t1", type="function", function=FunctionCall(name=name, arguments={}))
+        ],
+        finish_reason="tool",
+    )
+
+
+@pytest.mark.asyncio
+async def test_followup_user_content_injected_as_user_message_after_tool_result():
+    msgs = _msgs()
+    llm = MockLLM([_call("attach"), LLMResponse(content="done", finish_reason="stop")])
+
+    events = await _collect(
+        run_agent_loop(llm=llm, messages=msgs, tools={"attach": AttachTool()}, max_steps=5)
+    )
+
+    # A user message carrying exactly the follow-up blocks was appended.
+    followup = [
+        m
+        for m in msgs
+        if m.role == "user" and isinstance(m.content, list) and m.content == _IMAGE_BLOCKS
+    ]
+    assert len(followup) == 1
+
+    # Ordering: it comes after the tool result, not before it.
+    roles = [m.role for m in msgs]
+    tool_idx = roles.index("tool")
+    followup_idx = msgs.index(followup[0])
+    assert followup_idx > tool_idx
+
+    # The second model call sees the follow-up user message in its history.
+    assert any(
+        m.role == "user" and m.content == _IMAGE_BLOCKS for m in llm.seen_messages[1]
+    )
+
+    # A hidden injected-message event is emitted for observability.
+    injected = [e for e in events if isinstance(e, InjectedMessageEvent)]
+    assert any("attached" in e.content.lower() for e in injected)
+
+    done = [e for e in events if isinstance(e, DoneEvent)]
+    assert len(done) == 1
+    assert done[0].final_content == "done"
+
+
+@pytest.mark.asyncio
+async def test_no_followup_content_appends_no_extra_user_message():
+    msgs = _msgs()
+    llm = MockLLM([_call("plain"), LLMResponse(content="done", finish_reason="stop")])
+
+    await _collect(
+        run_agent_loop(llm=llm, messages=msgs, tools={"plain": PlainTool()}, max_steps=5)
+    )
+
+    # No user message with list content was injected (zero impact).
+    assert not any(m.role == "user" and isinstance(m.content, list) for m in msgs)

--- a/tests/test_vision_review_tool.py
+++ b/tests/test_vision_review_tool.py
@@ -399,3 +399,83 @@ def test_add_workspace_tools_routes_vision_review_to_catalog_vision_model(tmp_pa
     vision_tool = next(tool for tool in tools if tool.name == "vision_review")
     assert vision_tool.llm.model == "vision-model"
     assert vision_tool.llm.max_output_tokens == 8192
+
+
+class _NoCallLLM:
+    """Vision LLM that must never be called (native strategy proxies nothing)."""
+
+    provider = "openai"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate(self, *args, **kwargs):  # pragma: no cover - must not run
+        self.calls += 1
+        raise AssertionError("native strategy must not call the proxy LLM")
+
+
+@pytest.mark.asyncio
+async def test_native_strategy_attaches_images_without_proxy_call(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    llm = _NoCallLLM()
+    tool = VisionReviewTool(llm=llm, workspace_dir=str(tmp_path), allow_full_access=False)
+
+    result = await tool.execute(
+        image_paths=["slide.png"], strategy="native", instructions="check contrast"
+    )
+
+    assert result.success, result.error
+    assert llm.calls == 0
+    # No report is written in native mode.
+    assert not (tmp_path / "visual_review.md").exists()
+    assert "slide.png" in result.content
+    # Images are handed to the main model as follow-up user content.
+    blocks = result.followup_user_content
+    assert blocks is not None
+    assert "check contrast" in blocks[0]["text"]
+    image_block = next(block for block in blocks if block.get("type") == "image_url")
+    assert image_block["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_native_strategy_uses_anthropic_block_shape(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+
+    class _AnthropicLLM(_NoCallLLM):
+        provider = "anthropic"
+
+    tool = VisionReviewTool(llm=_AnthropicLLM(), workspace_dir=str(tmp_path), allow_full_access=False)
+    result = await tool.execute(image_paths=["slide.png"], strategy="native")
+
+    assert result.success, result.error
+    image_block = next(
+        block for block in result.followup_user_content if block.get("type") == "image"
+    )
+    assert image_block["source"]["media_type"] == "image/png"
+    assert image_block["source"]["type"] == "base64"
+
+
+@pytest.mark.asyncio
+async def test_invalid_strategy_rejected(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    tool = VisionReviewTool(llm=FakeVisionLLM(), workspace_dir=str(tmp_path), allow_full_access=False)
+
+    result = await tool.execute(image_paths=["slide.png"], strategy="bogus")
+
+    assert not result.success
+    assert "strategy" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_proxy_strategy_sets_no_followup_content(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    tool = VisionReviewTool(llm=FakeVisionLLM(), workspace_dir=str(tmp_path), allow_full_access=False)
+
+    result = await tool.execute(image_paths=["slide.png"])  # default proxy
+
+    assert result.success, result.error
+    assert result.followup_user_content is None


### PR DESCRIPTION
vision_review currently proxies screenshots to a separate vision model and returns only text to the main model, so a vision-capable main model never sees the raw pixels. Add a second strategy so both are available:

- proxy (default, unchanged): a side vision call inspects the images and returns a written PASS/ISSUE report.
- native: the tool attaches the raw images directly to the MAIN model's context for its next turn and inspects nothing itself — no side LLM call, no report. Use when the main model can see images and should reason over pixels.

Native delivery uses a new opt-in contract: `ToolResult.followup_user_content` carries provider-shaped content blocks (text + image/image_url). The agent loop accumulates these during tool execution and flushes them as ONE follow-up `user` message at the next step boundary — after every tool result is in place, before the next model call — so assistant->tool_result->user ordering and tool-call closure are preserved. When no tool sets the field (the default), the loop behaves exactly as before; the field is excluded from serialization so image payloads never bloat host events.

Tests cover the native tool path (image blocks returned, no proxy call, both Anthropic and OpenAI block shapes, invalid strategy rejected, proxy leaves the field None) and the loop delivery (follow-up user message injected after the tool result; absent field is a no-op).

Note: robustness follow-ups (content-sniffed MIME, no raw-bytes fallback on decode failure, permission-request passthrough) are intentionally left out of this PR to keep it focused on the two-strategy behavior.

## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

### Design and architecture impact

- Affected layers and owners:
- Contract, schema, or protocol impact:
- Documentation updated:

### Target branch consistency

- Base branch and reviewed Head SHA:
- Relevant target-branch changes considered:
- Rebase, compatibility, or historical-fix risk:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [ ] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [ ] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` passed for the current Head SHA, or the missing status is explained.
