### PR TITLE
fix: 修正网页摘要模型参数并移除强制截断

### DIFF
--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -54,7 +54,6 @@ from .tools.mcp_tool_search import (
     MCPToolExposureManager,
     ToolSearchTool,
 )
-from .tools.model_tool_context import scoped_model_tool_context
 from .tools.skill_preload import build_active_skills_prompt
 from .tool_result_storage import ToolResultStorage
 from .utils import calculate_display_width
@@ -988,15 +987,6 @@ class Agent:
             context_resource_dedup_enabled=self.context_resource_dedup_enabled,
             tool_exposure_manager=self.mcp_tool_exposure,
             tool_result_storage=self.tool_result_storage,
-        )
-        events = scoped_model_tool_context(
-            events,
-            model=getattr(effective_options.llm, "model", ""),
-            max_output_tokens=getattr(
-                effective_options.llm,
-                "max_output_tokens",
-                0,
-            ),
         )
         async for event in events:
             # Track token usage on Agent instance for backward compat

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -54,6 +54,7 @@ from .tools.mcp_tool_search import (
     MCPToolExposureManager,
     ToolSearchTool,
 )
+from .tools.model_tool_context import scoped_model_tool_context
 from .tools.skill_preload import build_active_skills_prompt
 from .tool_result_storage import ToolResultStorage
 from .utils import calculate_display_width
@@ -936,7 +937,7 @@ class Agent:
         if callable(set_child_negotiator):
             set_child_negotiator(effective_options.permission_negotiator)
 
-        async for event in run_agent_loop(
+        events = run_agent_loop(
             llm=effective_options.llm,
             summary_llm=effective_options.summary_llm,
             messages=self.messages,
@@ -987,7 +988,17 @@ class Agent:
             context_resource_dedup_enabled=self.context_resource_dedup_enabled,
             tool_exposure_manager=self.mcp_tool_exposure,
             tool_result_storage=self.tool_result_storage,
-        ):
+        )
+        events = scoped_model_tool_context(
+            events,
+            model=getattr(effective_options.llm, "model", ""),
+            max_output_tokens=getattr(
+                effective_options.llm,
+                "max_output_tokens",
+                0,
+            ),
+        )
+        async for event in events:
             # Track token usage on Agent instance for backward compat
             if isinstance(event, TokenUsageEvent):
                 self.api_total_tokens = event.total_tokens

--- a/box_agent/mcp_servers/web_extract.py
+++ b/box_agent/mcp_servers/web_extract.py
@@ -20,7 +20,6 @@ from box_agent.tools.base import Tool, ToolResult
 
 
 _SUMMARY_THRESHOLD_CHARS = 5_000
-_SUMMARY_OUTPUT_CHARS = 5_000
 _FETCH_TIMEOUT_SECONDS = 60.0
 _SUMMARY_TIMEOUT_SECONDS = 180.0
 _BLOCKED_DOMAINS = ("youtube.com", "zhihu.com")
@@ -98,12 +97,25 @@ class WebExtractTool(Tool):
                         "current Box-Agent model."
                     ),
                 },
+                "max_output_tokens": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Optional output-token capability for the selected model. "
+                        "The Box-Agent host supplies this from the current session binding."
+                    ),
+                },
             },
             "required": ["url"],
             "additionalProperties": False,
         }
 
-    async def execute(self, url: str, model: str | None = None) -> ToolResult:
+    async def execute(
+        self,
+        url: str,
+        model: str | None = None,
+        max_output_tokens: int | None = None,
+    ) -> ToolResult:
         normalized_url, validation_error = _validate_public_url(url)
         if validation_error:
             return ToolResult(success=False, error=validation_error)
@@ -123,37 +135,41 @@ class WebExtractTool(Tool):
 
         content = result.content.strip()
         if not content:
-            return ToolResult(success=False, error="Fetched page contained no extractable text")
+            return ToolResult(
+                success=False,
+                error="Fetched page contained no extractable text",
+            )
 
         original_chars = len(content)
         effective_model = (model or "").strip() or _current_model_name(self.llm)
         summarized = False
