### PR TITLE
feat: make runtime operational limits configurable (zero default impact)

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1748,6 +1748,7 @@ class BoxACPAgent:
             thinking_enabled=deep_think,
             max_parallel_tools=self._config.agent.max_parallel_tools,
             parallel_tool_timeout_seconds=self._config.agent.parallel_tool_timeout_seconds,
+            provider_stale_seconds=self._config.agent.provider_stale_seconds,
             memory_promotion_enabled=self._config.agent.memory_promotion_proposal_enabled,
             memory_promotion_hit_threshold=self._config.agent.memory_promotion_hit_threshold,
             memory_promotion_cooldown_days=self._config.agent.memory_promotion_cooldown_days,

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -487,6 +487,7 @@ class Agent:
         memory_promotion_cooldown_days: int = 14,
         max_parallel_tools: int = 8,
         parallel_tool_timeout_seconds: float | None = 900.0,
+        provider_stale_seconds: float | None = None,
         truncation_continuation_enabled: bool = True,
         max_truncation_continuations: int = 3,
         max_truncated_tool_call_retries: int = 3,
@@ -506,6 +507,7 @@ class Agent:
         self.tool_limits = tool_limits or ToolLimitsConfig()
         self.max_parallel_tools = max_parallel_tools
         self.parallel_tool_timeout_seconds = parallel_tool_timeout_seconds
+        self.provider_stale_seconds = provider_stale_seconds
         self.truncation_continuation_enabled = truncation_continuation_enabled
         self.max_truncation_continuations = max_truncation_continuations
         self.max_truncated_tool_call_retries = max_truncated_tool_call_retries
@@ -947,6 +949,7 @@ class Agent:
             title=effective_options.title,
             max_parallel_tools=self.max_parallel_tools,
             parallel_tool_timeout_seconds=self.parallel_tool_timeout_seconds,
