### PR TITLE
fix(workflows): Harden controlled presentation recovery

### DIFF
--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.8.87",
-  "generated_at": "2026-08-21T09:08:02Z",
+  "generated_at": "2026-08-21T12:30:52Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/document-skills/pptx/scripts/validate_outline.js
+++ b/box_agent/skills/document-skills/pptx/scripts/validate_outline.js
@@ -297,6 +297,18 @@ function validate(outline, opts) {
   const publicResearch = isPublicResearchOutline(outline);
   const verifiedResearch = opts.verifiedResearch;
 
+  if (
+    verifiedResearch
+    && verifiedResearch.deliveryMode === "framework"
+    && !publicResearch
+  ) {
+    issues.push(
+      "source_mode must remain public_authoritative_research when a presentation " +
+      "research fallback handoff is supplied; do not relabel framework fallback as " +
+      "user_provided"
+    );
+  }
+
   for (const field of ["deck_goal", "source_mode"]) {
     if (!text(outline[field])) issues.push(`Missing top-level field: ${field}`);
   }

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -11,6 +11,12 @@ from .base import Tool, ToolResult
 from .mcp_tool_catalog import MCPToolCatalog
 
 TOOL_SEARCH_NAME = "tool_search"
+_ACTIVATION_COMPANIONS: dict[str, tuple[str, ...]] = {
+    # Playwright navigation returns metadata before the page-body snapshot.
+    # Exposing one without the other creates a runtime state the model cannot
+    # complete once a workflow requires exact-page evidence.
+    "managed_browser_navigate": ("managed_browser_snapshot",),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,6 +68,8 @@ class ToolSearchTool(Tool):
             "keywords; task-specific operands are tolerated but should be omitted "
             "when possible. Set top_k to however many matching tool "
             "schemas the task actually needs, including ten or more when appropriate. "
+            "A query hit may activate a protocol-required companion, such as the "
+            "snapshot paired with managed browser navigation, in addition to top_k. "
             "The response reports catalog_tool_count for the applied server scope, "
             "matched_count after query limits, and activated_count after conflict "
             "filtering; never infer the catalog total from top_k or matched_count. "
@@ -112,8 +120,9 @@ class ToolSearchTool(Tool):
                     "description": (
                         "Exact maximum number of query matches to return and activate; "
                         "ignored for tool_names. Choose any positive count required by "
-                        "the task; there is no small fixed cap. Unreturned catalog "
-                        "tools remain hidden."
+                        "the task; there is no small fixed cap. Protocol-required "
+                        "companions may be activated in addition to these query matches. "
+                        "Other unreturned catalog tools remain hidden."
                     ),
                 },
             },
@@ -160,6 +169,7 @@ class ToolSearchTool(Tool):
                 **search_input,
                 "catalog_tool_count": None,
                 "matched_count": 0,
+                "companion_count": 0,
                 "activated_count": 0,
                 "activated": [],
                 "conflicts": [],
@@ -179,6 +189,7 @@ class ToolSearchTool(Tool):
                 "state": "catalog_loading",
                 "catalog_tool_count": None,
                 "matched_count": 0,
+                "companion_count": 0,
                 "activated_count": 0,
                 "activated": [],
                 "conflicts": [],
@@ -212,6 +223,22 @@ class ToolSearchTool(Tool):
                 server_name=normalized_server_name,
                 top_k=top_k,
             )