-        summary_error: str | None = None
 
         if original_chars > _SUMMARY_THRESHOLD_CHARS:
             summary, summary_error = await self._summarize(
                 content,
                 normalized_url,
                 requested_model=(model or "").strip(),
+                requested_max_output_tokens=max_output_tokens,
             )
-            if summary:
-                content = _cap_summary(summary)
-                summarized = True
-            else:
-                content = _summary_fallback(content, summary_error)
+            if not summary:
+                return ToolResult(
+                    success=False,
+                    error=summary_error or "Summarization failed",
+                )
+            content = summary
+            summarized = True
 
         metadata = {
             "type": "web_extract",
             "url": normalized_url,
             "final_url": result.final_url,
             "summarized": summarized,
+            "content_truncated": False,
             "model": effective_model if summarized else None,
             "original_chars": original_chars,
             "returned_chars": len(content),
             "from_cache": result.from_cache,
         }
-        if summary_error:
-            metadata["summary_error"] = summary_error
 
         return ToolResult(
             success=True,
@@ -207,19 +223,29 @@ class WebExtractTool(Tool):
         url: str,
         *,
         requested_model: str,
+        requested_max_output_tokens: int | None,
     ) -> tuple[str | None, str | None]:
         if self.llm is None:
             return None, "No LLM is available for summarization"
 
         summary_llm = self.llm
-        if requested_model:
+        summary_model = requested_model or _current_model_name(self.llm)
+        summary_max_output_tokens = _positive_int(requested_max_output_tokens)
+        if summary_max_output_tokens is None:
+            summary_max_output_tokens = _positive_int(
+                getattr(self.llm, "max_output_tokens", None)
+            )
+        if summary_model:
             for_model = getattr(self.llm, "for_model", None)
             if not callable(for_model):
-                return None, f"The current LLM cannot switch to model '{requested_model}'"
+                return None, f"The current LLM cannot select model '{summary_model}'"
             try:
-                summary_llm = for_model(requested_model, max_output_tokens=4096)
+                summary_llm = for_model(
+                    summary_model,
+                    max_output_tokens=summary_max_output_tokens,
+                )
             except Exception as exc:
-                return None, f"Could not select model '{requested_model}': {exc}"
+                return None, f"Could not select model '{summary_model}': {exc}"
 
         messages = [
             Message(
@@ -439,20 +465,7 @@ def _current_model_name(llm: Any | None) -> str | None:
     return model or None
 
 
-def _cap_summary(summary: str) -> str:
-    if len(summary) <= _SUMMARY_OUTPUT_CHARS:
-        return summary
-    return (
-        summary[:_SUMMARY_OUTPUT_CHARS]
-        + "\n\n[Summary truncated to 5,000 characters for context management.]"
-    )
-
-
-def _summary_fallback(content: str, error: str | None) -> str:
-    fallback = content[:_SUMMARY_OUTPUT_CHARS]
-    detail = error or "unknown summarization error"
-    return (
-        fallback
-        + "\n\n[Content truncated to the first 5,000 characters because LLM "
-        + f"summarization was unavailable: {detail}]"
-    )
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value

--- a/box_agent/mcp_servers/web_extract_server.py
+++ b/box_agent/mcp_servers/web_extract_server.py
@@ -62,9 +62,17 @@ def _extractor() -> WebExtractTool:
         "the optional model supplied by the caller. JavaScript is not executed."
     ),
 )
-async def web_extract(url: str, model: str | None = None) -> str:
-    """Fetch one URL and return extracted text or a bounded LLM summary."""
-    result = await _extractor().execute(url=url, model=model)
+async def web_extract(
+    url: str,
+    model: str | None = None,
+    max_output_tokens: int | None = None,
+) -> str:
+    """Fetch one URL and return extracted text or an LLM summary."""
+    result = await _extractor().execute(
+        url=url,
+        model=model,
+        max_output_tokens=max_output_tokens,
+    )
     if not result.success:
         raise ValueError(result.error or "Web extraction failed")
     return result.content or ""