+            provider_stale_seconds=self.provider_stale_seconds,
             force_plan_start=effective_options.force_plan_start,
             require_plan_approval=effective_options.require_plan_approval,
             plan_approval=effective_options.plan_approval,

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -386,6 +386,7 @@ def _config_summary(config: Config, config_path: Path, show_secrets: bool = Fals
             "api_key": image_api_key,
             "auth_file": config.image_generation.auth_file,
             "timeout": config.image_generation.timeout,
+            "max_dimension": config.image_generation.max_dimension,
         },
         "tool_limits": config.tool_limits.model_dump(),
         "agent": {
@@ -393,6 +394,7 @@ def _config_summary(config: Config, config_path: Path, show_secrets: bool = Fals
             "workspace_dir": config.agent.workspace_dir,
             "max_parallel_tools": config.agent.max_parallel_tools,
             "parallel_tool_timeout_seconds": config.agent.parallel_tool_timeout_seconds,
+            "provider_stale_seconds": config.agent.provider_stale_seconds,
             "sub_agent_batch_synthesis_timeout_seconds": (
                 config.agent.sub_agent_batch_synthesis_timeout_seconds
             ),
@@ -2197,6 +2199,7 @@ async def run_agent(
         thinking_enabled=deep_think,
         max_parallel_tools=config.agent.max_parallel_tools,
         parallel_tool_timeout_seconds=config.agent.parallel_tool_timeout_seconds,
+        provider_stale_seconds=config.agent.provider_stale_seconds,
         memory_promotion_enabled=config.agent.memory_promotion_proposal_enabled,
         memory_promotion_hit_threshold=config.agent.memory_promotion_hit_threshold,
         memory_promotion_cooldown_days=config.agent.memory_promotion_cooldown_days,

--- a/box_agent/config.py
+++ b/box_agent/config.py
@@ -125,6 +125,12 @@ class ImageGenerationConfig(BaseModel):
     model: str = "gpt-image-1"
     timeout: float = 120.0
     auth_file: str = ""
+    # Longest-edge cap (pixels) applied only to generic/custom OpenAI-compatible
+    # endpoints, which otherwise forward an explicit ``size`` unchanged and can
+    # 504 on oversized requests. OpenAI, Doubao/Seedream, and host-aligned
+    # ``/images/gen`` endpoints keep their own size rules. ``0`` disables the
+    # clamp; ``BOX_AGENT_IMAGE_MAX_DIM`` overrides this value.
+    max_dimension: int = 1024
 
 
 class ToolLimitsModel(BaseModel):
@@ -228,6 +234,12 @@ class AgentConfig(BaseModel):
     # sibling results are kept; unfinished siblings get synthetic timeout
     # failures so the parent can continue instead of waiting forever.
     parallel_tool_timeout_seconds: float = 900.0
+    # Seconds a streaming response may go without a new provider chunk before
+    # the loop treats it as stale and triggers bounded recovery. The default
+    # matches the historical hardcoded baseline; raise it for slow/deep-thinking
+    # models whose single step can legitimately exceed it, or lower it to fail
+    # faster. The ``BOX_AGENT_PROVIDER_STALE_SECONDS`` env var overrides this.
+    provider_stale_seconds: float = 180.0
     # Per-call token budget for sub-agent child contexts before they summarize.
     # The child runs in an isolated context, so this is independent of the main
     # loop's context_token_limit. Single source of truth for the value that was
@@ -522,12 +534,15 @@ class Config(BaseModel):
         image_generation_data = data.get("image_generation", {})
         if not isinstance(image_generation_data, dict):
             image_generation_data = {}
+        raw_max_dimension = image_generation_data.get("max_dimension", 1024)
+        max_dimension = int(raw_max_dimension) if raw_max_dimension is not None else 1024
         image_generation_config = ImageGenerationConfig(
             endpoint=str(image_generation_data.get("endpoint", "") or "").strip(),
             api_key=str(image_generation_data.get("api_key", "") or "").strip(),
             model=str(image_generation_data.get("model", "gpt-image-1") or "").strip(),
             timeout=float(image_generation_data.get("timeout", 120.0) or 120.0),
             auth_file=image_generation_data.get("auth_file") or llm_config.auth_file,
+            max_dimension=max_dimension,
         )
 
         tool_limits_data = data.get("tool_limits", {})

--- a/box_agent/config/config-example.yaml
+++ b/box_agent/config/config-example.yaml
@@ -21,6 +21,11 @@ api_key: "YOUR_API_KEY_HERE"
 api_base: "https://api.anthropic.com"
 model: "claude-sonnet-4-20250514"
 provider: "anthropic"
+# Thinking dialect: models whose name starts with sensenova-/sn-sensenova- use
+# the SenseNova reasoning extension. To opt an extra model family into that
+# dialect without a code change, set (comma/whitespace-separated, additive —
+# the built-ins are always kept):
+#   export BOX_AGENT_SENSENOVA_MODEL_PREFIXES="my-family-,another-"
 # Hosted officev3 login auth lives outside config.yaml so token refreshes do not
 # mark model/provider config dirty. By default Box-Agent reads auth.json next to
 # this file before every LLM request and URL-based MCP connection.
@@ -69,6 +74,8 @@ retry:
 # max_steps: 300 # Maximum execution steps
 max_parallel_tools: 8 # Hard cap on concurrent parallel_safe tool calls (sub_agent, generate_image) per step
 parallel_tool_timeout_seconds: 900 # Per-step wall-clock cap for one parallel_safe tool batch
+# provider_stale_seconds: 180 # Seconds without a new provider chunk before a stream is treated as stale.
+#                             # Raise for slow/deep-thinking models; env BOX_AGENT_PROVIDER_STALE_SECONDS overrides.
 # sub_agent_token_limit: 50000 # Per-call child context budget
 # sub_agent_batch_synthesis_timeout_seconds: 600 # files batch synthesis call; 0 disables this extra cap
 workspace_dir: "./workspace" # Working directory
@@ -163,6 +170,10 @@ image_generation:
   api_key: "" # optional dedicated bearer token; leave empty to reuse hosted auth
   model: "gpt-image-1"
   timeout: 300.0
+  max_dimension: 1024 # Longest-edge cap for generic/custom OpenAI-compatible endpoints that would
+  #                     otherwise forward an oversized `size` unchanged (and 504). OpenAI, Doubao/Seedream,
+  #                     and host-aligned `/images/gen` endpoints keep their own rules. 0 disables the clamp;
+  #                     env BOX_AGENT_IMAGE_MAX_DIM overrides.
   # auth_file defaults to the top-level auth_file / auth.json next to config.yaml.
   # auth_file: "/path/to/auth.json"
 #

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -14,6 +14,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import traceback
@@ -121,12 +122,42 @@ TOOL_ACTIVITY_INTERVAL_SECONDS: Final[float] = 15.0
 LLM_PROVIDER_STALE_SECONDS: Final[float] = 180.0
 MAX_PROVIDER_STALE_RECOVERIES: Final[int] = 3
 MAX_TOOL_PERMISSION_RETRIES: Final[int] = 4
+_PROVIDER_STALE_SECONDS_ENV: Final[str] = "BOX_AGENT_PROVIDER_STALE_SECONDS"
+
+
+def _resolve_provider_stale_seconds(config_value: float | None = None) -> float:
+    """Effective provider-stale cutoff.
+
+    Precedence: the ``BOX_AGENT_PROVIDER_STALE_SECONDS`` env var (an operational
+    escape hatch) wins, then the configured ``agent.provider_stale_seconds``,
+    then the historical ``LLM_PROVIDER_STALE_SECONDS`` default. Non-positive,
+    non-finite (``inf``/``nan``), or unparseable values are ignored so a bad
+    override cannot silently disable the guard.
+    """
+    raw = os.environ.get(_PROVIDER_STALE_SECONDS_ENV)
+    if raw is not None and raw.strip():
+        try:
+            parsed = float(raw)
+        except ValueError:
+            parsed = 0.0
+        if math.isfinite(parsed) and parsed > 0:
+            return parsed
+    if config_value is not None and math.isfinite(config_value) and config_value > 0:
+        return float(config_value)
+    return LLM_PROVIDER_STALE_SECONDS
 
 
 async def _stream_with_activity(
     stream: AsyncIterator[StreamEvent],
+    *,
+    stale_seconds: float | None = None,
 ) -> AsyncIterator[StreamEvent]:
     """Add bounded host heartbeats and stop a provider stream that is stale."""
+    # Read the module default at call time (not def time) so monkeypatching
+    # ``LLM_PROVIDER_STALE_SECONDS`` still takes effect and callers can pass an
+    # explicit per-turn value.
+    if stale_seconds is None:
+        stale_seconds = LLM_PROVIDER_STALE_SECONDS
     iterator = stream.__aiter__()
     next_chunk: asyncio.Task[StreamEvent] | None = None
     last_provider_chunk = perf_counter()
@@ -137,15 +168,15 @@ async def _stream_with_activity(
                 {next_chunk}, timeout=LLM_ACTIVITY_INTERVAL_SECONDS
             )
             if not done:
-                stale_seconds = perf_counter() - last_provider_chunk
-                if stale_seconds >= LLM_PROVIDER_STALE_SECONDS:
+                stale_seconds_elapsed = perf_counter() - last_provider_chunk
+                if stale_seconds_elapsed >= stale_seconds:
                     yield StreamEvent(
                         type="finish",
                         finish_reason="provider_stale",
                         activity={
                             "protocol": "agent_activity_v1",
                             "phase": "provider_wait",
-                            "seconds_since_provider_chunk": round(stale_seconds, 1),
+                            "seconds_since_provider_chunk": round(stale_seconds_elapsed, 1),
                         },
                     )
                     return
@@ -154,7 +185,7 @@ async def _stream_with_activity(
                     activity={
                         "protocol": "agent_activity_v1",
                         "phase": "provider_wait",
-                        "seconds_since_provider_chunk": round(stale_seconds, 1),
+                        "seconds_since_provider_chunk": round(stale_seconds_elapsed, 1),
                     },
                 )
                 continue
@@ -2710,6 +2741,7 @@ async def run_agent_loop(
     no_progress_limit: int | None = None,
     max_parallel_tools: int = 8,
     parallel_tool_timeout_seconds: float | None = 900.0,
+    provider_stale_seconds: float | None = None,
     completion_gate: CompletionGate | None = None,
     truncation_continuation_enabled: bool = True,
     max_truncation_continuations: int = 3,
@@ -3076,6 +3108,10 @@ async def run_agent_loop(
     oversized_tool_argument_retries = 0
     provider_stale_retries = 0
     provider_stale_recoveries = 0
+    # Resolve once per turn: env override > configured value > module default.
+    effective_provider_stale_seconds = _resolve_provider_stale_seconds(
+        provider_stale_seconds
+    )
 
     # Per-turn guard for tools that can be repeatedly requested by the model
     # after it already has enough evidence. Once a budget is reached, later
@@ -3768,7 +3804,9 @@ async def run_agent_loop(
             if effective_call_kind:
                 stream_kwargs["call_kind"] = effective_call_kind
             llm_stream = llm.generate_stream(**stream_kwargs)
-            async for chunk in _stream_with_activity(llm_stream):
+            async for chunk in _stream_with_activity(
+                llm_stream, stale_seconds=effective_provider_stale_seconds
+            ):
                 if cancelled():
                     break
                 if chunk.type == "thinking":
@@ -4033,7 +4071,7 @@ async def run_agent_loop(
                     "consecutive_empty=%d partial_content_len=%d",
                     provider_stale_recoveries,
                     MAX_PROVIDER_STALE_RECOVERIES,
-                    LLM_PROVIDER_STALE_SECONDS,
+                    effective_provider_stale_seconds,
                     provider_stale_retries,
                     len(response.content),
                 )

--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -3,6 +3,7 @@
 import inspect
 import json
 import logging
+import os
 import re
 import uuid
 from collections.abc import AsyncIterator
@@ -36,7 +37,8 @@ logger = logging.getLogger(__name__)
 # generous default; users can override via ``LLMConfig.max_output_tokens``.
 _DEFAULT_MAX_TOKENS = 64000
 _DEEP_THINK_REASONING_EFFORT = "high"
-_SENSENOVA_MODEL_PREFIXES = ("sensenova-", "sn-sensenova-")
+_DEFAULT_SENSENOVA_MODEL_PREFIXES = ("sensenova-", "sn-sensenova-")
+_SENSENOVA_MODEL_PREFIXES_ENV = "BOX_AGENT_SENSENOVA_MODEL_PREFIXES"
 _SENSENOVA_PSEUDO_TOOL_CALL_RE = re.compile(
     r"<tool_call>\s*<function=([A-Za-z_][\w.-]*)>\s*(.*?)\s*</function>\s*</tool_call>",
     re.DOTALL,
@@ -48,9 +50,30 @@ _SENSENOVA_PSEUDO_PARAMETER_RE = re.compile(
 _MAX_RECOVERED_SENSENOVA_TOOL_CALLS = 4
 
 
+def _sensenova_model_prefixes() -> tuple[str, ...]:
+    """Built-in SenseNova dialect prefixes plus any added via env.
+
+    ``BOX_AGENT_SENSENOVA_MODEL_PREFIXES`` is a comma/whitespace-separated
+    additive list so a new model family can opt into the SenseNova thinking
+    dialect without a source change. The built-ins are always kept, so
+    deployments that do not set the env var are unaffected.
+    """
+    extra_raw = os.environ.get(_SENSENOVA_MODEL_PREFIXES_ENV, "")
+    if not extra_raw.strip():
+        return _DEFAULT_SENSENOVA_MODEL_PREFIXES
+    extra = tuple(
+        token.strip().casefold()
+        for token in re.split(r"[,\s]+", extra_raw)
+        if token.strip()
+    )
+    return _DEFAULT_SENSENOVA_MODEL_PREFIXES + extra
+
+
 def _is_sensenova_model(model: str | None) -> bool:
     """Return whether ``model`` uses the SenseNova OpenAI-compatible dialect."""
-    return bool(model and model.strip().casefold().startswith(_SENSENOVA_MODEL_PREFIXES))
+    return bool(
+        model and model.strip().casefold().startswith(_sensenova_model_prefixes())
+    )
 
 
 def _sensenova_thinking_body() -> dict[str, Any]:

--- a/box_agent/tools/image_generation_tool.py
+++ b/box_agent/tools/image_generation_tool.py
@@ -31,8 +31,10 @@ if TYPE_CHECKING:
 _ENDPOINT_ENV = ("BOX_AGENT_IMAGE_GENERATION_ENDPOINT", "BOX_AGENT_IMAGE_GEN_ENDPOINT")
 _API_KEY_ENV = ("BOX_AGENT_IMAGE_GENERATION_API_KEY", "BOX_AGENT_IMAGE_GEN_API_KEY")
 _TIMEOUT_ENV = "BOX_AGENT_IMAGE_GENERATION_TIMEOUT"
+_MAX_DIM_ENV = "BOX_AGENT_IMAGE_MAX_DIM"
 _DEFAULT_TIMEOUT = 120.0
 _MIN_IMAGE_DIMENSION = 1024
+_DEFAULT_MAX_IMAGE_DIMENSION = 1024
 _MIN_OPENAI_IMAGE_PIXELS = _MIN_IMAGE_DIMENSION * _MIN_IMAGE_DIMENSION
 _HOST_IMAGE_DIMENSION_ALIGNMENT = 16
 _CANONICAL_IMAGE_RATIOS: tuple[tuple[int, int], ...] = (
@@ -308,6 +310,41 @@ def _normalize_explicit_size(size: str) -> tuple[str, int, int]:
     return f"{width}x{height}", width, height
 
 
+def _resolve_max_image_dimension(configured: int | None) -> int:
+    """Effective longest-edge cap for generic/custom endpoints.
+
+    Precedence: ``BOX_AGENT_IMAGE_MAX_DIM`` env (operational override) > the
+    configured ``image_generation.max_dimension`` > the built-in default.
+    A non-positive value disables the clamp; an unparseable env is ignored.
+    """
+    raw = os.environ.get(_MAX_DIM_ENV, "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    if configured is not None:
+        return int(configured)
+    return _DEFAULT_MAX_IMAGE_DIMENSION
+
+
+def _clamp_to_max_dimension(width: int, height: int, max_dim: int) -> tuple[str, int, int]:
+    """Scale a size down so neither side exceeds ``max_dim``, preserving ratio.
+
+    Only the generic/custom OpenAI-compatible branch uses this: those endpoints
+    forward an explicit ``size`` unchanged and can 504 on oversized requests.
+    OpenAI, Doubao/Seedream, and host-aligned endpoints keep their own size
+    rules. ``max_dim <= 0`` disables the clamp.
+    """
+    longest = max(width, height)
+    if max_dim <= 0 or longest <= max_dim:
+        return f"{width}x{height}", width, height
+    scale = max_dim / float(longest)
+    clamped_width = max(1, int(width * scale))
+    clamped_height = max(1, int(height * scale))
+    return f"{clamped_width}x{clamped_height}", clamped_width, clamped_height
+
+
 def _normalize_openai_explicit_size(size: str) -> tuple[str, int, int]:
     normalized_size, width, height = _normalize_explicit_size(size)
     pixel_count = width * height
@@ -360,6 +397,7 @@ class GenerateImageTool(Tool):
         model: str | None = None,
         auth_file: str | None = None,
         timeout: float | None = None,
+        max_dimension: int | None = None,
     ) -> None:
         self.workspace_dir = Path(workspace_dir).absolute()
         self.output_dir = Path(output_dir).absolute() if output_dir else self.workspace_dir
@@ -370,6 +408,7 @@ class GenerateImageTool(Tool):
         self.model = model or _DEFAULT_MODEL
         self.auth_file = auth_file or ""
         self.timeout = timeout
+        self.max_dimension = _resolve_max_image_dimension(max_dimension)
 
     @property
     def name(self) -> str:
@@ -521,6 +560,15 @@ class GenerateImageTool(Tool):
                     size, width, height = _normalize_openai_explicit_size(size)
                 else:
                     size, width, height = _normalize_explicit_size(size)
+                    # Generic/custom endpoints have no downstream size rule of
+                    # their own and would forward an oversized request as-is
+                    # (a common cause of 504s). Clamp the longest edge — but not
+                    # for Doubao/Seedream, which re-map dimensions below and must
+                    # keep their own rules.
+                    if not _is_large_image_service(self.endpoint, self.model):
+                        size, width, height = _clamp_to_max_dimension(
+                            width, height, self.max_dimension
+                        )
             if _is_large_image_service(self.endpoint, self.model):
                 size, width, height = _seedream_size_for_ratio(width, height)
             else:

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -710,25 +710,33 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
         )
         _out(f"{Colors.GREEN}✅ Loaded vision review tool (vision_review){Colors.RESET}")
 
-    # Image generation tool — standard Box-Agent capability shared by CLI and ACP
+    # Image generation tool — standard Box-Agent capability shared by CLI and ACP.
+    # Only register when an endpoint is configured (via config or env): an
+    # unconfigured generate_image can only fail on every call and wastes steps.
     image_generation_config = getattr(config, "image_generation", None)
-    tools.append(
-        GenerateImageTool(
-            workspace_dir=str(workspace_dir),
-            output_dir=str(artifact_root) if artifact_root else None,
-            allow_full_access=allow_full_access,
-            permission_engine=permission_engine,
-            endpoint=getattr(image_generation_config, "endpoint", "") or None,
-            api_key=getattr(image_generation_config, "api_key", "") or None,
-            model=getattr(image_generation_config, "model", "") or None,
-            auth_file=(
-                getattr(image_generation_config, "auth_file", "")
-                or getattr(getattr(config, "llm", None), "auth_file", "")
-            ),
-            timeout=getattr(image_generation_config, "timeout", None),
+    if image_generation_service_configured(config):
+        tools.append(
+            GenerateImageTool(
+                workspace_dir=str(workspace_dir),
+                output_dir=str(artifact_root) if artifact_root else None,
+                allow_full_access=allow_full_access,
+                permission_engine=permission_engine,
+                endpoint=getattr(image_generation_config, "endpoint", "") or None,
+                api_key=getattr(image_generation_config, "api_key", "") or None,
+                model=getattr(image_generation_config, "model", "") or None,
+                auth_file=(
+                    getattr(image_generation_config, "auth_file", "")
+                    or getattr(getattr(config, "llm", None), "auth_file", "")
+                ),
+                timeout=getattr(image_generation_config, "timeout", None),
+                max_dimension=getattr(image_generation_config, "max_dimension", None),
+            )
         )
-    )
-    _out(f"{Colors.GREEN}✅ Loaded image generation tool (generate_image){Colors.RESET}")
+        _out(f"{Colors.GREEN}✅ Loaded image generation tool (generate_image){Colors.RESET}")
+    else:
+        _out(
+            f"{Colors.DIM}⏭️  Skipped image generation tool (no image_generation.endpoint configured){Colors.RESET}"
+        )
 
     # Obsidian tools — host/Vault dependent, so register with workspace tools
     # before sub-agent so child agents inherit the native Obsidian capability.
@@ -751,6 +759,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             ),
             artifact_detection_enabled=use_output_dir,
             artifact_root_dir=str(artifact_root) if artifact_root else None,
+            provider_stale_seconds=config.agent.provider_stale_seconds,
         )
         if skill_loader is not None:
             sub_agent_tool.set_skill_provider(lambda: skill_loader)

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -250,6 +250,7 @@ class SubAgentTool(EventEmittingTool):
         batch_synthesis_timeout_seconds: float = _DEFAULT_BATCH_SYNTHESIS_TIMEOUT_SECONDS,
         artifact_detection_enabled: bool = True,
         artifact_root_dir: str | None = None,
+        provider_stale_seconds: float | None = None,
     ):
         super().__init__()
         self._llm = llm
@@ -280,6 +281,9 @@ class SubAgentTool(EventEmittingTool):
         self._batch_synthesis_timeout_seconds = batch_synthesis_timeout_seconds
         self._artifact_detection_enabled = artifact_detection_enabled
         self._artifact_root_dir = artifact_root_dir
+        # Inherit the parent's provider-stale cutoff so slow-model configs also
+        # apply to child agents. None lets run_agent_loop resolve env/default.
+        self._provider_stale_seconds = provider_stale_seconds
 
     def set_parent_system_prompt(self, system_prompt: str) -> None:
         """Attach parent constraints without advertising parent-only MCP search."""
@@ -715,6 +719,7 @@ class SubAgentTool(EventEmittingTool):
                 tool_limits=self._tool_limits,
                 token_limit=self._token_limit,
                 workspace_dir=self._workspace_dir,
+                provider_stale_seconds=self._provider_stale_seconds,
                 no_progress_limit=self._no_progress_limit,
                 artifact_detection_enabled=self._artifact_detection_enabled,
                 artifact_root_dir=self._artifact_root_dir,

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -58,6 +58,7 @@ decision, read those entries together.
 | Sub-agent delegation | `sub_agent_tool.py`, `sub_agent_capabilities.py`, `required_tools`, `write_scope`, `files` | The public request is flat; runtime-derived policy limits implicit tools to trusted local readers, keeps process/external/unknown MCP capabilities fail-closed, and scopes path writes. | Supersedes the caller-authored nested constraint contract while retaining its runtime enforcement goals. | [2026-08-19 flattened contract](#2026-08-19--flattened-sub-agent-contract-with-derived-policy) |
 | Workflow ownership | `workflow_owner_store.py`, explicit Skills, ACP decisions, presentation recovery | Runtime-selected owner precedes artifact discovery. Unknown Skills use the generic external lifecycle; foreign `deck.json` files cannot activate controlled finalization. | Pending implementation; hardens external-Skill and controlled-presentation recovery. | [2026-08-20 owner hardening](#2026-08-20--workflow-owner-precedence-for-third-party-skills) |
 | Model routing and controlled presentations | `box_agent/llm/model_routing.py`, `box_agent/workflows/presentation_*`, controlled PPTX | Automatic child-model routing uses a host allowlist, while presentation-specific state and recovery remain outside the generic kernel. | PR #30 is the main record; later research hardening must be checked where relevant. | [PR #30](#2026-08-14--runtime-routing-and-presentation-reliability-pr-30), [later hardening](#other-target-branch-changes-after-or-adjacent-to-those-prs) |
+| Configurable operational limits | `box_agent/config.py`, `box_agent/core.py` (`provider_stale_seconds`), `image_generation_tool.py` (`max_dimension`), `setup.py` (`generate_image` gating), `openai_client.py` (SenseNova prefixes) | Hardcoded stale/image/thinking limits become config/env with unchanged defaults; generic image endpoints clamp oversized sizes and unconfigured `generate_image` is not registered. | Pending; defaults unchanged except the generic image clamp and `generate_image` gating. | [2026-08-21 configurable limits](#2026-08-21--configurable-runtime-operational-limits) |
 
 For research execution, Todo/progress behavior, browser routing, or contributor
 branch history, also check
@@ -117,6 +118,35 @@ Release, provider API, and ACP compatibility have their own sources under
   tests, foreign-deck recovery tests, and controlled checkpoint command tests.
 - Runtime boundary: source verification does not prove OfficeV3 adoption until
   the runtime is rebuilt, installed, restarted, and replayed with a fresh task.
+
+### 2026-08-21 — configurable runtime operational limits
+
+- Change: implementation on `feat/configurable-runtime-limits`; no merge or
+  release reference exists yet.
+- Configuration surface: four previously hardcoded operational values become
+  config/env, with defaults preserving current behavior unless explicitly set:
+  - `agent.provider_stale_seconds` (default 180) plus
+    `BOX_AGENT_PROVIDER_STALE_SECONDS`, threaded through
+    `Agent` → `run_agent_loop` → `_stream_with_activity` and into sub-agents.
+    Non-positive, non-finite (`inf`/`nan`), or unparseable overrides are ignored
+    so the stale guard cannot be silently disabled.
+  - `image_generation.max_dimension` (default 1024) plus `BOX_AGENT_IMAGE_MAX_DIM`
+    (`0` disables).
+  - `BOX_AGENT_SENSENOVA_MODEL_PREFIXES` (additive; built-ins always kept)
+    extends the SenseNova thinking-dialect prefix list.
+- Compatibility default change: generic/custom OpenAI-compatible image endpoints
+  now clamp an explicit oversized `size` to the configured longest edge (default
+  1024) to avoid 504s. OpenAI, Doubao/Seedream, and host-aligned `/images/gen`
+  endpoints keep their own size rules and are not clamped.
+- Registration change: `generate_image` is no longer registered when no image
+  endpoint is configured (via config or env); an unconfigured tool could only
+  fail on every call.
+- Proof anchors: `tests/test_image_generation_tool.py`,
+  `tests/test_llm_activity.py`, `tests/test_openai_client_sensenova.py`,
+  `tests/test_sub_agent_tool.py`.
+- Rollback: revert the implementation commit; unset the new env vars / config
+  keys to restore prior values. Only the generic image clamp and the
+  `generate_image` gating change any default behavior.
 
 ## Recent material changes on `main`
 

--- a/tests/test_image_generation_tool.py
+++ b/tests/test_image_generation_tool.py
@@ -265,6 +265,209 @@ async def test_generate_image_accepts_explicit_size(
     assert result.raw_output["height"] == 2048
 
 
+def test_image_generation_config_default_max_dimension() -> None:
+    assert ImageGenerationConfig().max_dimension == 1024
+
+
+@pytest.mark.asyncio
+async def test_generate_image_clamps_oversized_size_for_generic_endpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["size"] == "1024x1024"
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(PNG_BYTES).decode("ascii")}]},
+        )
+
+    patch_async_client(monkeypatch, handler)
+    tool = GenerateImageTool(
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        endpoint="https://custom.example.test/v1/generate",
+        max_dimension=1024,
+    )
+
+    result = await tool.execute(
+        prompt="oversized hero",
+        output_path="assets/generated/hero.png",
+        size="1400x1400",
+    )
+
+    assert result.success
+    assert result.raw_output["size"] == "1024x1024"
+    assert result.raw_output["width"] == 1024
+    assert result.raw_output["height"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_generate_image_generic_clamp_preserves_aspect_ratio(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["size"] == "1024x512"
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(PNG_BYTES).decode("ascii")}]},
+        )
+
+    patch_async_client(monkeypatch, handler)
+    tool = GenerateImageTool(
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        endpoint="https://custom.example.test/v1/generate",
+        max_dimension=1024,
+    )
+
+    result = await tool.execute(
+        prompt="wide banner",
+        output_path="assets/generated/banner.png",
+        size="2000x1000",
+    )
+
+    assert result.success
+    assert result.raw_output["width"] == 1024
+    assert result.raw_output["height"] == 512
+
+
+@pytest.mark.asyncio
+async def test_generate_image_generic_clamp_disabled_forwards_size(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["size"] == "1400x1400"
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(PNG_BYTES).decode("ascii")}]},
+        )
+
+    patch_async_client(monkeypatch, handler)
+    tool = GenerateImageTool(
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        endpoint="https://custom.example.test/v1/generate",
+        max_dimension=0,  # clamp disabled
+    )
+
+    result = await tool.execute(
+        prompt="oversized on purpose",
+        output_path="assets/generated/big.png",
+        size="1400x1400",
+    )
+
+    assert result.success
+    assert result.raw_output["size"] == "1400x1400"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_max_dimension_env_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BOX_AGENT_IMAGE_MAX_DIM", "768")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["size"] == "768x768"
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(PNG_BYTES).decode("ascii")}]},
+        )
+
+    patch_async_client(monkeypatch, handler)
+    tool = GenerateImageTool(
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        endpoint="https://custom.example.test/v1/generate",
+        max_dimension=1024,  # env override wins over this
+    )
+
+    result = await tool.execute(
+        prompt="env clamp",
+        output_path="assets/generated/env.png",
+        size="1400x1400",
+    )
+
+    assert result.success
+    assert result.raw_output["width"] == 768
+
+
+@pytest.mark.asyncio
+async def test_generate_image_seedream_endpoint_not_clamped_by_max_dimension(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A Doubao/Seedream service reached through a generic (non /images/gen)
+    # endpoint must keep its own size mapping — the generic max-dimension clamp
+    # must not shrink the explicit size before _seedream_size_for_ratio runs.
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["size"] == "4096x4096"
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(PNG_BYTES).decode("ascii")}]},
+        )
+
+    patch_async_client(monkeypatch, handler)
+    tool = GenerateImageTool(
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        endpoint="https://custom.example.test/v1/generate",
+        model="Doubao-Seedream-5.0-lite",
+        max_dimension=1024,
+    )
+
+    result = await tool.execute(
+        prompt="wide courtyard",
+        output_path="assets/generated/ds.png",
+        size="4096x4096",
+    )
+
+    assert result.success
+    assert result.raw_output["width"] == 4096
+    assert result.raw_output["height"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_generate_image_openai_endpoint_size_not_clamped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        # OpenAI-style endpoints keep their own normalization; the generic
+        # max-dimension clamp must not shrink them.
+        assert payload["size"] == "2048x2048"
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(PNG_BYTES).decode("ascii")}]},
+        )
+
+    patch_async_client(monkeypatch, handler)
+    tool = GenerateImageTool(
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        endpoint="https://image.example.test/v1/images/generations",
+        max_dimension=1024,
+    )
+
+    result = await tool.execute(
+        prompt="high-res",
+        output_path="assets/generated/openai.png",
+        size="2048x2048",
+    )
+
+    assert result.success
+    assert result.raw_output["width"] == 2048
+    assert result.raw_output["height"] == 2048
+
+
 @pytest.mark.asyncio
 async def test_generate_image_upscales_too_small_explicit_size_for_openai_style_endpoint(
     tmp_path: Path,
@@ -900,10 +1103,29 @@ def test_add_workspace_tools_registers_generate_image(tmp_path: Path) -> None:
 
     class Config:
         tools = ToolsConfig(enable_bash=False, enable_file_tools=False, enable_todo=False, enable_sub_agent=False)
+        image_generation = ImageGenerationConfig(
+            endpoint="https://image.example.test/v1/images/generations"
+        )
 
     add_workspace_tools(tools, Config(), tmp_path, allow_full_access=False, output=lambda *_: None)
 
     assert any(tool.name == "generate_image" for tool in tools)
+
+
+def test_add_workspace_tools_skips_generate_image_without_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("BOX_AGENT_IMAGE_GENERATION_ENDPOINT", raising=False)
+    monkeypatch.delenv("BOX_AGENT_IMAGE_GEN_ENDPOINT", raising=False)
+    tools = []
+
+    class Config:
+        tools = ToolsConfig(enable_bash=False, enable_file_tools=False, enable_todo=False, enable_sub_agent=False)
+        image_generation = ImageGenerationConfig()  # endpoint unset
+
+    add_workspace_tools(tools, Config(), tmp_path, allow_full_access=False, output=lambda *_: None)
+
+    assert not any(tool.name == "generate_image" for tool in tools)
 
 
 def test_image_generation_service_is_box_agent_configured_for_cli_and_acp() -> None:
@@ -1085,6 +1307,9 @@ def test_project_mode_tools_keep_workspace_relative_root(tmp_path: Path) -> None
             enable_file_tools=True,
             enable_todo=False,
             enable_sub_agent=False,
+        )
+        image_generation = ImageGenerationConfig(
+            endpoint="https://image.example.test/v1/images/generations"
         )
 
     add_workspace_tools(

--- a/tests/test_llm_activity.py
+++ b/tests/test_llm_activity.py
@@ -64,3 +64,67 @@ async def test_provider_stream_liveness_prevents_false_stale(monkeypatch):
 
     assert events[-1].finish_reason == "stop"
     assert not any(event.finish_reason == "provider_stale" for event in events)
+
+
+def test_resolve_provider_stale_seconds_precedence(monkeypatch):
+    monkeypatch.delenv("BOX_AGENT_PROVIDER_STALE_SECONDS", raising=False)
+    # default
+    assert core._resolve_provider_stale_seconds() == core.LLM_PROVIDER_STALE_SECONDS
+    # configured value used when no env
+    assert core._resolve_provider_stale_seconds(350) == 350.0
+    # non-positive / bad configured value falls back to default
+    assert core._resolve_provider_stale_seconds(0) == core.LLM_PROVIDER_STALE_SECONDS
+    assert core._resolve_provider_stale_seconds(-5) == core.LLM_PROVIDER_STALE_SECONDS
+    # env overrides configured value
+    monkeypatch.setenv("BOX_AGENT_PROVIDER_STALE_SECONDS", "500")
+    assert core._resolve_provider_stale_seconds(350) == 500.0
+    # unparseable env ignored -> falls back to configured value
+    monkeypatch.setenv("BOX_AGENT_PROVIDER_STALE_SECONDS", "junk")
+    assert core._resolve_provider_stale_seconds(350) == 350.0
+    # non-positive env ignored
+    monkeypatch.setenv("BOX_AGENT_PROVIDER_STALE_SECONDS", "0")
+    assert core._resolve_provider_stale_seconds(350) == 350.0
+    # non-finite env (inf / 1e309 overflow) ignored — must not disable the guard
+    monkeypatch.setenv("BOX_AGENT_PROVIDER_STALE_SECONDS", "inf")
+    assert core._resolve_provider_stale_seconds(350) == 350.0
+    monkeypatch.setenv("BOX_AGENT_PROVIDER_STALE_SECONDS", "1e309")
+    assert core._resolve_provider_stale_seconds(350) == 350.0
+    monkeypatch.setenv("BOX_AGENT_PROVIDER_STALE_SECONDS", "nan")
+    assert core._resolve_provider_stale_seconds(350) == 350.0
+    # non-finite configured value ignored -> falls back to the module default
+    monkeypatch.delenv("BOX_AGENT_PROVIDER_STALE_SECONDS", raising=False)
+    assert core._resolve_provider_stale_seconds(float("inf")) == core.LLM_PROVIDER_STALE_SECONDS
+    assert core._resolve_provider_stale_seconds(float("nan")) == core.LLM_PROVIDER_STALE_SECONDS
+
+
+def test_agent_config_infinite_provider_stale_seconds_does_not_disable_guard():
+    # A YAML/config value like `.inf` (or the string "1e309") coerces to float
+    # inf on AgentConfig; the resolver must still fall back to a finite cutoff.
+    from box_agent.config import AgentConfig
+
+    cfg = AgentConfig(provider_stale_seconds=float("inf"))
+    assert core._resolve_provider_stale_seconds(cfg.provider_stale_seconds) == (
+        core.LLM_PROVIDER_STALE_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_wrapper_honors_explicit_stale_seconds(monkeypatch):
+    monkeypatch.setattr(core, "LLM_ACTIVITY_INTERVAL_SECONDS", 0.01)
+    # Module default is generous; the explicit per-turn value is what bites.
+    monkeypatch.setattr(core, "LLM_PROVIDER_STALE_SECONDS", 100.0)
+
+    async def stuck_stream():
+        await asyncio.sleep(10)
+        yield StreamEvent(type="text", delta="late")
+
+    events = [
+        event
+        async for event in core._stream_with_activity(
+            stuck_stream(), stale_seconds=0.025
+        )
+    ]
+
+    assert events[-1].type == "finish"
+    assert events[-1].finish_reason == "provider_stale"
+    assert not any(event.type == "text" for event in events)

--- a/tests/test_openai_client_sensenova.py
+++ b/tests/test_openai_client_sensenova.py
@@ -1,0 +1,35 @@
+from box_agent.llm.openai_client import (
+    _DEFAULT_SENSENOVA_MODEL_PREFIXES,
+    _is_sensenova_model,
+    _sensenova_model_prefixes,
+)
+
+
+def test_default_sensenova_prefixes(monkeypatch):
+    monkeypatch.delenv("BOX_AGENT_SENSENOVA_MODEL_PREFIXES", raising=False)
+    assert _sensenova_model_prefixes() == _DEFAULT_SENSENOVA_MODEL_PREFIXES
+    assert _is_sensenova_model("sensenova-v6")
+    assert _is_sensenova_model("SN-SenseNova-Turbo")
+    # Case-insensitive; a SenseNova-Flash model already matches the built-ins.
+    assert _is_sensenova_model("SenseNova-Flash-Lite-20260727")
+    assert not _is_sensenova_model("deepseek-v4")
+    assert not _is_sensenova_model(None)
+    assert not _is_sensenova_model("")
+
+
+def test_env_extends_prefixes_without_dropping_builtins(monkeypatch):
+    monkeypatch.setenv("BOX_AGENT_SENSENOVA_MODEL_PREFIXES", "deepseek-, flash-")
+    prefixes = _sensenova_model_prefixes()
+    # Built-ins are always retained.
+    for builtin in _DEFAULT_SENSENOVA_MODEL_PREFIXES:
+        assert builtin in prefixes
+    assert "deepseek-" in prefixes
+    assert "flash-" in prefixes
+    assert _is_sensenova_model("deepseek-v4")
+    assert _is_sensenova_model("Flash-X")
+    assert _is_sensenova_model("sensenova-v6")
+
+
+def test_blank_env_falls_back_to_builtins(monkeypatch):
+    monkeypatch.setenv("BOX_AGENT_SENSENOVA_MODEL_PREFIXES", "   ")
+    assert _sensenova_model_prefixes() == _DEFAULT_SENSENOVA_MODEL_PREFIXES

--- a/tests/test_sub_agent_tool.py
+++ b/tests/test_sub_agent_tool.py
@@ -114,6 +114,16 @@ def test_parallel_safe():
     assert tool.parallel_safe is True
 
 
+def test_provider_stale_seconds_defaults_to_none():
+    tool = SubAgentTool(llm=AsyncMock(), parent_tools={})
+    assert tool._provider_stale_seconds is None
+
+
+def test_provider_stale_seconds_is_stored_for_child_loop():
+    tool = SubAgentTool(llm=AsyncMock(), parent_tools={}, provider_stale_seconds=350.0)
+    assert tool._provider_stale_seconds == 350.0
+
+
 def test_automatic_child_routing_selects_from_host_allowlist():
     class RoutingLLM:
         auto_model_candidates = (


### PR DESCRIPTION
Expose four hardcoded operational values as config/env so slow models and custom deployments can adapt them, with defaults preserving current behavior.

- core: provider-stale cutoff is now `agent.provider_stale_seconds` (default 180, unchanged), overridable by `BOX_AGENT_PROVIDER_STALE_SECONDS`. Threaded through Agent -> run_agent_loop -> _stream_with_activity; the module default is still read at call time so existing monkeypatch-based tests keep working. Sub-agents inherit the value via SubAgentTool so a raised config also applies to child loops (not just the top-level agent).
- image: generic/custom OpenAI-compatible endpoints forward an explicit `size` unchanged and can 504 on oversized requests. Add a longest-edge clamp (`image_generation.max_dimension`, default 1024, env `BOX_AGENT_IMAGE_MAX_DIM`, 0 disables). OpenAI, Doubao/Seedream and host-aligned `/images/gen` endpoints keep their own size rules — the clamp is skipped for Doubao/Seedream services so their dimension mapping is never pre-shrunk.
- tools: skip registering `generate_image` when no endpoint is configured (via config or env); an unconfigured tool can only fail on every call.
- llm: `_SENSENOVA_MODEL_PREFIXES` becomes extensible via `BOX_AGENT_SENSENOVA_MODEL_PREFIXES` (additive, built-ins always kept) so a new model family can opt into the SenseNova thinking dialect without a source change.

config-example.yaml documents the two new config keys and the two thinking/ image env overrides. Tests added for each behavior; the generate_image registration tests are updated to configure an endpoint to match the new gated behavior, plus regressions for the Seedream clamp exclusion and sub-agent stale-seconds propagation.

## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

### Design and architecture impact

- Affected layers and owners:
- Contract, schema, or protocol impact:
- Documentation updated:

### Target branch consistency

- Base branch and reviewed Head SHA:
- Relevant target-branch changes considered:
- Rebase, compatibility, or historical-fix risk:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [ ] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [ ] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` passed for the current Head SHA, or the missing status is explained.
