### PR TITLE
fix(runtime): harden Python sandbox bootstrap

### DIFF
--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -83,7 +83,7 @@ async def _communicate_sandbox_process(
     """Collect a sandbox bootstrap process without allowing an infinite wait."""
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except TimeoutError as exc:
+    except asyncio.TimeoutError as exc:
         try:
             proc.kill()
         except ProcessLookupError:
@@ -109,7 +109,7 @@ async def _start_sandbox_kernel(
                 asyncio.to_thread(kernel_manager.start_kernel),
                 timeout=timeout,
             )
-    except TimeoutError as exc:
+    except asyncio.TimeoutError as exc:
         async_shutdown = getattr(kernel_manager, "_async_shutdown_kernel", None)
         if callable(async_shutdown):
             try:

--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -11,6 +11,7 @@ import json
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -31,6 +32,12 @@ IS_FROZEN = getattr(sys, "frozen", False)
 # timeout: it discards the (now busy, un-reusable) session so a fresh kernel is
 # built next time, instead of silently returning success with partial/no output.
 KERNEL_EXEC_TIMEOUT = "KERNEL_EXEC_TIMEOUT"
+
+# Environment bootstrap runs before a tool call can return anything to the
+# model or TUI, so every child process needs a hard upper bound. Pip also gets
+# short network retries below; this outer timeout covers resolver/build hangs.
+_SANDBOX_PROBE_TIMEOUT_SECONDS = 30
+_SANDBOX_INSTALL_TIMEOUT_SECONDS = 120
 
 # Default packages installed in the sandbox venv on first startup
 SANDBOX_DEFAULT_PACKAGES = [
@@ -65,6 +72,55 @@ MAX_EXECUTE_CODE_CHARS_DISPLAY = f"{MAX_EXECUTE_CODE_CHARS:,}"
 # User-level directory for packages installed at runtime in frozen mode.
 # Survives across sessions; kept separate from the frozen binary itself.
 RUNTIME_PACKAGES_DIR = Path.home() / ".box-agent" / "runtime-packages"
+
+
+async def _communicate_sandbox_process(
+    proc: asyncio.subprocess.Process,
+    *,
+    operation: str,
+    timeout: float,
+) -> tuple[bytes, bytes]:
+    """Collect a sandbox bootstrap process without allowing an infinite wait."""
+    try:
+        return await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        await proc.communicate()
+        raise RuntimeError(
+            f"{operation} timed out after {timeout:g} seconds"
+        ) from exc
+
+
+async def _start_sandbox_kernel(
+    kernel_manager: Any,
+    *,
+    timeout: float = 30,
+) -> None:
+    """Start a Jupyter kernel without blocking the host event loop forever."""
+    async_start = getattr(kernel_manager, "_async_start_kernel", None)
+    try:
+        if callable(async_start):
+            await asyncio.wait_for(async_start(), timeout=timeout)
+        else:
+            await asyncio.wait_for(
+                asyncio.to_thread(kernel_manager.start_kernel),
+                timeout=timeout,
+            )
+    except TimeoutError as exc:
+        async_shutdown = getattr(kernel_manager, "_async_shutdown_kernel", None)
+        if callable(async_shutdown):
+            try:
+                await asyncio.wait_for(async_shutdown(now=True), timeout=5)
+            except Exception:
+                pass
+        raise RuntimeError(
+            f"Sandbox kernel startup timed out after {timeout:g} seconds"
+        ) from exc
+    except Exception as exc:
+        raise RuntimeError(f"Sandbox kernel startup failed: {exc}") from exc
 
 
 def _kernel_write_guard_setup_code(workspace: Path) -> str:
@@ -310,37 +366,50 @@ class SandboxEnvironment:
         self.venv_dir.parent.mkdir(parents=True, exist_ok=True)
 
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, "-m", "venv", str(self.venv_dir),
+            sys.executable,
+            "-m",
+            "venv",
+            "--without-pip",
+            str(self.venv_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await proc.communicate()
+        stdout, stderr = await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox venv creation",
+            timeout=_SANDBOX_INSTALL_TIMEOUT_SECONDS,
+        )
         if proc.returncode != 0:
             raise RuntimeError(f"Failed to create sandbox venv: {stderr.decode()}")
 
-        # Ensure pip is available (some systems skip it)
-        proc = await asyncio.create_subprocess_exec(
-            str(self.python_path), "-m", "ensurepip", "--upgrade",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        await proc.communicate()
+        # ``uv`` project interpreters may not ship ensurepip. Create the venv
+        # independently, then bootstrap pip through ensurepip or uv.
+        await self._ensure_pip_available(on_progress, None)
 
         if on_progress:
             on_progress("Sandbox environment created.")
 
     async def _install_defaults(self, on_progress: Any = None) -> None:
         """Install default packages into the sandbox venv."""
+        await self._ensure_pip_available(on_progress, None)
         if on_progress:
             on_progress(f"Installing default packages: {', '.join(SANDBOX_DEFAULT_PACKAGES)}...")
 
         proc = await asyncio.create_subprocess_exec(
-            str(self.python_path), "-m", "pip", "install",
-            "--quiet", *SANDBOX_DEFAULT_PACKAGES,
+            *self._venv_install_command(SANDBOX_DEFAULT_PACKAGES),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await proc.communicate()
+        try:
+            stdout, stderr = await _communicate_sandbox_process(
+                proc,
+                operation="Sandbox default package installation",
+                timeout=_SANDBOX_INSTALL_TIMEOUT_SECONDS,
+            )
+        except RuntimeError as exc:
+            if on_progress:
+                on_progress(f"Warning: {exc}")
+            return
         if proc.returncode != 0:
             # Non-fatal: some packages may fail on some platforms
             if on_progress:
@@ -357,20 +426,29 @@ class SandboxEnvironment:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        await proc.communicate()
+        await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox ipykernel probe",
+            timeout=_SANDBOX_PROBE_TIMEOUT_SECONDS,
+        )
         if proc.returncode == 0:
             return
 
         if on_progress:
             on_progress("Installing ipykernel in sandbox...")
 
+        await self._ensure_pip_available(on_progress, None)
+
         proc = await asyncio.create_subprocess_exec(
-            str(self.python_path), "-m", "pip", "install",
-            "--quiet", "ipykernel",
+            *self._venv_install_command(["ipykernel"]),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await proc.communicate()
+        stdout, stderr = await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox ipykernel installation",
+            timeout=_SANDBOX_INSTALL_TIMEOUT_SECONDS,
+        )
         if proc.returncode != 0:
             raise RuntimeError(f"Failed to install ipykernel in sandbox: {stderr.decode()}")
 
@@ -431,19 +509,49 @@ class SandboxEnvironment:
 
         # In bundled-override mode the bundled python may live in a read-only
         # location, so install to RUNTIME_PACKAGES_DIR via --target instead.
-        pip_args = ["-m", "pip", "install", "--quiet", "--disable-pip-version-check"]
         if self._bundled_override:
+            install_command = [
+                str(self.python_path),
+                "-m",
+                "pip",
+                "install",
+                "--quiet",
+                "--disable-pip-version-check",
+                "--timeout",
+                "15",
+                "--retries",
+                "1",
+            ]
             RUNTIME_PACKAGES_DIR.mkdir(parents=True, exist_ok=True)
-            pip_args += ["--target", str(RUNTIME_PACKAGES_DIR), "--no-warn-script-location"]
-        pip_args += missing
+            install_command += [
+                "--target",
+                str(RUNTIME_PACKAGES_DIR),
+                "--no-warn-script-location",
+                *missing,
+            ]
+        else:
+            install_command = self._venv_install_command(missing)
 
         proc = await asyncio.create_subprocess_exec(
-            str(self.python_path), *pip_args,
+            *install_command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
-        stdout, stderr = await proc.communicate()
+        try:
+            stdout, stderr = await _communicate_sandbox_process(
+                proc,
+                operation="Sandbox missing package installation",
+                timeout=_SANDBOX_INSTALL_TIMEOUT_SECONDS,
+            )
+        except RuntimeError:
+            if self._bundled_override:
+                raise
+            if on_progress:
+                on_progress(
+                    "Warning: sandbox missing package installation timed out"
+                )
+            return
         if proc.returncode != 0:
             if self._bundled_override:
                 raise RuntimeError(
@@ -464,6 +572,33 @@ class SandboxEnvironment:
         if on_progress:
             on_progress(f"Re-installed: {', '.join(missing)}")
 
+    def _venv_install_command(self, packages: list[str]) -> list[str]:
+        """Prefer uv for fast local-venv installs, with pip as a fallback."""
+        uv_path = shutil.which("uv")
+        if uv_path is not None:
+            return [
+                uv_path,
+                "pip",
+                "install",
+                "--python",
+                str(self.python_path),
+                "--quiet",
+                *packages,
+            ]
+        return [
+            str(self.python_path),
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--disable-pip-version-check",
+            "--timeout",
+            "15",
+            "--retries",
+            "1",
+            *packages,
+        ]
+
     async def _missing_required_packages(self, env: dict[str, str] | None) -> list[str]:
         missing = []
         for module_name, pip_name in self._REQUIRED_MODULES.items():
@@ -473,7 +608,11 @@ class SandboxEnvironment:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
             )
-            await proc.communicate()
+            await _communicate_sandbox_process(
+                proc,
+                operation=f"Sandbox import probe for {module_name}",
+                timeout=_SANDBOX_PROBE_TIMEOUT_SECONDS,
+            )
             if proc.returncode != 0:
                 missing.append(pip_name)
         return missing
@@ -483,20 +622,68 @@ class SandboxEnvironment:
         on_progress: Any,
         env: dict[str, str] | None,
     ) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            str(self.python_path),
+            "-c",
+            "import pip",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox pip probe",
+            timeout=_SANDBOX_PROBE_TIMEOUT_SECONDS,
+        )
+        if proc.returncode == 0:
+            return
+
         if on_progress:
-            on_progress("Host python: bootstrapping pip...")
+            on_progress("Sandbox Python: bootstrapping pip...")
         proc = await asyncio.create_subprocess_exec(
             str(self.python_path), "-m", "ensurepip", "--upgrade",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
-        stdout, stderr = await proc.communicate()
+        stdout, stderr = await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox ensurepip bootstrap",
+            timeout=_SANDBOX_INSTALL_TIMEOUT_SECONDS,
+        )
+        ensurepip_error = stderr.decode(errors="replace")[:500]
+
         if proc.returncode != 0:
-            raise RuntimeError(
-                "Failed to bootstrap pip for host python sandbox: "
-                f"{stderr.decode(errors='replace')[:500]}"
+            uv_path = shutil.which("uv", path=(env or os.environ).get("PATH"))
+            if uv_path is None:
+                raise RuntimeError(
+                    "Failed to bootstrap pip for sandbox Python with ensurepip, "
+                    "and uv is unavailable: "
+                    f"{ensurepip_error}"
+                )
+            proc = await asyncio.create_subprocess_exec(
+                uv_path,
+                "pip",
+                "install",
+                "--python",
+                str(self.python_path),
+                "pip",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
             )
+            _, uv_stderr = await _communicate_sandbox_process(
+                proc,
+                operation="Sandbox uv pip bootstrap",
+                timeout=_SANDBOX_INSTALL_TIMEOUT_SECONDS,
+            )
+            if proc.returncode != 0:
+                raise RuntimeError(
+                    "Failed to bootstrap pip for sandbox Python with ensurepip "
+                    "or uv: "
+                    f"ensurepip={ensurepip_error}; "
+                    f"uv={uv_stderr.decode(errors='replace')[:500]}"
+                )
 
         proc = await asyncio.create_subprocess_exec(
             str(self.python_path), "-c", "import pip",
@@ -504,10 +691,14 @@ class SandboxEnvironment:
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
-        stdout, stderr = await proc.communicate()
+        stdout, stderr = await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox pip verification",
+            timeout=_SANDBOX_PROBE_TIMEOUT_SECONDS,
+        )
         if proc.returncode != 0:
             raise RuntimeError(
-                "pip is still unavailable after ensurepip: "
+                "pip is still unavailable after bootstrap: "
                 f"{stderr.decode(errors='replace')[:500]}"
             )
 
@@ -748,7 +939,7 @@ class JupyterKernelSession:
         # Create KernelManager with our custom spec
         km = jupyter_client.KernelManager()
         km._kernel_spec = kernel_spec  # Override the kernel spec
-        km.start_kernel()
+        await _start_sandbox_kernel(km)
         self._km = km
         # Register the kernel subprocess PID with the Windows kill-on-close Job
         # Object (no-op off-Windows). jupyter_client 8.x exposes the PID via

--- a/box_agent/tools/runtime.py
+++ b/box_agent/tools/runtime.py
@@ -211,15 +211,30 @@ def _build_python_runtime(
             notes=("Frozen runtime has no separate shell Python executable; use execute_code for Python code execution.",),
         )
 
+    shell_path = (
+        str(shell_python_path)
+        if shell_python_path is not None
+        and _is_executable_file(str(shell_python_path))
+        else None
+    )
     env = sandbox_env or SandboxEnvironment()
     python_path = Path(env.python_path)
     if python_path.is_file() and os.access(python_path, os.X_OK):
         sandbox_path = str(python_path)
-        shell_path = (
-            str(shell_python_path)
-            if shell_python_path is not None and _is_executable_file(str(shell_python_path))
-            else sandbox_path
+        effective_shell_path = shell_path or sandbox_path
+        return SkillRuntime(
+            kind="python",
+            status="available",
+            provider="box_agent",
+            executable_path=effective_shell_path,
+            env_vars={
+                "BOX_AGENT_PYTHON": effective_shell_path,
+                "BOX_AGENT_PYTHON3": effective_shell_path,
+                "BOX_AGENT_SANDBOX_PYTHON": sandbox_path,
+            },
         )
+
+    if shell_path is not None:
         return SkillRuntime(
             kind="python",
             status="available",
@@ -228,8 +243,11 @@ def _build_python_runtime(
             env_vars={
                 "BOX_AGENT_PYTHON": shell_path,
                 "BOX_AGENT_PYTHON3": shell_path,
-                "BOX_AGENT_SANDBOX_PYTHON": sandbox_path,
             },
+            notes=(
+                "Shell Python is available; execute_code will initialize its "
+                "isolated sandbox on first use.",
+            ),
         )
 
     return SkillRuntime(

--- a/tests/test_jupyter_runtime_python.py
+++ b/tests/test_jupyter_runtime_python.py
@@ -13,6 +13,8 @@ from box_agent.tools.jupyter_tool import (
     JupyterKernelSession,
     JupyterSandboxTool,
     SandboxEnvironment,
+    _communicate_sandbox_process,
+    _start_sandbox_kernel,
 )
 
 
@@ -34,6 +36,46 @@ def _clear_python_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "BOX_AGENT_BUNDLED_PYTHON",
     ):
         monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_sandbox_bootstrap_process_timeout_terminates_child() -> None:
+    proc = await jupyter_tool.asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+        stdout=jupyter_tool.asyncio.subprocess.PIPE,
+        stderr=jupyter_tool.asyncio.subprocess.PIPE,
+    )
+
+    with pytest.raises(RuntimeError, match="probe timed out"):
+        await _communicate_sandbox_process(
+            proc,
+            operation="Sandbox test probe",
+            timeout=0.01,
+        )
+
+    assert proc.returncode is not None
+
+
+@pytest.mark.asyncio
+async def test_sandbox_kernel_startup_timeout_is_bounded() -> None:
+    class HangingKernelManager:
+        def __init__(self) -> None:
+            self.shutdown_called = False
+
+        async def _async_start_kernel(self) -> None:
+            await jupyter_tool.asyncio.Event().wait()
+
+        async def _async_shutdown_kernel(self, now: bool = False) -> None:
+            self.shutdown_called = now
+
+    manager = HangingKernelManager()
+
+    with pytest.raises(RuntimeError, match="kernel startup timed out"):
+        await _start_sandbox_kernel(manager, timeout=0.01)
+
+    assert manager.shutdown_called is True
 
 
 def test_sandbox_env_accepts_host_python_on_non_windows(
@@ -155,6 +197,32 @@ def test_required_modules_cover_officev3_provisioned_package_surface() -> None:
         assert required[module_name] == package_name
 
 
+def test_local_sandbox_prefers_uv_for_package_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    uv_path = tmp_path / "bin" / "uv"
+    monkeypatch.setattr(
+        jupyter_tool.shutil,
+        "which",
+        lambda *_args, **_kwargs: str(uv_path),
+    )
+    env = SandboxEnvironment(base_dir=tmp_path / "sandbox")
+
+    command = env._venv_install_command(["pandas", "numpy"])
+
+    assert command == [
+        str(uv_path),
+        "pip",
+        "install",
+        "--python",
+        str(env.python_path),
+        "--quiet",
+        "pandas",
+        "numpy",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_host_python_bootstraps_pip_before_installing_missing_packages(
     monkeypatch: pytest.MonkeyPatch,
@@ -199,6 +267,53 @@ exit 1
 
     assert (python_path.parent / "pip-ready").exists()
     assert (python_path.parent / "ipykernel-ready").exists()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_python_uses_uv_when_ensurepip_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    python_path = tmp_path / "sandbox" / "venv" / "bin" / "python"
+    _write_executable(
+        python_path,
+        """#!/bin/sh
+dir="$(dirname "$0")"
+if [ "$1" = "-c" ] && [ "$2" = "import pip" ]; then
+  [ -f "$dir/pip-ready" ] && exit 0 || exit 1
+fi
+if [ "$1" = "-m" ] && [ "$2" = "ensurepip" ]; then
+  echo "No module named ensurepip" >&2
+  exit 1
+fi
+exit 1
+""",
+    )
+    uv_path = tmp_path / "bin" / "uv"
+    _write_executable(
+        uv_path,
+        """#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--python" ]; then
+    shift
+    python_path="$1"
+    break
+  fi
+  shift
+done
+touch "$(dirname "$python_path")/pip-ready"
+""",
+    )
+    monkeypatch.setattr(
+        jupyter_tool.shutil,
+        "which",
+        lambda *_args, **_kwargs: str(uv_path),
+    )
+    env = SandboxEnvironment(base_dir=tmp_path / "sandbox")
+
+    await env._ensure_pip_available(None, None)
+
+    assert (python_path.parent / "pip-ready").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -105,6 +105,25 @@ def test_cli_shell_python_is_separate_from_execute_code_sandbox(tmp_path: Path) 
     assert ctx.env()["BOX_AGENT_SANDBOX_PYTHON"] == str(sandbox.python_path)
 
 
+def test_cli_shell_python_is_available_before_sandbox_creation(tmp_path: Path) -> None:
+    sandbox = SandboxEnvironment(base_dir=tmp_path / "sandbox")
+    shell_python = tmp_path / "python-runtime" / "bin" / "python3"
+    _make_executable(shell_python)
+
+    ctx = build_skill_runtime_context(
+        sandbox_mode=True,
+        sandbox_env=sandbox,
+        shell_python_path=shell_python,
+        node_runtime_root=tmp_path / "missing-node",
+    )
+
+    assert not sandbox.python_path.exists()
+    assert ctx.get("python").status == "available"
+    assert ctx.env()["BOX_AGENT_PYTHON"] == str(shell_python)
+    assert ctx.env()["BOX_AGENT_PYTHON3"] == str(shell_python)
+    assert "BOX_AGENT_SANDBOX_PYTHON" not in ctx.env()
+
+
 def test_frozen_python_runtime_does_not_inject_fake_path(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("box_agent.tools.runtime.sys.frozen", True, raising=False)
 


### PR DESCRIPTION
## Task

Harden Python sandbox initialization across uv-managed, standard Python, and packaged runtime environments.

- Create the sandbox venv independently of `ensurepip`.
- Bootstrap pip with `ensurepip`, falling back to `uv pip` when necessary.
- Prefer `uv pip` for local sandbox installs when available, while retaining the standard pip fallback.
- Add bounded timeouts for environment creation, package installation, import probes, and Jupyter kernel startup.
- Keep shell Python available before the isolated sandbox has been initialized.
- Export `BOX_AGENT_SANDBOX_PYTHON` only after the sandbox executable exists.

This does not change the sandbox package set or make uv mandatory.

## Proof

- `uv run pytest tests/test_jupyter_runtime_python.py tests/test_skill_runtime.py -q`
  - 54 passed
  - 2 unrelated Python `tarfile` deprecation warnings
- `git diff --check upstream/main...HEAD`
  - Passed
- Branch is rebased on the latest `upstream/main`.

## Risk

- When uv is available on `PATH`, local sandbox package installation now prefers `uv pip`, even for Python interpreters not managed by uv.
- Without uv, installation continues through `python -m pip`.
- Environments with neither `ensurepip` nor uv now fail with an explicit bootstrap error.
- The new 30-second probe/kernel and 120-second installation limits may expose unusually slow environments as timeout failures instead of waiting indefinitely.
- No configuration or data migration is required. Rollback is a normal revert of the commit.