--- a/box_agent/runtime.py
+++ b/box_agent/runtime.py
@@ -19,12 +19,13 @@ from .core import (
 from .events import AgentEvent
 from .loop_guards import CompletionGate
 from .tools.base import Tool, ToolResult
+from .tools.model_tool_context import scoped_model_tool_context
 from .workflows import create_workflow_policy
 
 
 @wraps(_run_agent_loop)
 def run_agent_loop(**kwargs: Any) -> AsyncIterator[AgentEvent]:
-    """Run the kernel with any completion-gate workflow policy composed in."""
+    """Run the kernel with shared workflow and model-tool context composed in."""
     if kwargs.get("workflow_policy") is None:
         completion_gate = kwargs.get("completion_gate")
         kwargs["workflow_policy"] = create_workflow_policy(
@@ -42,7 +43,13 @@ def run_agent_loop(**kwargs: Any) -> AsyncIterator[AgentEvent]:
             ),
             available_tool_names=frozenset(kwargs.get("tools", {})),
         )
-    return _run_agent_loop(**kwargs)
+    llm = kwargs.get("llm")
+    events = _run_agent_loop(**kwargs)
+    return scoped_model_tool_context(
+        events,
+        model=getattr(llm, "model", ""),
+        max_output_tokens=getattr(llm, "max_output_tokens", 0),
+    )
 
 
 async def invoke_tool_with_permissions(

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -64,6 +64,7 @@ from .browser_tool_names import (
     public_browser_tool_text,
 )
 from .mcp_tool_catalog import get_mcp_tool_catalog
+from .model_tool_context import current_model_tool_context
 
 
 def _warn(msg: str) -> None:
@@ -352,6 +353,10 @@ class MCPTool(Tool):
     async def execute(self, **kwargs) -> ToolResult:
         """Execute MCP tool via the session with timeout protection."""
         timeout = self._execute_timeout or _default_timeout_config.execute_timeout
+        is_web_extract = (
+            self._server_name == "box-agent-web-extract"
+            and self._remote_name == "web_extract"
+        )
         browser_runtime_acquired = False
         release_browser_runtime_after_call = False
         concurrency_slot_acquired = False
@@ -380,6 +385,13 @@ class MCPTool(Tool):
                     concurrency_slot_acquired = True
                     waiting_for_concurrency_slot = False
                 call_arguments = {**kwargs, **self._fixed_arguments}
+                if is_web_extract:
+                    model_context = current_model_tool_context()
+                    if model_context is not None:
+                        call_arguments["model"] = model_context.model
+                        call_arguments["max_output_tokens"] = (
+                            model_context.max_output_tokens
+                        )
                 result = await self._session.call_tool(
                     self._remote_name,
                     arguments=call_arguments,

--- a/box_agent/tools/model_tool_context.py
+++ b/box_agent/tools/model_tool_context.py
@@ -1,0 +1,107 @@
+"""Turn-scoped model capabilities available to model-invoked tools."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import TypeVar
+
+
+@dataclass(frozen=True, slots=True)
+class ModelToolContext:
+    model: str
+    max_output_tokens: int
+
+
+_CURRENT_MODEL_TOOL_CONTEXT: ContextVar[ModelToolContext | None] = ContextVar(
+    "box_agent_model_tool_context",
+    default=None,
+)
+
+_EventT = TypeVar("_EventT")
+
+
+def current_model_tool_context() -> ModelToolContext | None:
+    return _CURRENT_MODEL_TOOL_CONTEXT.get()
+
+
+def set_model_tool_context(
+    *,
+    model: object,
+    max_output_tokens: object,
+) -> Token[ModelToolContext | None]:
+    normalized_model = model.strip() if isinstance(model, str) else ""
+    normalized_max_tokens = (
+        max_output_tokens
+        if isinstance(max_output_tokens, int)
+        and not isinstance(max_output_tokens, bool)
+        and max_output_tokens > 0
+        else 0
+    )
+    context = (
+        ModelToolContext(
+            model=normalized_model,
+            max_output_tokens=normalized_max_tokens,
+        )
+        if normalized_model and normalized_max_tokens
+        else None
+    )
+    return _CURRENT_MODEL_TOOL_CONTEXT.set(context)
+
+
+def reset_model_tool_context(token: Token[ModelToolContext | None]) -> None:
+    _CURRENT_MODEL_TOOL_CONTEXT.reset(token)
+
+
+class _ScopedModelToolIterator(AsyncIterator[_EventT]):
+    def __init__(
+        self,
+        events: AsyncIterator[_EventT],
+        *,
+        model: object,
+        max_output_tokens: object,
+    ) -> None:
+        self._events = events.__aiter__()
+        self._model = model
+        self._max_output_tokens = max_output_tokens
+
+    def __aiter__(self) -> "_ScopedModelToolIterator[_EventT]":
+        return self
+
+    async def __anext__(self) -> _EventT:
+        token = set_model_tool_context(
+            model=self._model,
+            max_output_tokens=self._max_output_tokens,
+        )
+        try:
+            return await self._events.__anext__()
+        finally:
+            reset_model_tool_context(token)
+
+    async def aclose(self) -> None:
+        close = getattr(self._events, "aclose", None)
+        if callable(close):
+            await close()
+
+
+def scoped_model_tool_context(
+    events: AsyncIterator[_EventT],
+    *,
+    model: object,
+    max_output_tokens: object,
+) -> AsyncIterator[_EventT]:
+    return _ScopedModelToolIterator(
+        events,
+        model=model,
+        max_output_tokens=max_output_tokens,
+    )
+
+
+__all__ = [
+    "ModelToolContext",
+    "current_model_tool_context",
+    "reset_model_tool_context",
+    "scoped_model_tool_context",
+    "set_model_tool_context",
+]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -33,6 +33,12 @@ from box_agent.tools.mcp_loader import (
     reconnect_auth_failed_mcp_servers_if_token_changed,
     set_mcp_timeout_config,
 )
+from box_agent.tools.model_tool_context import (
+    current_model_tool_context,
+    reset_model_tool_context,
+    scoped_model_tool_context,
+    set_model_tool_context,
+)
 from box_agent.tools.setup import merge_mcp_tools, register_mcp_tools
 from box_agent.tools.base import Tool, ToolResult
 
@@ -385,6 +391,77 @@ class TestMCPToolExecution:
 
         assert result.success is False
         assert result.error == "Query 不能为空。"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "max_output_tokens"),
+        [
+            ("sn-sensenova-6-8-flash-lite", 63_999),
+            ("sn-glm-5-2", 100_000),
+        ],
+    )
+    async def test_web_extract_receives_current_model_capabilities(
+        self,
+        model: str,
+        max_output_tokens: int,
+    ):
+        class FakeSession:
+            arguments = None
+
+            async def call_tool(self, name, arguments):
+                assert name == "web_extract"
+                self.arguments = arguments
+                return SimpleNamespace(content=[], isError=False)
+
+        session = FakeSession()
+        tool = MCPTool(
+            name="web_extract",
+            description="extract",
+            parameters={"type": "object"},
+            session=session,
+            server_name="box-agent-web-extract",
+        )
+        token = set_model_tool_context(
+            model=model,
+            max_output_tokens=max_output_tokens,
+        )
+        try:
+            result = await tool.execute(
+                url="https://example.com",
+                model="model-supplied-wrong-value",
+                max_output_tokens=1,
+            )
+        finally:
+            reset_model_tool_context(token)
+
+        assert result.success is True
+        assert session.arguments == {
+            "url": "https://example.com",
+            "model": model,
+            "max_output_tokens": max_output_tokens,
+        }
+
+    @pytest.mark.asyncio
+    async def test_scoped_model_context_resets_before_yield_and_closes_cross_task(
+        self,
+    ):
+        async def source():
+            context = current_model_tool_context()
+            assert context is not None
+            assert context.model == "sn-glm-5-2"
+            yield "event"
+
+        events = scoped_model_tool_context(
+            source(),
+            model="sn-glm-5-2",
+            max_output_tokens=100_000,
+        )
+
+        assert await events.__anext__() == "event"
+        assert current_model_tool_context() is None
+        close = getattr(events, "aclose")
+        await asyncio.create_task(close())
+        assert current_model_tool_context() is None
 
     @pytest.mark.parametrize(
         "error_value",

--- a/tests/test_sub_agent_tool.py
+++ b/tests/test_sub_agent_tool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from time import perf_counter
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,6 +17,12 @@ from box_agent.schema import LLMResponse, Message, StreamEvent, TokenUsage
 from box_agent.agent import Agent
 from box_agent.tools.base import Tool, ToolResult
 from box_agent.tools.file_tools import ReadTool, WriteTool
+from box_agent.tools.mcp_loader import MCPTool
+from box_agent.tools.model_tool_context import (
+    current_model_tool_context,
+    reset_model_tool_context,
+    set_model_tool_context,
+)
 from box_agent.tools.permissions import CapabilityPolicy, GrantStore, PermissionEngine
 from box_agent.tools.skill_loader import SkillLoader
 from box_agent.tools.sub_agent_tool import SubAgentTool
@@ -1090,6 +1097,96 @@ async def test_sub_agent_forwards_web_search_reference_event():
     assert web_events[0].parent_tool_call_id == "parent-sub-agent"
     assert web_events[0].sub_agent_id.startswith("subagent-")
     assert web_events[0].event.payload["refs"][0]["url"] == "https://example.com"
+
+
+async def test_sub_agent_web_extract_uses_child_model_context(monkeypatch):
+    """Child web extraction must not inherit the surrounding parent model."""
+    from box_agent.schema import FunctionCall, ToolCall
+
+    class FakeSession:
+        arguments = None
+
+        async def call_tool(self, name, arguments):
+            assert name == "web_extract"
+            self.arguments = arguments
+            return SimpleNamespace(
+                content=[SimpleNamespace(text="page content")],
+                isError=False,
+            )
+
+    class ChildLLM:
+        model = "child-model"
+        max_output_tokens = 222
+
+        def __init__(self):
+            self.calls = 0
+
+        async def generate_stream(self, *, messages, tools, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                yield StreamEvent(
+                    type="finish",
+                    finish_reason="tool_use",
+                    tool_calls=[
+                        ToolCall(
+                            id="child-extract-1",
+                            type="function",
+                            function=FunctionCall(
+                                name="web_extract",
+                                arguments={"url": "https://example.com"},
+                            ),
+                        )
+                    ],
+                )
+                return
+            yield StreamEvent(type="text", delta="child summary")
+            yield StreamEvent(type="finish", finish_reason="stop", tool_calls=None)
+
+    session = FakeSession()
+    web_extract = MCPTool(
+        name="web_extract",
+        description="extract",
+        parameters={
+            "type": "object",
+            "properties": {"url": {"type": "string"}},
+            "required": ["url"],
+        },
+        session=session,
+        server_name="box-agent-web-extract",
+    )
+    child_llm = ChildLLM()
+    tool = SubAgentTool(
+        llm=AsyncMock(),
+        parent_tools={"web_extract": web_extract},
+    )
+    monkeypatch.setattr(
+        tool,
+        "_resolve_task_llm",
+        lambda **kwargs: (child_llm, {"mode": "test"}),
+    )
+
+    parent_token = set_model_tool_context(
+        model="parent-model",
+        max_output_tokens=111,
+    )
+    try:
+        result = await tool.execute(
+            task="Extract and summarize the page",
+            required_tools=["web_extract"],
+        )
+        restored_context = current_model_tool_context()
+        assert restored_context is not None
+        assert restored_context.model == "parent-model"
+        assert restored_context.max_output_tokens == 111
+    finally:
+        reset_model_tool_context(parent_token)
+
+    assert result.success is True
+    assert session.arguments == {
+        "url": "https://example.com",
+        "model": "child-model",
+        "max_output_tokens": 222,
+    }
 
 
 async def test_empty_output_returns_error():

--- a/tests/test_web_extract.py
+++ b/tests/test_web_extract.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
 import socket
+from types import SimpleNamespace
 
 import httpx
 import pytest
 
 from box_agent.mcp_servers import web_extract
+
+
+class _SummaryLLM:
+    def __init__(self, model: str = "sn-sensenova-6-8-flash-lite") -> None:
+        self.model = model
+        self.selected: tuple[str, int] | None = None
+
+    def for_model(self, model: str, *, max_output_tokens: int):
+        self.selected = (model, max_output_tokens)
+        return self
+
+    async def generate(self, **kwargs):
+        return SimpleNamespace(content="Summary")
 
 
 def _address_info(address: str, port: int) -> tuple:
@@ -101,11 +115,83 @@ async def test_tool_returns_short_extracted_page_without_summarization(monkeypat
         "url": "https://example.com/start",
         "final_url": "https://example.com/final",
         "summarized": False,
+        "content_truncated": False,
         "model": None,
         "original_chars": 21,
         "returned_chars": 21,
         "from_cache": False,
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_output_tokens", [63_999, 100_000])
+async def test_summary_uses_session_model_output_tokens(max_output_tokens: int) -> None:
+    llm = _SummaryLLM()
+    tool = web_extract.WebExtractTool(llm=llm)
+
+    summary, error = await tool._summarize(
+        "Long page content",
+        "https://example.com/page",
+        requested_model="",
+        requested_max_output_tokens=max_output_tokens,
+    )
+
+    assert error is None
+    assert summary == "Summary"
+    assert llm.selected == (
+        "sn-sensenova-6-8-flash-lite",
+        max_output_tokens,
+    )
+
+
+@pytest.mark.asyncio
+async def test_long_summary_is_returned_without_truncation(monkeypatch) -> None:
+    tool = web_extract.WebExtractTool(llm=_SummaryLLM())
+
+    async def fake_fetch(url: str):
+        return web_extract._FetchedPage(
+            content="p" * 5_001,
+            final_url=url,
+        )
+
+    async def fake_summarize(*args, **kwargs):
+        return "s" * 6_000, None
+
+    monkeypatch.setattr(tool, "_fetch", fake_fetch)
+    monkeypatch.setattr(tool, "_summarize", fake_summarize)
+
+    result = await tool.execute("https://example.com/long")
+
+    assert result.success is True
+    assert result.content.endswith("s" * 6_000)
+    assert "truncated" not in result.content.lower()
+    assert result.raw_output["summarized"] is True
+    assert result.raw_output["content_truncated"] is False
+    assert result.raw_output["returned_chars"] == 6_000
+
+
+@pytest.mark.asyncio
+async def test_summary_failure_returns_tool_error(monkeypatch) -> None:
+    tool = web_extract.WebExtractTool(llm=_SummaryLLM())
+
+    async def fake_fetch(url: str):
+        return web_extract._FetchedPage(
+            content="p" * 5_001,
+            final_url=url,
+        )
+
+    async def fake_summarize(*args, **kwargs):
+        return None, "provider rejected max_tokens"
+
+    monkeypatch.setattr(tool, "_fetch", fake_fetch)
+    monkeypatch.setattr(tool, "_summarize", fake_summarize)
+
+    result = await tool.execute("https://example.com/long")
+
+    assert result.success is False
+    assert result.content == ""
+    assert result.error == "provider rejected max_tokens"
+    assert result.raw_output is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TPR

### Task

- What changed: propagate the active model name and `max_output_tokens` to the bundled `web_extract` MCP summarizer, return complete summaries without the old 5,000-character cap, and scope model-tool context at the shared runtime loop boundary so routed child agents use their own model capabilities.
- Why: the previous summary path could bind the wrong model parameters, forcibly truncate successful summaries, and initially allowed child agents to inherit the parent model context.
- Affected entry points: `Agent.run_events`, the stable `runtime.run_agent_loop` facade, `MCPTool.execute` for `box-agent-web-extract/web_extract`, and the bundled web-extract MCP server.
- Out of scope: changing fetch/SSRF policy, other MCP tool argument handling, provider routing policy, OfficeV3 packaging, or desktop runtime installation.

### Proof

- Tests or checks run:
  - `uv run pytest tests/test_sub_agent_tool.py tests/test_mcp.py tests/test_web_extract.py tests/test_agent_run_options.py -q --tb=short` — `155 passed, 3 skipped` on Head `c430773837cc1da6157c3bd2dc04194a56a85d54`.
  - `uv run python -m compileall -q box_agent` — passed on the reviewed Head.
  - `git diff --check origin/main...origin/pr/80` — passed.
  - GitHub Python 3.10/3.11/3.12 checks, GitGuardian, and `teamwork/local-ci` — success for the reviewed Head.
- Logs, screenshots, probes, or manifests: the regression test uses parent context `parent-model/111` and routed child LLM `child-model/222`, asserts `web_extract` receives the child values, and verifies the parent context is restored afterward.
- Not run, with reason: packaged runtime build/install, OfficeV3 restart, and a fresh desktop task were not run; this review validates source behavior and CI only.

### Risk

- Compatibility: the MCP schema adds optional `max_output_tokens`; existing callers that only pass `url` or `model` remain valid. For long pages, summary failure now returns a tool failure instead of a truncated first-5,000-character fallback.
- Packaging/runtime impact: source changes affect the Box-Agent runtime used by OfficeV3, but no packaged runtime was built or installed in this PR validation. Deployment requires a later runtime rebuild/install and host restart.
- Config, secrets, or migration: no config, credential, data migration, or secret-handling changes. The summarizer continues to use the configured provider/endpoint/auth settings while selecting the session model and output limit.
- Rollback: revert the PR merge commit to restore the prior fixed 4,096-token summary binding and 5,000-character truncation/fallback behavior.
- Cross-repository follow-up: refresh the packaged Box-Agent runtime in OfficeV3 before claiming desktop adoption; no OfficeV3 source change is required by this PR.

### Design and architecture impact

- Affected layers and owners: shared runtime composition boundary, MCP adapter argument projection, and bundled web-extract tool/server.
- Contract, schema, or protocol impact: additive optional MCP parameter `max_output_tokens`; internal `ContextVar` scopes active model capabilities per runtime loop, including nested child loops.
- Documentation updated: no standalone user documentation described the old summary cap; tool schema descriptions, docstrings, and regression tests carry the changed contract.

### Target branch consistency

- Base branch and reviewed Head SHA: `main` at `4a7708a7d90b7c870be3250868fdfcc9534d2b98`; reviewed Head `c430773837cc1da6157c3bd2dc04194a56a85d54`.
- Relevant target-branch changes considered: the merge base equals the current base SHA; the reviewed merge-base diff is the complete PR.
- Rebase, compatibility, or historical-fix risk: no target-branch delta remains to rebase; the follow-up commit moves model context from the outer Agent facade to the shared runtime boundary and adds the exact child-agent regression requested during review.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [x] Shared behavior is implemented in shared runtime logic, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior.
- [x] Broader tests were run for shared runtime, tools, and MCP behavior.
- [x] Documentation impact was assessed; the callable schema/docstrings describe the additive contract and no separate document specified the old cap.
- [x] No built-in Skill or Skill manifest changed.
- [x] Packaged runtime impact and the unverified build/install/live-task boundary are stated above.
- [x] No local config, logs, workspace files, secrets, or generated `.understand-anything` artifacts are included.
- [x] The branch is based on the current `main`; `main` was not merged into the feature branch.
- [x] Design and target-branch consistency evidence is included above.
- [x] `teamwork/local-ci` passed for the current Head SHA.
