### PR TITLE
feat(vision-review): add native strategy alongside proxy

### DIFF
--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -3086,6 +3086,12 @@ async def run_agent_loop(
     delegated_tool_call_total = 0
     delegated_budget_guidance_injected = False
     completion_reserve_injected = False
+    # Multimodal follow-up content a tool asked to hand to the main model
+    # (e.g. vision_review in native strategy). Accumulated during tool
+    # execution and flushed as ONE user message at the next step boundary —
+    # after every tool result is appended, before the next model call — so
+    # tool-call/result closure is never interleaved with it.
+    pending_followup_user_content: list[dict] = []
     tool_budget_wrapup_injected: set[str] = set()
     visible_tool_call_total = 0
     final_summary_guidance_injected = False
@@ -3236,6 +3242,25 @@ async def run_agent_loop(
                     injection_id=injection_id,
                     user_visible=user_visible,
                 )
+
+        # Deliver any multimodal content a previous step's tool handed to the
+        # main model as a single follow-up user message before this step's
+        # model call. Runs after all prior tool results are already in
+        # ``messages`` so the assistant->tool_result->user ordering stays valid.
+        if pending_followup_user_content:
+            followup_block_count = len(pending_followup_user_content)
+            messages.append(
+                Message(role="user", content=pending_followup_user_content)
+            )
+            yield InjectedMessageEvent(
+                content=(
+                    f"A tool attached {followup_block_count} follow-up content "
+                    "block(s) to the conversation for the next model turn."
+                ),
+                injection_id=None,
+                user_visible=False,
+            )
+            pending_followup_user_content = []
 
         has_plan_tool = "plan_write" in tools
         latest_user_text = _latest_user_text(messages)
@@ -5461,6 +5486,8 @@ async def run_agent_loop(
             )
             msg_content = tool_msg.content
             messages.append(tool_msg)
+            if result.followup_user_content:
+                pending_followup_user_content.extend(result.followup_user_content)
             _record_context_resource_history(
                 tool_call_id=tc_id,
                 decision=resource_decision,
@@ -6069,6 +6096,8 @@ async def run_agent_loop(
                 )
                 msg_content = tool_msg.content
                 messages.append(tool_msg)
+                if result.followup_user_content:
+                    pending_followup_user_content.extend(result.followup_user_content)
                 _record_context_resource_history(
                     tool_call_id=tc_id,
                     decision=resource_decision,

--- a/box_agent/llm/anthropic_client.py
+++ b/box_agent/llm/anthropic_client.py
@@ -252,7 +252,29 @@ class AnthropicClient(LLMClientBase):
                     }
                 )
 
-        return system_message, api_messages
+        # Anthropic requires strictly alternating user/assistant turns. Tool
+        # results are emitted as user turns, so any following user message — an
+        # injected recovery/context note, or a vision_review native image
+        # attachment — would create two consecutive user turns and be rejected.
+        # Coalesce consecutive same-role turns into one, concatenating their
+        # content (normalizing string content to a text block).
+        def _as_blocks(content: Any) -> list[Any]:
+            if isinstance(content, list):
+                return content
+            if isinstance(content, str):
+                return [{"type": "text", "text": content}] if content else []
+            return [content]
+
+        merged: list[dict[str, Any]] = []
+        for entry in api_messages:
+            if merged and merged[-1]["role"] == entry["role"]:
+                merged[-1]["content"] = _as_blocks(merged[-1]["content"]) + _as_blocks(
+                    entry["content"]
+                )
+            else:
+                merged.append({"role": entry["role"], "content": entry["content"]})
+
+        return system_message, merged
 
     def _prepare_request(
         self,

--- a/box_agent/tools/base.py
+++ b/box_agent/tools/base.py
@@ -29,6 +29,15 @@ class ToolResult(BaseModel):
     # object leaves the execution loop; excluding it avoids duplicating a large
     # payload in serialized host events.
     persistence_content: str | None = Field(default=None, exclude=True)
+    # Optional multimodal content a tool asks the loop to deliver to the MAIN
+    # model as a follow-up ``user`` message, appended once after the whole tool
+    # batch completes (before the next model call). Each entry is a provider-
+    # shaped content block (e.g. a text block plus ``image``/``image_url``
+    # blocks). This is how a tool hands real images to a vision-capable main
+    # model instead of proxying them to a side call. ``None`` (the default)
+    # means the loop behaves exactly as before. Excluded from serialization
+    # because image payloads must not bloat host events.
+    followup_user_content: list[dict] | None = Field(default=None, exclude=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -699,6 +699,11 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
     # futile resize/retry loops during presentation QA.
     vision_llm = _vision_capable_llm(llm)
     if vision_llm is not None:
+        # native strategy attaches images to the MAIN model's own context, so it
+        # is only safe when the main model itself is vision-capable. When vision
+        # is instead routed to a separate utility model (vision_llm is not the
+        # bound main llm), native is refused and proxy is used.
+        native_supported = vision_llm is llm
         tools.append(
             VisionReviewTool(
                 llm=vision_llm,
@@ -706,6 +711,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                 allow_full_access=allow_full_access,
                 permission_engine=permission_engine,
                 relative_root_dir=str(relative_root),
+                native_supported=native_supported,
             )
         )
         _out(f"{Colors.GREEN}✅ Loaded vision review tool (vision_review){Colors.RESET}")

--- a/box_agent/tools/vision_review_tool.py
+++ b/box_agent/tools/vision_review_tool.py
@@ -60,6 +60,7 @@ class VisionReviewTool(Tool):
         allow_full_access: bool = True,
         permission_engine: PermissionEngine | None = None,
         relative_root_dir: str | None = None,
+        native_supported: bool = True,
     ) -> None:
         self.llm = llm
         self.workspace_dir = Path(workspace_dir).absolute()
@@ -69,6 +70,11 @@ class VisionReviewTool(Tool):
         self.allow_full_access = allow_full_access
         self._perm = permission_engine
         self._terminal_error: str | None = None
+        # native strategy attaches images to the MAIN model's context; it is
+        # only valid when the main model itself is the vision model. When vision
+        # is served by a separate utility model, ``self.llm`` is that utility and
+        # native would send images to a text-only main model — so it is refused.
+        self._native_supported = native_supported
 
     @property
     def name(self) -> str:
@@ -81,7 +87,9 @@ class VisionReviewTool(Tool):
             "sending them as image content to the current multimodal LLM, writing "
             "the markdown report to visual_review.md beside the first input image by default, and returning "
             "per-image PASS/ISSUE findings. Use this when a skill requires real "
-            "visual QA; passing image paths in text is not enough."
+            "visual QA; passing image paths in text is not enough. Set strategy=native "
+            "to attach the images to your own context and inspect them directly instead "
+            "of proxying to a separate vision model."
         )
 
     @property
@@ -115,6 +123,20 @@ class VisionReviewTool(Tool):
                         "image understanding without writing visual_review.md."
                     ),
                 },