+        query_matched_count = len(hits)
+        hit_ids = {entry.tool_id for entry in hits}
+        companion_entries = []
+        if not normalized_tool_names:
+            for entry in tuple(hits):
+                for companion_name in _ACTIVATION_COMPANIONS.get(entry.model_name, ()):
+                    companions, _ = self._catalog.lookup_exact(
+                        [companion_name],
+                        server_name=entry.server_name,
+                    )
+                    for companion in companions:
+                        if companion.tool_id in hit_ids:
+                            continue
+                        hit_ids.add(companion.tool_id)
+                        hits.append(companion)
+                        companion_entries.append(companion)
         activated_results = []
         conflicts = []
         protected_names = (
@@ -263,15 +290,17 @@ class ToolSearchTool(Tool):
             "success": not conflicts or bool(activated_results),
             **search_input,
             "catalog_tool_count": catalog_tool_count,
-            "matched_count": len(hits),
+            "matched_count": query_matched_count,
+            "companion_count": len(companion_entries),
             "activated_count": len(activated_results),
             "activated": activated_results,
             "conflicts": conflicts,
             "missing": missing,
             "notice": (
-                f"Activated exactly {len(activated_results)} returned tool(s) for this "
-                "session. Only these hits (plus explicit eager tools) are callable by "
-                "their real name on the next step; all other catalog tools remain hidden."
+                f"Activated {len(activated_results)} returned or required companion "
+                "tool(s) for this session. Only these hits, their protocol-required "
+                "companions, and explicit eager tools are callable by their real name "
+                "on the next step; all other catalog tools remain hidden."
                 if activated_results
                 else (
                     "Matching tools have conflicting model-facing names."

--- a/box_agent/workflows/controlled_presentation.py
+++ b/box_agent/workflows/controlled_presentation.py
@@ -181,8 +181,9 @@ _FINALIZE_TOOL_ERROR = (
 _APPLY_PATCH_TOOL_ERROR = (
     "CONTROLLED_PRESENTATION_APPLY_PATCH_REQUIRED: run the single deterministic "
     "apply_deck_patch.js command from the latest checkpoint with deck.json and "
-    "deck.patch.json. Do not substitute another script, compound the command, or "
-    "rewrite deck.json directly."
+    "deck.patch.json. A trailing 2>&1 stderr merge is allowed, but do not add a pipe, "
+    "another redirection, another command, substitute another script, or rewrite "
+    "deck.json directly."
 )
 _APPLY_PATCH_REPAIR_TOOL_ERROR = (
     "CONTROLLED_PRESENTATION_APPLY_PATCH_REPAIR_REQUIRED: the latest deterministic "
@@ -776,6 +777,12 @@ def _apply_patch_error(
         tokens = shlex.split(command)
     except ValueError:
         return _APPLY_PATCH_REPAIR_TOOL_ERROR if repair_allowed else _APPLY_PATCH_TOOL_ERROR
+    if tokens and tokens[-1] == "2>&1":
+        # Merging stderr into stdout does not change the deterministic mutation.
+        # Models commonly add this harmless suffix when invoking Node scripts;
+        # accept only this exact trailing token and keep every pipe, extra
+        # redirection, and compound command rejected below.
+        tokens = tokens[:-1]
     script_indexes = [
         index
         for index, token in enumerate(tokens)
@@ -1445,7 +1452,26 @@ def _research_artifact_target_error(
     if stage != "research":
         return None
     candidate: Any = None
-    if tool_name in {"write_file", "append_file", "edit_file"}:
+    if tool_name == "bash":
+        command = arguments.get("command")
+        if not isinstance(command, str):
+            return None
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            return None
+        if not any(Path(token).name in {"mkdir", "mkdir.exe"} for token in tokens):
+            return None
+        candidate = next(
+            (
+                token
+                for token in tokens
+                if Path(token).is_absolute()
+                and "research" in {part.casefold() for part in Path(token).parts}
+            ),
+            None,
+        )
+    elif tool_name in {"write_file", "append_file", "edit_file"}:
         candidate = arguments.get("path")
     elif tool_name == "staged_file_write" and arguments.get("action") == "begin":
         candidate = arguments.get("path")
@@ -2121,6 +2147,24 @@ class ControlledPresentationPolicy:
             "reason": research_input.get("fallback_reason"),
             "message": research_input.get("fallback_message"),
             "attempt_summary": research_input.get("attempt_summary", {}),
+            "presentation_handoff": {
+                "schema_version": 1,
+                "delivery_mode": "framework",
+                "verified_facts": [],
+                "gaps": [
+                    str(
+                        research_input.get("fallback_message")
+                        or research_input.get("fallback_reason")
+                        or "No validated public research facts are available."
+                    )
+                ],
+                "quality_summary": {
+                    "quality_ok": False,
+                    "actual_dimensions": None,
+                    "recommended_dimensions": None,
+                },
+                "context_files": [],
+            },
         }
         serialized = json.dumps(
             payload,

--- a/box_agent/workflows/presentation_checkpoint.py
+++ b/box_agent/workflows/presentation_checkpoint.py
@@ -1456,6 +1456,13 @@ def build_checkpoint_text(
         ),
         None,
     )
+    if research_report_path is None and research_fallback:
+        # ControlledPresentationPolicy persists this framework handoff while
+        # publishing the same checkpoint. Bind outline validation to it so a
+        # model cannot relabel failed public research as user-provided input.
+        research_report_path = (
+            artifact_root / "research" / "qa" / "research_status.json"
+        )
     research_report_argument = (
         f" --research-handoff {shlex.quote(str(research_report_path))}"
         if research_report_path is not None

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -1288,6 +1288,25 @@ def test_deep_research_checkpoint_falls_back_after_bounded_failed_searches(
     assert status["generation_continues"] is True
     assert status["reason"] == "research_sources_unavailable"
     assert status["attempt_summary"]["rounds"] == RESEARCH_ROUND_LIMIT
+    assert status["presentation_handoff"] == {
+        "schema_version": 1,
+        "delivery_mode": "framework",
+        "verified_facts": [],
+        "gaps": [
+            "Search or direct-read rounds returned only failures or empty results, "
+            "so no research report could be validated."
+        ],
+        "quality_summary": {
+            "quality_ok": False,
+            "actual_dimensions": None,
+            "recommended_dimensions": None,
+        },
+        "context_files": [],
+    }
+    assert (
+        f"--research-handoff {tmp_path / 'output' / 'research' / 'qa' / 'research_status.json'}"
+        in checkpoint
+    )
 
 
 def test_parallel_research_queries_count_as_one_round(tmp_path):
@@ -3541,6 +3560,35 @@ def test_controlled_research_writes_stay_under_artifact_root(tmp_path):
     assert f"actual_path='{escaped}'" in blocked
     assert "expected_path='research/...'" in blocked
     assert f"artifact_root='{output}'" in blocked
+
+
+def test_controlled_research_mkdir_stays_under_task_artifact_root(tmp_path):
+    task_root = tmp_path / "output" / "tasks" / "task-1"
+    task_root.mkdir(parents=True)
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=task_root,
+        research_mode="deep",
+        stage="research",
+    )
+
+    allowed = policy.tool_call_error(
+        "bash",
+        {"command": "pwd && mkdir -p research/qa"},
+        verified_evidence_urls=set(),
+    )
+    escaped = tmp_path / "output" / "research" / "qa"
+    blocked = policy.tool_call_error(
+        "bash",
+        {"command": f"mkdir -p {escaped}"},
+        verified_evidence_urls=set(),
+    )
+
+    assert allowed is None
+    assert blocked is not None
+    assert "CONTROLLED_PRESENTATION_RESEARCH_ARTIFACT_TARGET_REQUIRED" in blocked
+    assert f"actual_path='{escaped}'" in blocked
+    assert f"artifact_root='{task_root}'" in blocked
 
 
 def test_controlled_research_handoff_allows_only_its_staged_outline_transaction(
@@ -6469,7 +6517,7 @@ async def test_controlled_apply_patch_accepts_checkpoint_absolute_artifact_paths
     os.utime(patch_path, ns=(newer, newer))
     apply_command = (
         f"${{BOX_AGENT_NODE:-node}} {APPLY_PATCH_SCRIPT} "
-        f"{deck_path} {patch_path}"
+        f"{deck_path} {patch_path} 2>&1"
     )
     llm = MockLLM(
         [
@@ -6515,6 +6563,31 @@ async def test_controlled_apply_patch_accepts_checkpoint_absolute_artifact_paths
     )
     assert result.success is True
     assert bash_tool.calls == 1
+
+
+def test_controlled_apply_patch_allows_only_safe_trailing_stderr_merge(tmp_path):
+    output = tmp_path / "output"
+    output.mkdir()
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=output,
+        stage="apply_patch",
+    )
+    base = f"node {APPLY_PATCH_SCRIPT} {output / 'deck.json'} {output / 'deck.patch.json'}"
+
+    assert policy.tool_call_error(
+        "bash",
+        {"command": f"{base} 2>&1"},
+        verified_evidence_urls=set(),
+    ) is None
+    rejected = policy.tool_call_error(
+        "bash",
+        {"command": f"{base} 2>&1 | tail -20"},
+        verified_evidence_urls=set(),
+    )
+
+    assert rejected is not None
+    assert "CONTROLLED_PRESENTATION_APPLY_PATCH_REQUIRED" in rejected
 
 
 def test_controlled_apply_patch_stops_repeated_policy_rejection(tmp_path):

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -480,6 +480,70 @@ async def test_search_finds_multiple_exact_tool_names_inside_compound_query() ->
 
 
 @pytest.mark.asyncio
+async def test_search_activates_snapshot_companion_when_navigation_matches_alone() -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "playwright",
+        [
+            FakeMCPTool(
+                "managed_browser_navigate",
+                "playwright",
+                "Navigate to a URL",
+            ),
+            FakeMCPTool(
+                "managed_browser_snapshot",
+                "playwright",
+                "Capture the current page snapshot",
+            ),
+            FakeMCPTool("managed_browser_click", "playwright", "Click page element"),
+        ],
+    )
+    activated = OrderedDict()
+
+    result = await ToolSearchTool(catalog, activated).execute(
+        query="managed_browser_navigate",
+        server_name="playwright",
+        top_k=1,
+    )
+    payload = json.loads(result.content)
+
+    assert result.success is True
+    assert payload["matched_count"] == 1
+    assert payload["companion_count"] == 1
+    assert payload["activated_count"] == 2
+    assert {item["name"] for item in payload["activated"]} == {
+        "managed_browser_navigate",
+        "managed_browser_snapshot",
+    }
+
+
+@pytest.mark.asyncio
+async def test_exact_tool_activation_does_not_add_navigation_companion() -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "playwright",
+        [
+            FakeMCPTool("managed_browser_navigate", "playwright", "Navigate"),
+            FakeMCPTool("managed_browser_snapshot", "playwright", "Snapshot"),
+        ],
+    )
+    activated = OrderedDict()
+
+    result = await ToolSearchTool(catalog, activated).execute(
+        tool_names=["managed_browser_navigate"],
+        server_name="playwright",
+    )
+    payload = json.loads(result.content)
+
+    assert payload["matched_count"] == 1
+    assert payload["companion_count"] == 0
+    assert payload["activated_count"] == 1
+    assert [item["name"] for item in payload["activated"]] == [
+        "managed_browser_navigate"
+    ]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("server_name", "expected_server"),
     [(" weather ", "weather"), ("", None), ("   ", None)],

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -8484,6 +8484,59 @@ def test_outline_accepts_framework_research_handoff_with_explicit_gap(
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_outline_rejects_relabeling_framework_research_as_user_provided(
+    tmp_path: Path,
+) -> None:
+    outline_path = tmp_path / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=1,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "市场数据框架",
+            "message": "当前暂无可验证公开数据，保留后续补充位置。",
+            "bullets": ["市场规模待补充", "竞争格局待补充"],
+            "evidence": [],
+        }
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    research_status = tmp_path / "research_status.json"
+    research_status.write_text(
+        json.dumps(
+            {
+                "presentation_handoff": {
+                    "schema_version": 1,
+                    "delivery_mode": "framework",
+                    "verified_facts": [],
+                    "gaps": ["No verified public facts"],
+                    "quality_summary": {"quality_ok": False},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(
+        "validate_outline.js",
+        str(outline_path),
+        "--min-slides",
+        "1",
+        "--max-slides",
+        "1",
+        "--research-handoff",
+        str(research_status),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert any(
+        "source_mode must remain public_authoritative_research" in issue
+        for issue in payload["issues"]
+    )
+
+
 def test_outline_accepts_framework_structural_pages_without_evidence(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## TPR

### Task

- What changed:
  - Pair capability-query activation of `managed_browser_navigate` with its required `managed_browser_snapshot` companion while preserving exact `tool_names` semantics.
  - Keep controlled research artifacts inside the active task root, bind framework fallback to a persisted presentation handoff, and reject relabeling fallback as `user_provided`.
  - Allow the harmless trailing `2>&1` form for the deterministic deck patch command while continuing to reject pipes, extra redirects, and compound commands.
- Why:
  - A live OfficeV3 presentation run exposed missing snapshot activation, fallback provenance bypass, session-level research paths, and repeated apply-patch policy rejection.
- Affected entry points:
  - Deferred MCP tool search, controlled presentation workflow/checkpoints, PPT outline validation.
- Out of scope:
  - Authentication/model organization-code changes, OfficeV3 frontend changes, version bumps, and PPTX export.

### Proof

- Tests or checks run:
  - After rebasing onto current main, `bash general_review/ci/preflight.sh` on Head `24dd214cde2e6bf0f7dad8b1bab4d8cefc708214`: 2753 passed, 17 skipped, 1 deselected; sdist and wheel built successfully.
  - Focused source runs: completion gate 244 passed; MCP tool search 34 passed; PPT controlled deck 307 passed; manifest/skill loader 25 passed.
  - `git diff --check`, Python compileall, and Node syntax check passed.
- Logs, screenshots, probes, or manifests:
  - Built-in skill manifest regenerated after rebase to preserve the latest target-branch featured-skill exclusions.
  - User rebuilt/installed runtime 0.9.5 and restarted OfficeV3 1.0.19. Live session `bed5efd6-798a-494a-abdc-4171e7b3fab1` exercised all four fixes and completed with `delivery_status=complete`, final `index.html`, and passing deck/runtime QA.
- Not run, with reason:
  - No standalone PPTX export; the default controlled HTML deliverable was the requested acceptance layer.

### Risk

- Compatibility:
  - Exact MCP `tool_names` activation remains exact; companion activation applies only to capability-query hits.
  - Only an exact trailing `2>&1` is accepted for apply-patch. Pipes, additional redirects, commands, scripts, and noncanonical targets remain blocked.
- Packaging/runtime impact:
  - Packaged runtime rebuild/install/restart and one fresh live OfficeV3 task were observed successfully.
- Config, secrets, or migration:
  - No config, secret, schema migration, or persistent-data migration.
- Rollback:
  - Revert this commit to restore the prior strict activation, fallback, and apply-command behavior.
- Cross-repository follow-up:
  - None required for source compatibility. OfficeV3 consumes the packaged Box-Agent runtime unchanged.

### Design and architecture impact

- Affected layers and owners:
  - Capability layer (`mcp_tool_search`) and workflow policy/PPT validator layer.
- Contract, schema, or protocol impact:
  - Additive `companion_count` in tool-search receipts; persisted fallback status now contains the existing `presentation_handoff/v1` structure.
- Documentation updated:
  - No design boundary changed. Existing controlled-presentation and research contracts are enforced more consistently; built-in manifest regenerated.

### Target branch consistency

- Base branch and reviewed Head SHA:
  - `main@2d1317f57f25cd1415a0525ba4c0ced16d9ffe96`
  - `head@24dd214cde2e6bf0f7dad8b1bab4d8cefc708214`
- Relevant target-branch changes considered:
  - PR #66 added two featured recommended Skills. The only rebase conflict was the generated skill manifest; it was resolved by rerunning `scripts/generate_skills_manifest.py`.
- Rebase, compatibility, or historical-fix risk:
  - Branch was rebased, not merged, onto current `origin/main`. Exact-head preflight was rerun after regeneration.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [x] Shared behavior is implemented in shared capability/workflow logic, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior.
- [x] Broader tests were run for shared tools, MCP, workflows, and skills.
- [x] Documentation impact was assessed; no user-facing contract documentation change was required.
- [x] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [x] Packaged runtime impact and live-task proof are stated.
- [x] No local config, logs, workspace files, or generated graph/cache files are included.
- [x] This branch was rebased onto the latest `main`; `main` was not merged into it.
- [x] Design and target-branch consistency evidence is included above.
- [x] `teamwork/local-ci` preflight passed for the current Head SHA.