### PR TITLE
feat(pptx): optimize presentation delivery copy and narrow toolbar layout

### DIFF
--- a/box_agent/skills/document-skills/pptx/SKILL.md
+++ b/box_agent/skills/document-skills/pptx/SKILL.md
@@ -215,10 +215,10 @@ the same layout again. Common arrays are `cards-grid-v1.items`,
 8. The controlled theme catalog bundled under `themes/` is the runtime source of truth and includes an executable base theme for all 32 bundled Visual DNA ids. Eleven built-in composition families and their variants are selected and persisted under `design`, so a machine without `html-templates` still has both theme grammar and structural variety. Use `html-templates` as an optional richer matcher when it is available, but never block or invent a theme when it is absent. See §3.0.
 9. The controlled route authors content through the scaffold plus `deck.patch.json`; do not hand-write the full `deck.json` or compiled multi-slide HTML. `scripts/render_deck_html.js` is the only writer of controlled `index.html`. The fragment workflow in §3.5 applies only to an explicit legacy/custom-HTML escape route.
 10. Any PPTX line geometry written by direct generation paths (`PptxGenJS` / OOXML / python-pptx / other direct generators, i.e., not `dom-to-pptx` HTML export) must avoid negative width/height. Normalize line geometry from start/end coordinates (`x1`,`y1`,`x2`,`y2`) into non-negative geometry before writing geometry boxes: `x=min(x1,x2)`, `y=min(y1,y2)`, `w=abs(x2-x1)`, `h=abs(y2-y1)`.
-11. When the task declares `creative_image_mode`, successful image generation is mandatory for a complete delivery: at least one `generate_image` call must complete and the generated asset must be referenced in `assets/generated/manifest.json`. If `generate_image` is unavailable or every call fails, do not present the PPT as completed. When the deck remains structurally renderable, still finalize and deliver an editable degraded `index.html`, label the image requirement `BLOCKED`, and preserve the manifest findings as warnings so the user receives a usable artifact.
+11. When the task declares `creative_image_mode`, successful image generation is mandatory for a complete delivery: at least one `generate_image` call must complete and the generated asset must be referenced in `assets/generated/manifest.json`. If `generate_image` is unavailable or every call fails, do not present the PPT as completed. When the deck remains structurally renderable, still finalize and deliver an editable degraded `index.html`, explain under the localized usage-note label from §6 that the required image was not generated, and preserve the manifest findings as warnings so the user receives a usable artifact.
 12. New decks pass the content & outline gate before any HTML or image work (§1.1). A slide plan is the prerequisite for authoring slides. When the host supplies a `<presentation_config>` block, use each field's `source` to determine its strength: `explicit` values from the user's original request or an actively changed card choice are hard constraints, while `recommended` and `default` values are soft framing that may yield to the source material and original prompt. `confirmed_by=user` alone does not upgrade unchanged soft defaults. Do not ask again for choices already present in the block. For page count, `page_count_auto` and any range whose source is `recommended` or `default` are planning hints only: derive the natural count from independent narrative beats, content density, and any page structure the user supplied; never turn `5-10` into its midpoint or silently default to eight slides. Only a concrete page count or range explicitly stated by the user, including an actively selected range in the card, is hard. The host-facing option catalog lives in `references/presentation-preflight.json`; do not invent incompatible ids. A solution/design brief that names the goal, requested system components, emphasis, and approximate page count is sufficient to author a proposed architecture: keep `source_mode=user_provided`, frame unsupplied details as recommendations, and do not load `research-synthesis` by default. Route to `research-synthesis` only when the deck actually requires external evidence, market/company/policy facts, current data, citations, or source-backed quantitative claims. If two or more audience/scope/direction choices materially change the user-visible deck, call `request_user_decision`; do not present an A/B list only in Markdown. Internal recovery choices such as one-shot versus chunked `write_file` are implementation details: choose the safer path yourself. Do not use `request_user_input` for a missing fact. Search public facts within the selected research route's bounded budget; after that budget is exhausted, omit an optional unsupported claim or use an explicit placeholder such as `待补充`, `待客户确认`, or `暂无可验证公开数据` for a required field. Missing case metrics, quote amounts, contact names, or other user/private values are never pre-delivery blockers: use an explicit placeholder, finish the editable HTML, and summarize the gaps afterward. After a structured decision request, end the turn without deleting or rebuilding any existing outline, scaffold, manifest, or QA output. The user's next reply resumes this same deck from its filesystem checkpoint. (Hard `BLOCKED` is reserved for the `creative_image_mode` image rule above.)
 13. Scaffold the full `deck.json` once, using only exact ids supplied by the current `SCAFFOLD_INPUT`; never guess a theme/layout id or reread the registry when that input is present. Invoke the inspector directly without a pipe, `tail`, redirection, or a second command. After a blocking structural validation fails, patch only the paths named in the fresh report. The patch compiler deterministically reconciles every existing manifest asset to its declared slide id and `prop_path`; a full-slide `background` is always written at slide top level, never under `props`. Once a repair patch has been applied, the old blocking reports are stale: let the filesystem checkpoint invoke `finalize_controlled_deck.js` once instead of separately rerunning validators, render, self-check, and runtime probe. Never apply two repair patches from the same report. If the same refreshed spec issue class recurs twice, stop automatic repair and re-read the existing contract once. Source/URL/private-fact findings never trigger an automatic repair loop: use a neutral formulation, replace a required unavailable fact with an explicit placeholder, or omit the unsupported optional claim, then finish the HTML and summarize the finding afterward. Preserve every outline-bound title exactly plus the page's content anchors. Quantitative anchors may be split naturally across KPI/chart labels and values; do not duplicate a full source sentence in every cell merely to satisfy binding. Choose a neutral, source-safe outline title before scaffolding and place any placeholder in its supporting field. A public-research deck must not expose visible `待补充` for an optional gap; use supported copy instead. Reserve visible placeholders for required unavailable facts. Never rewrite scaffolded fact buckets, regenerate the whole deck, or reset with `--force` to clear validation errors.