+                "strategy": {
+                    "type": "string",
+                    "enum": ["proxy", "native"],
+                    "default": "proxy",
+                    "description": (
+                        "proxy (default): a separate vision model inspects the images and "
+                        "returns a text review — use when you need a written QA report or "
+                        "the main model cannot see images. native: attach the images "
+                        "directly to your own (the main model's) context for the next turn "
+                        "and inspect them yourself — use when you are a vision-capable model "
+                        "and want to reason over the raw pixels. native ignores mode and "
+                        "writes no report."
+                    ),
+                },
             },
             "required": ["image_paths"],
         }
@@ -125,12 +147,48 @@ class VisionReviewTool(Tool):
         output_path: str | None = None,
         instructions: str | None = None,
         mode: str = "review",
+        strategy: str = "proxy",
     ) -> ToolResult:
         """Run visual review and write the markdown report."""
         if not image_paths:
             return ToolResult(success=False, error="image_paths must contain at least one image path")
+        if strategy not in {"proxy", "native"}:
+            return ToolResult(success=False, error="strategy must be 'proxy' or 'native'")
         if mode not in {"review", "describe"}:
             return ToolResult(success=False, error="mode must be 'review' or 'describe'")
+
+        # Native strategy: hand the raw images to the MAIN model instead of
+        # proxying them to a side vision call. The images are attached as a
+        # follow-up user message (see ToolResult.followup_user_content) so the
+        # main model inspects the pixels itself on its next turn. No report is
+        # written and no extra LLM call is made.
+        if strategy == "native":
+            if not self._native_supported:
+                return ToolResult(
+                    success=False,
+                    error=(
+                        "native strategy requires a vision-capable main model, but this "
+                        "session routes vision to a separate utility model. Re-run with "
+                        "strategy='proxy' (the default) to get a written review."
+                    ),
+                )
+            try:
+                images = [self._load_image(path) for path in image_paths]
+            except ValueError as exc:
+                return ToolResult(success=False, error=str(exc))
+            blocks = self._build_native_blocks(images, instructions=instructions)
+            attached = ", ".join(image["path"] for image in images)
+            note = (
+                f"Attached {len(images)} image(s) to your context for direct visual "
+                f"inspection: {attached}. Inspect them yourself and continue the task; "
+                "do not call vision_review again for the same images."
+            )
+            return ToolResult(
+                success=True,
+                content=note,
+                followup_user_content=blocks,
+            )
+
         if self._terminal_error is not None:
             return ToolResult(success=False, error=self._terminal_error)
 