-14. Source-bound decks never invent named clients, projects, company/product names, financing rounds or stages, awards, publications, rankings, dates, team origins/sizes/history, project narratives, process steps, or future plans. User-authorized assumptions may support disclosed illustrative metrics or performance scenarios only; they do not authorize invented proper nouns, financing stages, dates, team facts, awards, or documentary claims. In a strict source-only request, factual fields such as statement/support copy, KPI detail, project positioning/caption, timeline step title/body, and card body must copy supplied wording, omit an optional field, or use `待补充` only when a required field is genuinely missing; polished generic prose is still unsupported. Do not infer a funding round, infer a founding year from “third year”, invent a prior team size, or turn missing evidence into generic positive copy such as “复购率持续提升”. Creative image direction permits visual imagination, not factual invention. A generated project/case-study image must use `origin: "generated"` and an explicit concept/placeholder alt or caption. Before authoring, a deep-research deck consumes the workflow-supplied generic `presentation_handoff` contract. A `full` delivery creates the complete sourced deck, `partial` uses only its verified subset and marks or omits gaps, and `framework` creates an editable structure without external factual claims. `validate_outline.js --research-handoff ...` accepts only exact `verified_facts[].canonical` values in `entity | claim | source_type | source_url` form. It does not depend on the upstream validator name or research-skill status fields. Conflicting, unverified, cross-entity, or excerpt-unsupported research never enters `truth_contract.research_facts`. Run `validate_deck_truth.js` only as a post-generation source advisory after `index.html` exists. Its source, URL, or private-fact findings never block HTML delivery, invalidate an otherwise usable deck, or trigger a repair loop; summarize them under `Source` or `Limitations`.
+14. Source-bound decks never invent named clients, projects, company/product names, financing rounds or stages, awards, publications, rankings, dates, team origins/sizes/history, project narratives, process steps, or future plans. User-authorized assumptions may support disclosed illustrative metrics or performance scenarios only; they do not authorize invented proper nouns, financing stages, dates, team facts, awards, or documentary claims. In a strict source-only request, factual fields such as statement/support copy, KPI detail, project positioning/caption, timeline step title/body, and card body must copy supplied wording, omit an optional field, or use an active-language missing-information marker only when a required field is genuinely missing; polished generic prose is still unsupported. Do not infer a funding round, infer a founding year from “third year”, invent a prior team size, or turn missing evidence into generic positive copy such as `复购率持续提升`. Creative image direction permits visual imagination, not factual invention. A generated project/case-study image must use `origin: "generated"` and an explicit concept/placeholder alt or caption. Before authoring, a deep-research deck consumes the workflow-supplied generic `presentation_handoff` contract. A `full` delivery creates the complete sourced deck, `partial` uses only its verified subset and marks or omits gaps, and `framework` creates an editable structure without external factual claims. `validate_outline.js --research-handoff ...` accepts only exact `verified_facts[].canonical` values in `entity | claim | source_type | source_url` form. It does not depend on the upstream validator name or research-skill status fields. Conflicting, unverified, cross-entity, or excerpt-unsupported research never enters `truth_contract.research_facts`. Run `validate_deck_truth.js` only as a post-generation source advisory after `index.html` exists. Its source, URL, or private-fact findings never block HTML delivery, invalidate an otherwise usable deck, or trigger a repair loop; summarize only concrete user impact under the localized usage-note label from §6.
 15. Never create a fake bitmap with Pillow, SVG, a solid fill, or copied placeholder merely to satisfy a media field. If image generation fails, switch to a layout whose media is optional or retain the built-in editable placeholder and record the decision as `failed`/`skip`. In `creative_image_mode`, mark the image requirement blocked and the HTML degraded, but still deliver the structurally valid editable HTML. Never relabel a placeholder as `generated`, and never reuse one placeholder as several supposedly distinct generated images.
 16. Exact user-authored `#RRGGBB` palettes are hard design contracts and outrank color-name paraphrases introduced by the outline. Two or three exact values map deterministically to background, primary, and accent unless the user labels those roles explicitly. Never replace an exact accent such as `#EF4444` with the nearest named red. A user instruction that forbids image generation is also a hard contract: every generated-image decision must remain `skip`, `generation_forbidden` is persisted in the manifest, and image QA must fail if a generated or required image entry reappears.
 
@@ -241,7 +241,7 @@ user order or page count.
 4. plan slide-level image decisions in the scaffolded `assets/generated/manifest.json`. Derive one stable deck context/style anchor from the selected theme and repeat it inside every generated-image prompt; do not add a competing top-level manifest schema. For each declared slot choose `generate`, `use_existing`, or `skip` from the narrative job. In `creative_image_mode`, promote an optional inner-page slot only when that page's visual intent explicitly requests a generative bitmap medium such as a screenshot, photograph, poster, mockup, scene, or object study; do not generate images for ordinary text, cards, data, or diagram pages. A concrete subject normally uses a fixed-frame hero slot; atmosphere may use the slide-level background; typography/data-led pages may skip bitmap media. Prefer one dominant media treatment rather than filling both hero and background without a reason.
 5. call `generate_image` for every `generate` item before final validation. Emit independent image calls together in one assistant tool-call batch; the executor runs this parallel-safe tool concurrently. Do not create a sub-agent merely to wait for image generation—the parent still needs the returned asset paths before manifest binding and QA. Always pass `watermark: false`. Localize every `use_existing` asset. Once the files exist, run `sync_image_manifest_status.js` once instead of manually editing the manifest. Store artifact-root-relative paths in the declared media prop or `slide.background`, and set media `origin` to `generated` or `asset`; the final `deck.json` never contains an unresolved generation request.
 6. fill the scaffolded `deck.json` with one controlled batch patch when practical, then run the checkpoint's single `scripts/finalize_controlled_deck.js deck.json --out index.html` command. The patch compiler first reconciles ready manifest assets to their exact slide/prop bindings. The finalizer treats deck structure and HTML rendering as hard prerequisites, records image-manifest findings as a delivery advisory, compiles HTML, runs HTML self-check and `probe_deck_runtime.js` at `1440x900`, then records source/truth findings as another non-blocking advisory. Once rendering succeeds, a downstream HTML/runtime QA failure is preserved as a degraded advisory and the existing `index.html` is still delivered; it must not start an automatic repair loop or be described as no output. On a blocking structural failure, patch only the named paths. Source/URL/private-fact findings are reported after generation and never start a repair loop. For public-research decks, do not expose `待补充` merely because a nonessential claim was not researched: omit that claim and use supported copy instead. For required unavailable public facts use `暂无可验证公开数据`; for required user/private facts use `待补充` or `待客户确认`, then continue without asking.
-7. `finalize_controlled_deck.js` is the only normal finalization command. Do not hand-edit the compiled HTML, split finalization into separate successful validator/render calls, or add another `output/` prefix. The generated HTML is the default deliverable and includes the controlled editor runtime. A failed core deck schema or render step blocks delivery because no trustworthy HTML can be compiled. Exact outline title/message binding drift is semantic QA: preserve it as a degraded deck-spec warning and still render; do not enter another model repair loop solely for that drift. Image-manifest findings likewise do not suppress HTML; deliver the HTML as degraded and report the image requirement under `Limitations` (or `BLOCKED` when explicitly required). A failed HTML self-check, editor-fit, contrast, or export-geometry report keeps the already-rendered HTML as a degraded draft with the exact QA findings preserved; return that artifact and do not loop. A source/truth advisory with findings does not block or invalidate an existing `index.html`; keep the HTML and summarize those findings afterward.
+7. `finalize_controlled_deck.js` is the only normal finalization command. Do not hand-edit the compiled HTML, split finalization into separate successful validator/render calls, or add another `output/` prefix. The generated HTML is the default deliverable and includes the controlled editor runtime. A failed core deck schema or render step blocks delivery because no trustworthy HTML can be compiled. Exact outline title/message binding drift is semantic QA: preserve it as a degraded deck-spec warning and still render; do not enter another model repair loop solely for that drift. Image-manifest findings likewise do not suppress HTML; deliver the HTML as degraded and explain a missing explicitly required image under the localized usage-note label from §6. A failed HTML self-check, editor-fit, contrast, or export-geometry report keeps the already-rendered HTML as a degraded draft with the exact QA findings preserved; return that artifact and do not loop. A source/truth advisory with findings does not block or invalidate an existing `index.html`; keep the HTML and summarize only its concrete user impact afterward.
 8. When the manifest contains `layout_contract`, run image layout contract validation after finalization.
 9. export with `scripts/html_to_editable_pptx.js` only when the user explicitly requests PPTX, then run PPTX structural QA.
 10. render and inspect when §4.2 triggers apply. Keep `deck.json` beside `index.html` as the reproducible generation source. After in-HTML edits, the saved HTML's embedded `#deck-document` is authoritative for that edited artifact; do not claim that the sibling `deck.json` was synchronized.
@@ -762,19 +762,20 @@ still produce HTML; such output is a degraded delivery, not a clean completion.
 source/URL/private-fact findings, but `"ok": false`, missing sources, or
 unverified claims must not block `index.html`, trigger repair, or prevent the
 workflow from completing. Preserve scaffolded `source_facts` and
-`research_facts`, and summarize advisory findings under `Source` or
-`Limitations`. For spec failures, patch only named paths; if the same issue
+`research_facts`, and summarize only user-impacting advisory findings under the
+localized usage-note label from §6. For spec failures, patch only named paths; if the same issue
 class returns twice, stop automatic repair and follow §0 rule 13. For self-check
 **issues**, retry at most three focused repair rounds; if the issue set stops
 shrinking, stop and report the HTML as a blocked draft rather than looping or
 claiming completion. Warnings are diagnostic: inspect actual clipping/overflow
 or unreadable contrast, but do not loop on font-metric slack warnings alone.
 The self-check aggregates text slack into at most one summary warning per slide;
-record those summaries in `Limitations` rather than treating every text node as
-a separate defect.
-If any required QA report contains warnings, final delivery may say the gates
-passed, but must report the warning count and must not describe the run as
-"clean", "all green", or warning-free.
+record only its concrete user impact under the localized usage-note label rather than treating every
+text node as a separate defect. Keep raw warning counts internal. If required QA
+reports contain warnings, the final delivery must not describe the run as
+"clean", "all green", or warning-free, but it must mention a note only when the
+finding changes how the user should preview, edit, download, or publicly use the
+result.
 If `assets/generated/manifest.json` contains `layout_contract`, `qa/image_layout_contract.json` must exist and pass before HTML self-check.
 
 For every created or modified `.pptx`, additionally run package validation,
@@ -811,7 +812,10 @@ When rendered visual inspection surfaces a problem, classify it before reacting.
 - Abandoning the image plan and rewriting slides text-only
 - Cascading "re-check after fix" loops that surface new cosmetic nits
 
-Cosmetic issues go directly into the `Limitations` section. They do not block delivery, do not justify a route switch, and do not get a repair attempt.
+Cosmetic issues may be summarized under the localized usage-note label only when they can affect
+how the user views or edits the deck. Purely diagnostic findings stay in the QA
+reports and the host's collapsed process details. They do not block delivery,
+do not justify a route switch, and do not get a repair attempt.
 
 ### 4.2 Visual inspection is optional
 