@@ -389,6 +447,46 @@ class VisionReviewTool(Tool):
         blocks: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
         for image in images:
             if "anthropic" in self._provider_hint():
+                blocks.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image["mime_type"],
+                            "data": image["base64"],
+                        },
+                    }
+                )
+            else:
+                blocks.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image["data_url"]},
+                    }
+                )
+        return blocks
+
+    def _build_native_blocks(
+        self,
+        images: list[dict[str, str]],
+        *,
+        instructions: str | None,
+    ) -> list[dict[str, Any]]:
+        """Provider-shaped blocks handed to the MAIN model for native review.
+
+        A leading text block frames the task, then each image is labeled and
+        attached in the current provider's wire format (Anthropic ``image`` vs
+        OpenAI ``image_url``). The main-model provider serializes these when the
+        loop appends them as a follow-up user message.
+        """
+        lead = (instructions or "").strip()
+        intro = "Inspect the following screenshot(s) directly and continue the task."
+        text = f"{intro} Extra criteria: {lead}" if lead else intro
+        blocks: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        provider = self._provider_hint()
+        for index, image in enumerate(images, start=1):
+            blocks.append({"type": "text", "text": f"Image {index}: {image['path']}"})
+            if "anthropic" in provider:
                 blocks.append(
                     {
                         "type": "image",

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -58,6 +58,7 @@ decision, read those entries together.
 | Sub-agent delegation | `sub_agent_tool.py`, `sub_agent_capabilities.py`, `required_tools`, `write_scope`, `files` | The public request is flat; runtime-derived policy limits implicit tools to trusted local readers, keeps process/external/unknown MCP capabilities fail-closed, and scopes path writes. | Supersedes the caller-authored nested constraint contract while retaining its runtime enforcement goals. | [2026-08-19 flattened contract](#2026-08-19--flattened-sub-agent-contract-with-derived-policy) |
 | Workflow ownership | `workflow_owner_store.py`, explicit Skills, ACP decisions, presentation recovery | Runtime-selected owner precedes artifact discovery. Unknown Skills use the generic external lifecycle; foreign `deck.json` files cannot activate controlled finalization. | Pending implementation; hardens external-Skill and controlled-presentation recovery. | [2026-08-20 owner hardening](#2026-08-20--workflow-owner-precedence-for-third-party-skills) |
 | Model routing and controlled presentations | `box_agent/llm/model_routing.py`, `box_agent/workflows/presentation_*`, controlled PPTX | Automatic child-model routing uses a host allowlist, while presentation-specific state and recovery remain outside the generic kernel. | PR #30 is the main record; later research hardening must be checked where relevant. | [PR #30](#2026-08-14--runtime-routing-and-presentation-reliability-pr-30), [later hardening](#other-target-branch-changes-after-or-adjacent-to-those-prs) |
+| Tool→main-model follow-up, vision review | `box_agent/tools/base.py` (`followup_user_content`), `box_agent/core.py` step-boundary flush, `box_agent/llm/anthropic_client.py` turn merge, `vision_review` `strategy` | Tools may hand multimodal follow-up to the main model via an opt-in field flushed as one user turn; `vision_review` adds a `native` strategy gated on main-model vision capability; Anthropic conversion coalesces consecutive same-role turns. | Pending; default behavior unchanged. | [2026-08-21 native follow-up](#2026-08-21--tool-to-main-model-image-follow-up-and-vision_review-native-strategy) |
 
 For research execution, Todo/progress behavior, browser routing, or contributor
 branch history, also check
@@ -117,6 +118,35 @@ Release, provider API, and ACP compatibility have their own sources under
   tests, foreign-deck recovery tests, and controlled checkpoint command tests.
 - Runtime boundary: source verification does not prove OfficeV3 adoption until
   the runtime is rebuilt, installed, restarted, and replayed with a fresh task.
+
+### 2026-08-21 — tool-to-main-model image follow-up and vision_review native strategy
+
+- Change: implementation on `feat/vision-review-native-strategy`; no merge or
+  release reference exists yet.
+- Tool contract: new opt-in `ToolResult.followup_user_content` (a list of
+  provider-shaped content blocks). The agent loop accumulates these during tool
+  execution and flushes them as one follow-up `user` message at the next step
+  boundary — after every tool result is appended, before the next model call —
+  so tool-call/result closure and assistant→tool_result→user ordering are
+  preserved. The field is excluded from serialization. When unset (the
+  default), the loop behaves exactly as before.
+- Vision review: `vision_review` gains `strategy=proxy|native` (default
+  `proxy`, unchanged). `native` attaches the raw screenshots to the MAIN
+  model's own context instead of proxying to a side vision call, and is refused
+  with a proxy-directed error unless the bound main model is itself
+  vision-capable (`native_supported`).
+- Provider compatibility: `AnthropicClient._convert_messages` now coalesces
+  consecutive same-role turns into one (string content normalized to a text
+  block). Anthropic emits tool results as user turns, so the native image
+  follow-up — and any injected user message after a tool result — would
+  otherwise form two consecutive user turns and be rejected. This also hardens
+  the existing injection paths.
+- Compatibility: default `proxy` and an unset `followup_user_content` are
+  byte-for-byte prior behavior; the Anthropic merge only changes payloads that
+  were already invalid (consecutive same-role turns).
+- Proof anchors: `tests/test_tool_followup_user_content.py`,
+  `tests/test_vision_review_tool.py`, `tests/test_anthropic_message_merge.py`.
+- Rollback: revert the implementation commit; no data migration required.
 
 ## Recent material changes on `main`
 

--- a/tests/test_anthropic_message_merge.py
+++ b/tests/test_anthropic_message_merge.py
@@ -1,0 +1,81 @@
+"""Anthropic message conversion: consecutive same-role turns are merged.
+
+Anthropic requires strictly alternating user/assistant turns. Tool results are
+emitted as user turns, so a following user message (e.g. a vision_review native
+image attachment or an injected note) must be merged into the same user turn
+rather than sent as a second consecutive user turn (which Anthropic rejects).
+"""
+
+from box_agent.llm import AnthropicClient
+from box_agent.schema import FunctionCall, Message, ToolCall
+
+
+def _client() -> AnthropicClient:
+    return AnthropicClient(
+        api_key="test-key",
+        api_base="https://api.anthropic.com",
+        model="claude-sonnet-4-20250514",
+    )
+
+
+def _no_consecutive_same_role(api_messages) -> bool:
+    roles = [m["role"] for m in api_messages]
+    return all(roles[i] != roles[i + 1] for i in range(len(roles) - 1))
+
+
+def test_tool_result_and_following_user_image_merge_into_one_turn():
+    client = _client()
+    image_blocks = [
+        {"type": "text", "text": "Inspect this."},
+        {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+        },
+    ]
+    messages = [
+        Message(role="system", content="sys"),
+        Message(role="user", content="hi"),
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    id="t1",
+                    type="function",
+                    function=FunctionCall(name="vision_review", arguments={}),
+                )
+            ],
+        ),
+        Message(role="tool", content="attached", tool_call_id="t1", name="vision_review"),
+        Message(role="user", content=image_blocks),
+    ]
+
+    system, api = client._convert_messages(messages)
+
+    assert system == "sys"
+    assert _no_consecutive_same_role(api), [m["role"] for m in api]
+    # The tool_result and the image blocks live in ONE user turn.
+    last = api[-1]
+    assert last["role"] == "user"
+    block_types = [b.get("type") for b in last["content"]]
+    assert "tool_result" in block_types
+    assert "image" in block_types
+
+
+def test_plain_alternating_history_is_unchanged():
+    client = _client()
+    messages = [
+        Message(role="system", content="sys"),
+        Message(role="user", content="hi"),
+        Message(role="assistant", content="hello"),
+        Message(role="user", content="bye"),
+    ]
+
+    system, api = client._convert_messages(messages)
+
+    assert system == "sys"
+    assert [m["role"] for m in api] == ["user", "assistant", "user"]
+    # String content is preserved as-is when no merge is needed.
+    assert api[0]["content"] == "hi"
+    assert api[1]["content"] == "hello"
+    assert api[2]["content"] == "bye"

--- a/tests/test_tool_followup_user_content.py
+++ b/tests/test_tool_followup_user_content.py
@@ -1,0 +1,153 @@
+"""Tests for ToolResult.followup_user_content -> main-model injection.
+
+A tool can hand multimodal content (e.g. vision_review's native strategy) to
+the main model. The loop appends it as ONE follow-up user message at the next
+step boundary — after every tool result is in place, before the next model
+call — so tool-call/result closure is never interleaved with it.
+"""
+
+import asyncio
+
+import pytest
+
+from box_agent.core import run_agent_loop
+from box_agent.events import DoneEvent, InjectedMessageEvent
+from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
+from box_agent.tools.base import Tool, ToolResult
+
+
+class MockLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._idx = 0
+        self.seen_messages = []
+
+    async def generate_stream(self, messages, tools=None, **_):
+        # Snapshot a shallow copy of history at each call for later assertions.
+        self.seen_messages.append(list(messages))
+        resp = self._responses[self._idx]
+        self._idx += 1
+        if resp.content:
+            yield StreamEvent(type="text", delta=resp.content)
+        yield StreamEvent(
+            type="finish",
+            finish_reason=resp.finish_reason,
+            usage=resp.usage,
+            tool_calls=resp.tool_calls,
+        )
+
+
+_IMAGE_BLOCKS = [
+    {"type": "text", "text": "Inspect the following screenshot(s)."},
+    {"type": "text", "text": "Image 1: slide.png"},
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+]
+
+
+class AttachTool(Tool):
+    @property
+    def name(self):
+        return "attach"
+
+    @property
+    def description(self):
+        return "Attaches images to the main model"
+
+    @property
+    def parameters(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self):
+        return ToolResult(
+            success=True,
+            content="Attached 1 image(s) for direct inspection.",
+            followup_user_content=list(_IMAGE_BLOCKS),
+        )
+
+
+class PlainTool(Tool):
+    @property
+    def name(self):
+        return "plain"
+
+    @property
+    def description(self):
+        return "Returns text only"
+
+    @property
+    def parameters(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self):
+        return ToolResult(success=True, content="ok")
+
+
+def _msgs():
+    return [
+        Message(role="system", content="sys"),
+        Message(role="user", content="hi"),
+    ]
+
+
+async def _collect(gen):
+    return [ev async for ev in gen]
+
+
+def _call(name):
+    return LLMResponse(
+        content="",
+        tool_calls=[
+            ToolCall(id="t1", type="function", function=FunctionCall(name=name, arguments={}))
+        ],
+        finish_reason="tool",
+    )
+
+
+@pytest.mark.asyncio
+async def test_followup_user_content_injected_as_user_message_after_tool_result():
+    msgs = _msgs()
+    llm = MockLLM([_call("attach"), LLMResponse(content="done", finish_reason="stop")])
+
+    events = await _collect(
+        run_agent_loop(llm=llm, messages=msgs, tools={"attach": AttachTool()}, max_steps=5)
+    )
+
+    # A user message carrying exactly the follow-up blocks was appended.
+    followup = [
+        m
+        for m in msgs
+        if m.role == "user" and isinstance(m.content, list) and m.content == _IMAGE_BLOCKS
+    ]
+    assert len(followup) == 1
+
+    # Ordering: it comes after the tool result, not before it.
+    roles = [m.role for m in msgs]
+    tool_idx = roles.index("tool")
+    followup_idx = msgs.index(followup[0])
+    assert followup_idx > tool_idx
+
+    # The second model call sees the follow-up user message in its history.
+    assert any(
+        m.role == "user" and m.content == _IMAGE_BLOCKS for m in llm.seen_messages[1]
+    )
+
+    # A hidden injected-message event is emitted for observability.
+    injected = [e for e in events if isinstance(e, InjectedMessageEvent)]
+    assert any("attached" in e.content.lower() for e in injected)
+
+    done = [e for e in events if isinstance(e, DoneEvent)]
+    assert len(done) == 1
+    assert done[0].final_content == "done"
+
+
+@pytest.mark.asyncio
+async def test_no_followup_content_appends_no_extra_user_message():
+    msgs = _msgs()
+    llm = MockLLM([_call("plain"), LLMResponse(content="done", finish_reason="stop")])
+
+    await _collect(
+        run_agent_loop(llm=llm, messages=msgs, tools={"plain": PlainTool()}, max_steps=5)
+    )
+
+    # No user message with list content was injected (zero impact).
+    assert not any(m.role == "user" and isinstance(m.content, list) for m in msgs)

--- a/tests/test_vision_review_tool.py
+++ b/tests/test_vision_review_tool.py
@@ -399,3 +399,132 @@ def test_add_workspace_tools_routes_vision_review_to_catalog_vision_model(tmp_pa
     vision_tool = next(tool for tool in tools if tool.name == "vision_review")
     assert vision_tool.llm.model == "vision-model"
     assert vision_tool.llm.max_output_tokens == 8192
+    # Vision is served by a separate utility model, not the text main model,
+    # so native must be refused for this session.
+    assert vision_tool._native_supported is False
+
+
+def test_add_workspace_tools_marks_native_supported_when_main_model_is_vision(tmp_path: Path):
+    class VisionMainLLM(FakeVisionLLM):
+        model = "vision-model"
+        api_base = "https://example.test/v1"
+        auto_model_candidates = (
+            {"model": "vision-model", "tags": ["vision", "code"], "abilityLevel": 5},
+        )
+
+    tools = []
+    add_workspace_tools(
+        tools,
+        ToolConfig(),
+        tmp_path,
+        allow_full_access=False,
+        llm=VisionMainLLM(),
+        output=lambda *_: None,
+    )
+
+    vision_tool = next(tool for tool in tools if tool.name == "vision_review")
+    # The bound main model is itself vision-capable, so native is allowed.
+    assert vision_tool._native_supported is True
+
+
+class _NoCallLLM:
+    """Vision LLM that must never be called (native strategy proxies nothing)."""
+
+    provider = "openai"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate(self, *args, **kwargs):  # pragma: no cover - must not run
+        self.calls += 1
+        raise AssertionError("native strategy must not call the proxy LLM")
+
+
+@pytest.mark.asyncio
+async def test_native_strategy_attaches_images_without_proxy_call(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    llm = _NoCallLLM()
+    tool = VisionReviewTool(llm=llm, workspace_dir=str(tmp_path), allow_full_access=False)
+
+    result = await tool.execute(
+        image_paths=["slide.png"], strategy="native", instructions="check contrast"
+    )
+
+    assert result.success, result.error
+    assert llm.calls == 0
+    # No report is written in native mode.
+    assert not (tmp_path / "visual_review.md").exists()
+    assert "slide.png" in result.content
+    # Images are handed to the main model as follow-up user content.
+    blocks = result.followup_user_content
+    assert blocks is not None
+    assert "check contrast" in blocks[0]["text"]
+    image_block = next(block for block in blocks if block.get("type") == "image_url")
+    assert image_block["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_native_strategy_uses_anthropic_block_shape(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+
+    class _AnthropicLLM(_NoCallLLM):
+        provider = "anthropic"
+
+    tool = VisionReviewTool(llm=_AnthropicLLM(), workspace_dir=str(tmp_path), allow_full_access=False)
+    result = await tool.execute(image_paths=["slide.png"], strategy="native")
+
+    assert result.success, result.error
+    image_block = next(
+        block for block in result.followup_user_content if block.get("type") == "image"
+    )
+    assert image_block["source"]["media_type"] == "image/png"
+    assert image_block["source"]["type"] == "base64"
+
+
+@pytest.mark.asyncio
+async def test_invalid_strategy_rejected(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    tool = VisionReviewTool(llm=FakeVisionLLM(), workspace_dir=str(tmp_path), allow_full_access=False)
+
+    result = await tool.execute(image_paths=["slide.png"], strategy="bogus")
+
+    assert not result.success
+    assert "strategy" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_proxy_strategy_sets_no_followup_content(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    tool = VisionReviewTool(llm=FakeVisionLLM(), workspace_dir=str(tmp_path), allow_full_access=False)
+
+    result = await tool.execute(image_paths=["slide.png"])  # default proxy
+
+    assert result.success, result.error
+    assert result.followup_user_content is None
+
+
+@pytest.mark.asyncio
+async def test_native_refused_when_main_model_not_vision_capable(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    # native_supported=False models the "text main model + separate vision
+    # utility" routing: images must not be handed to the text main model.
+    tool = VisionReviewTool(
+        llm=FakeVisionLLM(),
+        workspace_dir=str(tmp_path),
+        allow_full_access=False,
+        native_supported=False,
+    )
+
+    native = await tool.execute(image_paths=["slide.png"], strategy="native")
+    assert not native.success
+    assert "proxy" in (native.error or "")
+    assert native.followup_user_content is None
+
+    # proxy still works in the same configuration.
+    proxy = await tool.execute(image_paths=["slide.png"], strategy="proxy")
+    assert proxy.success, proxy.error


### PR DESCRIPTION
vision_review currently proxies screenshots to a separate vision model and returns only text to the main model, so a vision-capable main model never sees the raw pixels. Add a second strategy so both are available:

- proxy (default, unchanged): a side vision call inspects the images and returns a written PASS/ISSUE report.
- native: the tool attaches the raw images directly to the MAIN model's context for its next turn and inspects nothing itself — no side LLM call, no report. Use when the main model can see images and should reason over pixels.

Native delivery uses a new opt-in contract: `ToolResult.followup_user_content` carries provider-shaped content blocks (text + image/image_url). The agent loop accumulates these during tool execution and flushes them as ONE follow-up `user` message at the next step boundary — after every tool result is in place, before the next model call. When no tool sets the field (the default) the loop behaves exactly as before; the field is excluded from serialization so image payloads never bloat host events.

Two correctness constraints handled:

1. Anthropic alternating-turn protocol. Anthropic emits tool results as user turns, so a following user message (the native image attachment — also any injected note) would create two consecutive user turns and be rejected. `AnthropicClient._convert_messages` now coalesces consecutive same-role turns into one, concatenating content (string content normalized to a text block). This fixes native on Anthropic and hardens existing injection paths.

2. native only when the MAIN model is vision-capable. When vision is routed to a separate utility model (the bound main model is text-only), attaching images to the main model would fail. setup passes `native_supported` = "the vision client is the bound main llm"; native returns a clear error pointing to proxy when it is not.

Tests: native tool path (image blocks, no proxy call, Anthropic/OpenAI block shapes, invalid strategy, proxy leaves the field None), native refusal for a text main model while proxy still works (tool- and setup-level), loop delivery (follow-up user message injected after the tool result; absent field is a no-op), and Anthropic consecutive-turn merging.

Note: robustness follow-ups (content-sniffed MIME, no raw-bytes fallback on decode failure, permission-request passthrough) are intentionally left out to keep this PR focused on the two-strategy behavior.

## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

### Design and architecture impact

- Affected layers and owners:
- Contract, schema, or protocol impact:
- Documentation updated:

### Target branch consistency

- Base branch and reviewed Head SHA:
- Relevant target-branch changes considered:
- Rebase, compatibility, or historical-fix risk:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [ ] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [ ] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` passed for the current Head SHA, or the missing status is explained.