@@ -857,19 +861,69 @@ selected by the runtime. Never add another nested `output/` directory.
 
 ## 6. Final Response Format
 
-Use exact sections in this order:
+The normal user-facing response must be concise and use the active user-visible
+response language. An explicit user language request wins; otherwise follow the
+host `ui_language` instruction when present, then the language of the user's
+task. Never override that contract with a locale-specific default, and do not
+mix headings from one language with body text from another.
 
-1. `Created`
-2. `Source`
-3. `QA`
-4. `Fixes`
-5. `Limitations`
+Present information in this priority order:
+
+1. Start with one plain-language completion sentence using the matching
+   localized completion, editable-draft, or incomplete status below.
+2. Name only the primary user deliverable: the editable presentation, requested
+   PowerPoint export, or requested PDF export. Do not enumerate reproducibility
+   or workflow files.
+3. Add the localized usage-note label only when a finding changes how the user should preview,
+   edit, download, or publicly use the result. Explain the concrete impact and
+   recommended action; omit purely diagnostic findings.
+4. End with concrete next steps in the active response language, for example
+   previewing, downloading, continuing edits, or updating after adding sources.
+5. Add a compact block using the matching localized generation-details heading;
+   the host
+   moves this section into its collapsed details area before the existing
+   generated-files module. Retain QA totals and relevant technical artifacts.
+   Translate fixed checkpoint keys into the matching localized QA labels. Keep artifact
+   names and directories such as `deck.patch.json`, `qa/`, and `research/`
+   literal so the result remains traceable.
+
+Use these stable labels for the host-supported locales. If the user explicitly
+requests another language, translate the same semantic roles consistently:
+
+| Role | `zh` | `en` | `ja` |
+| --- | --- | --- | --- |
+| Complete | `演示文稿已完成` | `Presentation complete` | `プレゼンテーションが完成しました` |
+| Editable draft | `已生成可编辑草稿` | `Editable draft ready` | `編集可能な下書きができました` |
+| Incomplete | `演示文稿尚未完成` | `Presentation not complete` | `プレゼンテーションは未完成です` |
+| Usage note | `使用前注意` | `Before use` | `ご利用前の注意` |
+| Generation details heading | `## 生成详情` | `## Generation details` | `## 生成の詳細` |
+| QA passed label | `质量检查` | `Quality checks` | `品質チェック` |
+| QA notice label | `检查提示` | `Check notices` | `確認事項` |
+
+Never print raw checkpoint key names such as `qa_ok` or `qa_warnings`, internal
+research delivery-mode ids such as `framework` or `partial`, validator names,
+or commands. Their values may be retained only under clear localized labels.
+Technical filenames and report directories remain literal under the localized
+generation-details heading.
+Do not turn a diagnostic count into a user warning: explain it under
+the localized usage-note section only when it changes how the user should use the result.
+
+Translate internal outcomes into user impact:
+
+- When the editable HTML is current and core checks pass, say it can be
+  previewed and edited normally.
+- When source or private-fact advisories exist, make clear that they do not
+  prevent preview/editing and state whether public sharing needs source review.
+- When a usable HTML draft exists but a presentation issue may affect display,
+  use the localized editable-draft status and name the affected use, not the validator.
+- When HTML is usable but a requested PPTX/PDF export is unavailable, deliver
+  the presentation and say only that the requested format has not been exported.
+- When no trustworthy HTML exists, do not claim completion.
 
 If a blocking structural, HTML, runtime, explicitly required image, or export
-step is blocked, write `BLOCKED` for that step while still listing any generated
-HTML under `Created`. Never use `BLOCKED` for a
-source/URL/private-fact advisory; list it under `Source` or `Limitations` after
-delivering the HTML.
+step is blocked, explain the user-visible consequence in the active response
+language. Never treat a
+source/URL/private-fact advisory as a blocked presentation.
 
 ## 7. References
 

--- a/box_agent/skills/document-skills/pptx/references/qa.md
+++ b/box_agent/skills/document-skills/pptx/references/qa.md
@@ -28,7 +28,8 @@ this semantic check is not complete.
 If a spec issue class repeats twice, stop automatic repair and follow the
 structural repair rules in `SKILL.md`. Never start a repair loop for a
 source/truth advisory; keep scaffolded `source_facts`/`research_facts` and
-summarize the advisory under `Source` or `Limitations`.
+summarize only its user-visible impact under the localized usage-note label
+defined in `SKILL.md` §6.
 
 For HTML-first decks exported with `scripts/html_to_editable_pptx.js` and
 `dom-to-pptx`, inspect both the source HTML preview PNGs and the rendered PPTX
@@ -146,12 +147,26 @@ Before final handoff, inspect the output folder.
 
 ## Reporting Format
 
-Use short sections. Put each result on its own line and leave a blank line
-between progress blocks; do not concatenate all QA steps into one paragraph.
+QA reports remain machine-readable files under `qa/`. Retain their summary
+counts and relevant paths under the generation-details heading localized for
+the active response language. Render `qa_ok` and `qa_warnings` with the matching
+QA labels from `SKILL.md` §6; never expose those raw key names.
+Keep technical artifact names such as `deck.patch.json` and directories such as
+`qa/` and `research/` literal. Do not enumerate validator or script names.
 
-1. `Created`: output `.pptx` path.
-2. `Source`: generator script and asset paths.
-3. `QA`: package validation, text extraction, placeholder scan, rendering.
-4. `Fixes`: issues found and corrected.
-5. `Limitations`: blocked renderers, Quick Look-only checks, missing fonts,
-   unsupported objects, or post-generation source/URL/private-fact advisories.
+Translate QA into concise user impact in the active response language:
+
+1. Localized complete status: preview and editing are available and no finding requires
+   user action.
+2. Localized complete status + usage note: preview and editing are available, but a
+   concrete note changes how the result should be published or completed.
+3. Localized editable-draft status: a usable artifact exists, but a named presentation issue
+   may affect display, editing, or export.
+4. Localized incomplete status: no trustworthy primary presentation artifact exists.
+
+Purely structural or diagnostic warnings may contribute to the localized QA
+notice count in generation details, but they do not require a usage-note explanation.
+When a finding matters, state whether it affects preview, editing, download,
+export, or public use and tell the user what action is recommended. Technical
+evidence remains available in the QA files and the host's collapsed process
+details.

--- a/box_agent/skills/document-skills/pptx/runtime/deck.css
+++ b/box_agent/skills/document-skills/pptx/runtime/deck.css
@@ -7490,8 +7490,11 @@ body.deck-thumbnails-visible .deck-thumbnails {
   bottom: 24px;
   z-index: 1000;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
   gap: 6px;
+  width: max-content;
   max-width: calc(100vw - 32px);
   overflow: visible;
   padding: 11px 12px;

--- a/box_agent/workflows/presentation_checkpoint.py
+++ b/box_agent/workflows/presentation_checkpoint.py
@@ -64,6 +64,37 @@ _CONTROLLED_PRESENTATION_REPORTS: Final[tuple[str, ...]] = (
 )
 
 
+def _presentation_delivery_contract(
+    qa_ready: int,
+    qa_warnings: int,
+) -> str:
+    """Return language-aware labels for the user-visible delivery summary."""
+    qa_total = len(_CONTROLLED_PRESENTATION_REPORTS)
+    return (
+        "Use the active user-visible response language: an explicit user language "
+        "request wins, otherwise follow the host ui_language instruction when "
+        "present, then the language of the user's task. Never override that "
+        "contract with a locale-specific default. Select one matching label set: "
+        "ui_language=zh => completion `演示文稿已完成`, editable draft "
+        "`已生成可编辑草稿`, incomplete `演示文稿尚未完成`, usage note "
+        "`使用前注意`, heading `## 生成详情`, "
+        f"QA passed `质量检查：{qa_ready}/{qa_total} 项通过`, "
+        f"QA notices `检查提示：{qa_warnings} 项`; "
+        "ui_language=en => completion `Presentation complete`, editable draft "
+        "`Editable draft ready`, incomplete `Presentation not complete`, usage "
+        "note `Before use`, heading `## Generation details`, "
+        f"QA passed `Quality checks: {qa_ready}/{qa_total} passed`, "
+        f"QA notices `Check notices: {qa_warnings}`; "
+        "ui_language=ja => completion `プレゼンテーションが完成しました`, editable "
+        "draft `編集可能な下書きができました`, incomplete "
+        "`プレゼンテーションは未完成です`, usage note `ご利用前の注意`, heading "
+        "`## 生成の詳細`, "
+        f"QA passed `品質チェック：{qa_ready}/{qa_total} 項目合格`, "
+        f"QA notices `確認事項：{qa_warnings} 件`. If the user explicitly requests "
+        "another language, translate the same semantic roles consistently."
+    )
+
+
 def _newest_file(paths: list[Path]) -> Path | None:
     existing = [path for path in paths if path.is_file()]
     if not existing:
@@ -1774,6 +1805,7 @@ def build_checkpoint_text(
         )
         for name in _CONTROLLED_PRESENTATION_REPORTS
     )
+    delivery_contract = _presentation_delivery_contract(qa_ready, qa_warnings)
 
     outline_report_path = report_dir / "outline_check.json"
     outline_repair_input = (
@@ -1985,27 +2017,39 @@ def build_checkpoint_text(
         if not missing_reports:
             stage = "complete"
             next_action = (
-                "All required QA reports are ok. Stop calling tools and return "
-                "the editable HTML deliverable to the user. "
-                f"The reports contain {qa_warnings} warning(s); state that count "
-                "as pass-with-warnings in Limitations and do not call the run "
-                "clean, all-green, or warning-free when the count is non-zero."
+                "All required presentation checks are complete. Stop calling tools "
+                "and return a concise delivery summary that follows the delivery "
+                "language contract below. Start "
+                "with the user-visible completion state, identify only the primary "
+                "editable presentation, explain only findings that change how the "
+                "user should preview, edit, download, or publicly use it, and end "
+                "with concrete next steps in the same language. Then add a compact "
+                "block with the matching localized generation-details heading; the "
+                "host places it before the existing generated-files module. "
+                "Do not print the raw checkpoint "
+                "keys qa_ok or qa_warnings; use the matching localized QA labels "
+                "from the delivery contract. Retain relevant technical artifact "
+                "names and directories such as deck.patch.json, qa/, and research/ "
+                "literally for traceability. Do not expose validator names, commands, "
+                "or internal research delivery-mode ids such as framework or partial. "
+                "Purely structural or diagnostic warnings belong in the localized QA "
+                "notice count but require no usage-note explanation."
                 + (
                     " Research completed in fallback mode without a validated "
-                    "report. State clearly that a conservative HTML version was "
-                    "generated, that unsupported facts were omitted or marked "
-                    "暂无可验证公开数据, and offer two concrete choices: keep the "
-                    "current version, or continue research / provide data to replace "
-                    "the unavailable facts. Do not label this completed fallback "
-                    "delivery as Created without the limitation."
+                    "report. In the localized usage-note section, say that the editable "
+                    "presentation can be previewed and edited, but some content uses "
+                    "conservative wording because its sources are incomplete. For "
+                    "public sharing, recommend providing data or continuing source "
+                    "verification. Do not expose the fallback mode name."
                     if research_fallback
                     else ""
                 )
                 + (
                     " Research quality did not fully pass, but its fresh report "
-                    f"authorized a {research_delivery_mode} delivery. State that "
-                    "status separately from presentation QA and offer to enrich the "
-                    "verified subset after delivery."
+                    "authorized delivery. In the localized usage-note section, explain that "
+                    "preview and editing are available, while public sharing should "
+                    "use only the verified subset or continue source verification. "
+                    "Do not expose the internal research delivery-mode id."
                     if research_ready and research_delivery_mode != "full"
                     else ""
                 )
@@ -2586,6 +2630,11 @@ def build_checkpoint_text(
         f"qa_warnings={qa_warnings}.\n"
         "Hard rule: never move backward, never recreate an existing deck, and "
         "never pass --force to the scaffold command after downstream artifacts exist.\n"
+        "Visibility rule: raw checkpoint key names and internal mode ids above are "
+        "internal-only. In the user response, use the matching localized labels "
+        "from DELIVERY_CONTRACT. Technical filenames and report directories may be "
+        "retained literally under the localized generation-details heading.\n"
+        f"DELIVERY_CONTRACT={delivery_contract}\n"
         + (f"SCAFFOLD_INPUT={scaffold_input}\n" if scaffold_input is not None else "")
         + (f"IMAGE_INPUT={image_input}\n" if image_input is not None else "")
         + (f"PATCH_INPUT={patch_input}\n" if patch_input is not None else "")

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -35,6 +35,7 @@ from box_agent.workflows.presentation_checkpoint import (
     _deck_spec_failure_is_degradable,
     _image_manifest_failure_is_degradable,
     _outline_repair_input,
+    _presentation_delivery_contract,
     build_checkpoint_text,
     completion_gate_progress_text,
 )
@@ -4604,6 +4605,50 @@ def test_legacy_semantic_and_image_reports_can_resume_through_finalizer(
     assert _deck_spec_failure_is_degradable(spec_report) is False
 
 
+@pytest.mark.parametrize(
+    ("locale", "complete", "details_heading", "qa_passed", "qa_notice"),
+    (
+        (
+            "zh",
+            "演示文稿已完成",
+            "## 生成详情",
+            "质量检查：7/7 项通过",
+            "检查提示：2 项",
+        ),
+        (
+            "en",
+            "Presentation complete",
+            "## Generation details",
+            "Quality checks: 7/7 passed",
+            "Check notices: 2",
+        ),
+        (
+            "ja",
+            "プレゼンテーションが完成しました",
+            "## 生成の詳細",
+            "品質チェック：7/7 項目合格",
+            "確認事項：2 件",
+        ),
+    ),
+)
+def test_presentation_delivery_contract_covers_supported_host_languages(
+    locale,
+    complete,
+    details_heading,
+    qa_passed,
+    qa_notice,
+):
+    contract = _presentation_delivery_contract(7, 2)
+
+    assert f"ui_language={locale}" in contract
+    assert complete in contract
+    assert details_heading in contract
+    assert qa_passed in contract
+    assert qa_notice in contract
+    assert "explicit user language request wins" in contract
+    assert "Never override that contract with a locale-specific default" in contract
+
+
 def test_controlled_presentation_checkpoint_tracks_filesystem_stages(tmp_path):
     gate = CompletionGate(workflow_checkpoint_kind="controlled_presentation")
 
@@ -4818,7 +4863,23 @@ def test_controlled_presentation_checkpoint_tracks_filesystem_stages(tmp_path):
     assert checkpoint is not None
     assert f"{CONTROLLED_PRESENTATION_CHECKPOINT_MARKER}complete" in checkpoint
     assert "qa_warnings=2" in checkpoint
-    assert "pass-with-warnings" in checkpoint
+    assert "active user-visible response language" in checkpoint
+    assert "explicit user language request wins" in checkpoint
+    assert "ui_language=zh" in checkpoint
+    assert "ui_language=en" in checkpoint
+    assert "ui_language=ja" in checkpoint
+    assert "质量检查：7/7 项通过" in checkpoint
+    assert "检查提示：2 项" in checkpoint
+    assert "Quality checks: 7/7 passed" in checkpoint
+    assert "Check notices: 2" in checkpoint
+    assert "品質チェック：7/7 項目合格" in checkpoint
+    assert "確認事項：2 件" in checkpoint
+    assert "matching localized generation-details heading" in checkpoint
+    assert "before the existing generated-files module" in checkpoint
+    assert "deliverable card" not in checkpoint
+    assert "Do not print the raw checkpoint keys qa_ok or qa_warnings" in checkpoint
+    assert "deck.patch.json, qa/, and research/" in checkpoint
+    assert "state that count" not in checkpoint
 
 
 def test_controlled_presentation_checkpoint_ignores_other_task_artifacts(tmp_path):
@@ -4988,7 +5049,12 @@ def test_controlled_checkpoint_completes_with_current_failed_truth_report(tmp_pa
 
     assert f"{CONTROLLED_PRESENTATION_CHECKPOINT_MARKER}complete" in update.text
     assert "qa_warnings=2" in update.text
-    assert "pass-with-warnings" in update.text
+    assert "active user-visible response language" in update.text
+    assert "质量检查：7/7 项通过" in update.text
+    assert "检查提示：2 项" in update.text
+    assert "Quality checks: 7/7 passed" in update.text
+    assert "品質チェック：7/7 項目合格" in update.text
+    assert "state that count" not in update.text
     assert policy.allows_completion_continuation() is False
 
 

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -10180,7 +10180,15 @@ def test_example_validates_and_renders_deterministically(tmp_path: Path) -> None
     assert "outline: 1px solid #A8A8A2" in html
 
 
-def test_toolbar_groups_fit_embedded_editor_viewport(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("viewport_width", "expect_thumbnails"),
+    [(520, False), (1100, True)],
+)
+def test_toolbar_groups_fit_embedded_editor_viewport(
+    tmp_path: Path,
+    viewport_width: int,
+    expect_thumbnails: bool,
+) -> None:
     html_path = tmp_path / "toolbar.html"
     render = _run("render_deck_html.js", str(EXAMPLE), "--out", str(html_path))
     assert render.returncode == 0, render.stderr
@@ -10189,7 +10197,7 @@ def test_toolbar_groups_fit_embedded_editor_viewport(tmp_path: Path) -> None:
         "probe_deck_runtime.js",
         str(html_path),
         "--viewport",
-        "1100x800",
+        f"{viewport_width}x800",
     )
     if probe.returncode != 0 and (
         "Cannot find module 'playwright'" in probe.stderr
@@ -10200,10 +10208,10 @@ def test_toolbar_groups_fit_embedded_editor_viewport(tmp_path: Path) -> None:
     assert probe.returncode == 0, probe.stderr or probe.stdout
     runtime = json.loads(probe.stdout)
     assert runtime["ok"] is True
-    assert runtime["editor"]["thumbnailsVisible"] is True
+    assert runtime["editor"]["thumbnailsVisible"] is expect_thumbnails
     assert runtime["editor"]["toolbar"]["hasOverflow"] is False
     assert runtime["editor"]["toolbar"]["left"] >= 0
-    assert runtime["editor"]["toolbar"]["right"] <= 1100
+    assert runtime["editor"]["toolbar"]["right"] <= viewport_width
     assert runtime["editor"]["toolbarMenus"] == {
         "design": {"available": True, "open": True, "expanded": True},
         "page": {"available": True, "open": True, "expanded": True},

--- a/tests/test_pptx_user_facing_contract.py
+++ b/tests/test_pptx_user_facing_contract.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+
+PPTX_SKILL_ROOT = (
+    Path(__file__).resolve().parents[1]
+    / "box_agent"
+    / "skills"
+    / "document-skills"
+    / "pptx"
+)
+
+
+@pytest.mark.parametrize(
+    ("locale", "complete", "usage_note", "details_heading", "qa_passed", "qa_notice"),
+    (
+        ("zh", "演示文稿已完成", "使用前注意", "## 生成详情", "质量检查", "检查提示"),
+        (
+            "en",
+            "Presentation complete",
+            "Before use",
+            "## Generation details",
+            "Quality checks",
+            "Check notices",
+        ),
+        (
+            "ja",
+            "プレゼンテーションが完成しました",
+            "ご利用前の注意",
+            "## 生成の詳細",
+            "品質チェック",
+            "確認事項",
+        ),
+    ),
+)
+def test_pptx_skill_follows_the_supported_host_language_contract(
+    locale,
+    complete,
+    usage_note,
+    details_heading,
+    qa_passed,
+    qa_notice,
+):
+    skill_text = (PPTX_SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    normalized_skill_text = " ".join(skill_text.split())
+
+    assert "active user-visible response language" in normalized_skill_text
+    assert "An explicit user language request wins" in normalized_skill_text
+    assert "host `ui_language` instruction" in normalized_skill_text
+    assert f"| `{locale}` |" in skill_text.split("| Role ", 1)[1].splitlines()[0]
+    assert complete in skill_text
+    assert usage_note in skill_text
+    assert details_heading in skill_text
+    assert qa_passed in skill_text
+    assert qa_notice in skill_text
+    assert "`deck.patch.json`, `qa/`, and `research/`" in skill_text
+    assert "Use exact sections in this order" not in skill_text
+    assert "must be concise Simplified Chinese" not in skill_text
+
+
+def test_pptx_qa_reference_uses_localized_labels_and_keeps_artifact_paths():
+    qa_text = (PPTX_SKILL_ROOT / "references" / "qa.md").read_text(encoding="utf-8")
+
+    assert "active response language" in qa_text
+    assert "Render `qa_ok` and `qa_warnings` with the matching" in qa_text
+    assert "QA labels from `SKILL.md` §6" in qa_text
+    assert "generation-details heading localized" in qa_text
+    assert "`deck.patch.json`" in qa_text
+    assert "`qa/` and `research/`" in qa_text
+    assert "Simplified-Chinese user impact" not in qa_text


### PR DESCRIPTION
## TPR

### Task

- What changed:
  - Standardized successful PPTX delivery responses around a concise status in the active user-visible language, with only the primary deliverable shown by default.
  - Delivery language now follows this precedence: an explicit user request, then host `ui_language`, then the language of the user task. Stable status, usage-note, generation-details, and QA labels are defined for `zh`, `en`, and `ja`.
  - Added a localized generation-details section that maps internal QA fields to user-facing labels while retaining traceability paths such as `deck.patch.json`, `qa/`, and `research/`.
  - Updated presentation checkpoint completion guidance so raw checkpoint keys, validator commands, and internal research modes are not exposed to users.
  - Updated the controlled presentation toolbar layout to wrap and stay centered in narrow containers instead of overflowing.
  - Added regression coverage for the multilingual delivery contract, checkpoint copy, and toolbar behavior at 520px and 1100px viewport widths.
- Why:
  - The previous `Created/Source/QA/Fixes/Limitations` output and raw QA keys were too technical for users to quickly understand whether a presentation was ready and what to do next.
  - The first localized-copy implementation forced Simplified Chinese and conflicted with the existing ACP/system-prompt language contract for `zh` / `en` / `ja`.
  - Diagnostic warnings should remain implementation details unless they affect previewing, editing, downloading, or public use.
  - Toolbar controls could overflow in narrow embedded editor viewports.
- Affected entry points:
  - PPTX built-in skill instructions and QA reporting reference.
  - Controlled presentation checkpoint completion text.
  - Controlled deck editor toolbar CSS and runtime probe.
  - Regression tests for delivery language, checkpoint copy, and narrow toolbar layout.
- Out of scope:
  - No changes to the deck schema, QA report schema, export protocol, or generation algorithm.
  - No changes to non-PPTX skills, CLI or ACP command interfaces, or configuration.
  - No Office frontend changes for recognizing or rendering localized generation-details headings.

### Proof

- Tests or checks run:
  - Focused language/checkpoint/toolbar/manifest regression set: `17 passed in 5.73s`.
  - Final targeted rerun after restoring the existing source-safety example: `10 passed in 1.02s`.
  - `uv run python -m compileall -q box_agent` passed.
  - `git diff --check` passed.
  - `teamwork/local-ci` passed on current Head `25bb470ab801fefdc4b86749eadfd1be6e93539b`.
  - GitGuardian Security Checks passed with no secrets detected.
- Logs, probes, or manifests:
  - GitHub comparison: 3 commits, 7 files changed, 318 additions, and 52 deletions.
  - GitHub reports that the head is 3 commits ahead and 0 commits behind `main`; the merge base matches the current base SHA.
  - The parameterized runtime viewport probe covers both 520px and 1100px widths and asserts that the toolbar does not overflow.
  - The delivery-contract tests cover localized status, usage-note, generation-details, and QA labels for `zh`, `en`, and `ja`, while asserting that no Simplified-Chinese-only rule remains.
  - The `.understand-anything` knowledge graph was used as a navigation index; its recorded baseline was older than the reviewed Head, so conclusions were verified against current source and tests.
- Not run, with reason:
  - The built wheel was not installed into an Office runtime, the host was not restarted, and no fresh end-to-end Office task was run.
  - `box_agent/skills/_manifest.json` was not regenerated because no built-in skill name, path, frontmatter, or availability metadata changed. `test_generate_skills_manifest.py` passed.

### Risk

- Compatibility:
  - Internal checkpoint state and QA files remain unchanged, but the user-facing output contract changes from English technical sections to concise localized sections.
  - Delivery follows an explicit user language request first, then host `ui_language`, then the language of the user task.
  - Consumers that parse the previous English headings or raw `qa_ok` and `qa_warnings` fields must migrate to the localized generation-details section and per-locale user-facing labels.
- Packaging/runtime impact:
  - Bundled PPTX skill content, presentation checkpoint workflow text, and deck runtime CSS change at runtime.
  - Current-Head local CI, source compilation, package build, focused runtime viewport probes, and contract tests passed.
  - Runtime installation, host restart, and fresh live-task verification remain outstanding.
- Config, secrets, or migration:
  - None.
- Rollback:
  - Revert commits `06a3ced150c2113d495a727982d23b1d98feca47`, `a03005f9366419d809a11bbb4c12cb281f6fd46e`, and `25bb470ab801fefdc4b86749eadfd1be6e93539b`.
- Cross-repository follow-up:
  - The Raccoon Office host should recognize the localized generation-details headings for `zh`, `en`, and `ja` and move that section into collapsed process details before the generated-files module.
  - Verify end-to-end rendering of localized QA labels, conditional usage notes, and explicit user-language overrides in the Office client.

### Design and architecture impact

- Affected layers and owners:
  - Skill policy and documentation: `box_agent/skills/document-skills/pptx/`.
  - Shared controlled-presentation workflow: `box_agent/workflows/presentation_checkpoint.py`.
  - Presentation editor runtime styling: `box_agent/skills/document-skills/pptx/runtime/deck.css`.
  - Regression tests: completion gate, controlled deck runtime, and user-facing contract.
- Contract, schema, or protocol impact:
  - The user-facing completion-copy contract changes and now explicitly composes with the existing host/user language contract.
  - There are no persisted schema, API, MCP, CLI, ACP, or QA report protocol changes.
- Documentation updated:
  - Updated the PPTX `SKILL.md` and `references/qa.md` with the localized delivery and QA reporting contract.

### Target branch consistency

- Base branch and reviewed Head SHA:
  - Base: `Raccoon-Office/Box-Agent@main` at `3a1be8e764415dce2c0497e51250cb7b953e54b8`.
  - Reviewed head: `KRISACHAN/Box-Agent@feat/output-optimization` at `25bb470ab801fefdc4b86749eadfd1be6e93539b`.
- Relevant target-branch changes considered:
  - The branch is based directly on the latest fetched `main`; `main` was not merged into the feature branch.
  - GitHub comparison reports `ahead_by: 3` and `behind_by: 0`, with the merge base equal to the latest `main`.
- Rebase, compatibility, or historical-fix risk:
  - The branch is already aligned with the latest base and required no additional rebase for the current Head.
  - Current-Head local CI and security checks passed.
  - The remaining compatibility risk is limited to hosts or consumers that assume one fixed generation-details heading instead of locale-specific labels.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [x] Shared behavior is implemented in shared workflow policy, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior, including `zh`, `en`, and `ja` delivery paths.
- [x] Broader tests were run for the affected completion-gate, PPTX runtime, skill, and packaging paths through `teamwork/local-ci`.
- [x] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json` (not required: manifest-owned metadata did not change; generator tests passed).
- [x] Packaged runtime impact is stated, including the build/install/probe boundary reached.
- [x] No local config, logs, workspace files, or generated `.understand-anything` graph or cache files are included.
- [x] This branch is based on the latest base `main`; `main` was not merged into the feature branch.
- [x] Design and target-branch consistency evidence is included above.
- [x] `teamwork/local-ci` passed for the current Head SHA.