### PR TITLE
feat(skills): support managed builtin skill sources

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1672,8 +1672,21 @@ class BoxACPAgent:
         session_skill_loader = self._skill_loader
         if expert_context is not None and self._skill_loader is not None:
             session_skill_loader = self._skill_loader.with_expert_skill_sources(
-                expert_context.skill_names()
+                [name for name in expert_context.skill_names() if ":" not in name]
             )
+            session_skill_loader.require_skill_refs(
+                expert_context.required_skill_refs(), include_disabled=False
+            )
+        if session_skill_loader is not None:
+            # One ACP session gets an immutable Skill path/version snapshot.
+            session_skill_loader = session_skill_loader.snapshot()
+
+        expert_ref_skills = []
+        if expert_context is not None and session_skill_loader is not None:
+            for ref in expert_context.skill_refs():
+                skill = session_skill_loader.get_skill_by_ref(ref, include_disabled=False)
+                if skill is not None and skill not in expert_ref_skills:
+                    expert_ref_skills.append(skill)
 
         # Build per-session system prompt with conditional mode injection
         system_prompt = self._build_session_prompt(
@@ -1686,6 +1699,11 @@ class BoxACPAgent:
             artifact_mode=artifact_mode,
             follow_up_suggestions_enabled=follow_up_suggestions_enabled,
         )
+        if expert_ref_skills:
+            system_prompt = (
+                f"{system_prompt.rstrip()}\n\n## Expert-bound Skills\n"
+                + "\n\n".join(skill.to_prompt() for skill in expert_ref_skills)
+            )
 
         # Inject memory context (skipped for lightweight utility sessions)
         memory_block: str | None = None
@@ -1697,6 +1715,8 @@ class BoxACPAgent:
                 log.info("session/memory", session_id=session_id, message="Memory context injected")
 
         preloaded_skill_hashes: dict[str, str] = {}
+        for skill in expert_ref_skills:
+            preloaded_skill_hashes[skill.name] = sha256(skill.to_prompt().encode("utf-8")).hexdigest()
         explicitly_allowed_skill_names: set[str] = set()
         blocked_skill_names = (
             FAST_OPTIONAL_SKILLS if execution_profile == "fast" else frozenset()

--- a/box_agent/config.py
+++ b/box_agent/config.py
@@ -326,6 +326,8 @@ class ToolsConfig(BaseModel):
     # Skills
     enable_skills: bool = True
     skills_dir: str = "./skills"
+    skills_manifest_required: bool = False
+    bootstrap_skills_dir: str | None = None
 
     # MCP tools
     enable_mcp: bool = True
@@ -585,6 +587,8 @@ class Config(BaseModel):
             allow_full_access=tools_data.get("allow_full_access", False),
             enable_skills=tools_data.get("enable_skills", True),
             skills_dir=tools_data.get("skills_dir", "./skills"),
+            skills_manifest_required=tools_data.get("skills_manifest_required", False),
+            bootstrap_skills_dir=tools_data.get("bootstrap_skills_dir"),
             enable_mcp=tools_data.get("enable_mcp", True),
             mcp_config_path=tools_data.get("mcp_config_path", "mcp.json"),
             mcp=mcp_config,

--- a/box_agent/experts.py
+++ b/box_agent/experts.py
@@ -753,6 +753,22 @@ class ExpertSessionContext:
                     names.append(name)
         return names
 
+    def skill_refs(self) -> list[str]:
+        return [value for value in self.skill_names() if ":" in value]
+
+    def required_skill_refs(self) -> list[str]:
+        refs: list[str] = []
+        profiles: list[Any] = [self.expert] if self.expert else []
+        if self.team:
+            profiles.extend([self.team.leader, *self.team.members])
+        for profile in profiles:
+            if profile is None:
+                continue
+            for value in getattr(profile, "required_skills", []):
+                if ":" in value and value not in refs:
+                    refs.append(value)
+        return refs
+
     def team_progress_payload(self) -> dict[str, object] | None:
         if not self.team:
             return None

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -319,8 +319,12 @@ async def initialize_base_tools(
             # User skills take priority over builtin on name conflict
             sources = [
                 (user_skills_dir, "user"),
-                (builtin_dir, "builtin"),
+                (builtin_dir, "managed" if config.tools.skills_manifest_required else "builtin"),
             ]
+            if config.tools.bootstrap_skills_dir:
+                bootstrap_dir = Path(config.tools.bootstrap_skills_dir).expanduser()
+                if bootstrap_dir.exists() and bootstrap_dir.resolve() != builtin_dir.resolve():
+                    sources.append((bootstrap_dir.resolve(), "builtin"))
 
             # ACP path: defer discovery to a background task so a directory
             # full of malformed SKILL.md files can't block stdio setup and

--- a/box_agent/tools/skill_loader.py
+++ b/box_agent/tools/skill_loader.py
@@ -557,11 +557,6 @@ class SkillLoader:
         self.parse_errors = []
         orphan_count = 0
         discovered: List[Skill] = []
-        disabled_skill_names = _read_disabled_skill_names(self._skill_settings_path)
-        disabled_skill_refs = _read_disabled_skill_refs(self._skill_settings_path)
-        self._disabled_skill_names = disabled_skill_names
-        self._disabled_skill_refs = disabled_skill_refs
-
         # Reverse order: load lower-priority sources first, then higher-priority
         # ones overwrite by dict assignment.
         for entry in reversed(self._sources):
@@ -603,18 +598,12 @@ class SkillLoader:
 
                 self._all_skills[skill.name] = skill
 
-                if skill.name in disabled_skill_names or (skill.ref and skill.ref in disabled_skill_refs):
-                    self.loaded_skills.pop(skill.name, None)
-                    continue
-
-                self.loaded_skills[skill.name] = skill
-
             # Cache a cheap signature for reload detection. Keep last_mtime for
             # backward compatibility with older tests/debug code that may read it.
             entry.signature = self._source_signature(entry)
             entry.last_mtime = max((mtime for _, mtime, _ in entry.signature), default=0) / 1_000_000_000
 
-        self._skill_settings_signature = self._file_signature(self._skill_settings_path)
+        self._apply_disabled_skill_settings()
         discovered = list(self.loaded_skills.values())
 
         # Aggregate diagnostics: one line total, not one per broken file. The
@@ -890,15 +879,16 @@ class SkillLoader:
         Returns:
             True if a reload was performed, False otherwise.
         """
-        if self._frozen:
-            return False
-        changed = False
-        if hasattr(self, "_skill_settings_path"):
-            if (
-                self._file_signature(self._skill_settings_path)
-                != self._skill_settings_signature
-            ):
-                changed = True
+        settings_changed = hasattr(self, "_skill_settings_path") and (
+            self._file_signature(self._skill_settings_path)
+            != self._skill_settings_signature
+        )
+        if getattr(self, "_frozen", False):
+            if settings_changed:
+                self._apply_disabled_skill_settings()
+            return settings_changed
+
+        changed = settings_changed
         for entry in self._sources:
             current = self._source_signature(entry)
             if current != entry.signature:
@@ -908,6 +898,28 @@ class SkillLoader:
         if changed:
             self.discover_skills()
         return changed
+
+    def _apply_disabled_skill_settings(self) -> None:
+        """Apply current enable/disable settings without rediscovering sources.
+
+        Session snapshots use this to keep a stable skill file/version view while
+        still honoring an updated desktop enable/disable policy on later turns.
+        """
+        self._disabled_skill_names = _read_disabled_skill_names(
+            self._skill_settings_path
+        )
+        self._disabled_skill_refs = _read_disabled_skill_refs(
+            self._skill_settings_path
+        )
+        self.loaded_skills = {
+            name: skill
+            for name, skill in self._all_skills.items()
+            if name not in self._disabled_skill_names
+            and (skill.ref is None or skill.ref not in self._disabled_skill_refs)
+        }
+        self._skill_settings_signature = self._file_signature(
+            self._skill_settings_path
+        )
 
     def get_skill(self, name: str, *, include_disabled: bool = False) -> Optional[Skill]:
         """Get a loaded skill by name."""

--- a/box_agent/tools/skill_loader.py
+++ b/box_agent/tools/skill_loader.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 import yaml
 
 SkillSource = Literal["builtin", "user"]
+SkillDirectorySource = Literal["builtin", "user", "managed"]
 
 MANIFEST_FILENAME = "_manifest.json"
 
@@ -95,6 +96,19 @@ def _read_disabled_skill_names(settings_path: Optional[Path]) -> Set[str]:
     }
 
 
+def _read_disabled_skill_refs(settings_path: Optional[Path]) -> Set[str]:
+    if settings_path is None:
+        return set()
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    raw_refs = data.get("disabledSkillRefs") if isinstance(data, dict) else None
+    if not isinstance(raw_refs, list):
+        return set()
+    return {value for value in raw_refs if isinstance(value, str) and re.match(r"^(builtin|user|hub|bootstrap):[^:]+$", value)}
+
+
 @dataclass
 class Skill:
     """Skill data structure.
@@ -126,6 +140,8 @@ class Skill:
     workflow: Optional[str] = None
     broken: bool = False
     broken_reason: Optional[str] = None
+    ref: Optional[str] = None
+    version_id: Optional[str] = None
 
     def to_prompt(self) -> str:
         """Convert skill to prompt format.
@@ -178,6 +194,8 @@ All files and references in this skill are relative to this directory.
             "workflow": self.workflow,
             "broken": self.broken,
             "broken_reason": self.broken_reason,
+            "ref": self.ref,
+            "version_id": self.version_id,
         }
 
 
@@ -186,7 +204,7 @@ class _SourceEntry:
     """Internal: a single skills source directory with a label."""
 
     directory: Path
-    source: SkillSource
+    source: SkillDirectorySource
     last_mtime: float = 0.0
     signature: Tuple[Tuple[str, int, int], ...] = field(default_factory=tuple)
     # Optional whitelist of skill names. None means "no manifest, accept all".
@@ -195,6 +213,7 @@ class _SourceEntry:
     # Optional manifest-listed SKILL.md paths. None means "scan with rglob".
     manifest_paths: Optional[Tuple[Path, ...]] = None
     manifest_loaded: bool = False
+    manifest_refs: Dict[Path, Tuple[str, Optional[str]]] = field(default_factory=dict)
 
 
 class SkillLoader:
@@ -211,7 +230,7 @@ class SkillLoader:
 
     def __init__(
         self,
-        sources: Optional[List[Tuple[str | Path, SkillSource]] | str | Path] = None,
+        sources: Optional[List[Tuple[str | Path, SkillDirectorySource]] | str | Path] = None,
         skills_dir: Optional[str] = None,
         skill_settings_path: Optional[str | Path] = None,
     ):
@@ -243,10 +262,14 @@ class SkillLoader:
         self._skill_settings_signature: tuple[str, int, int] | None = None
         self.loaded_skills: Dict[str, Skill] = {}
         self._all_skills: Dict[str, Skill] = {}
+        self._skills_by_ref: Dict[str, Skill] = {}
+        self._disabled_skill_names: Set[str] = set()
+        self._disabled_skill_refs: Set[str] = set()
         # Accumulated (path, reason) pairs from the most recent discover_skills
         # run. Reset at the start of each discovery so callers can react to a
         # single pass without seeing stale data from earlier reloads.
         self.parse_errors: List[Tuple[Path, str]] = []
+        self._frozen = False
 
     @staticmethod
     def _parse_skill_name_list(raw_value: object) -> Optional[List[str]]:
@@ -529,11 +552,15 @@ class SkillLoader:
         """Discover skills from all sources; user overrides builtin on name conflict."""
         self.loaded_skills = {}
         self._all_skills = {}
+        self._skills_by_ref = {}
         # Reset per-run parse errors so callers always see the current pass only.
         self.parse_errors = []
         orphan_count = 0
         discovered: List[Skill] = []
         disabled_skill_names = _read_disabled_skill_names(self._skill_settings_path)
+        disabled_skill_refs = _read_disabled_skill_refs(self._skill_settings_path)
+        self._disabled_skill_names = disabled_skill_names
+        self._disabled_skill_refs = disabled_skill_refs
 
         # Reverse order: load lower-priority sources first, then higher-priority
         # ones overwrite by dict assignment.
@@ -544,16 +571,28 @@ class SkillLoader:
             # Manifest only applies to builtin sources. For user skills we
             # never want to hide SKILL.md files the user (or officev3) dropped
             # in at runtime.
-            if entry.source == "builtin":
+            if entry.source in ("builtin", "managed"):
                 self._load_manifest(entry)
 
             for skill_file in self._iter_skill_files(entry):
-                skill = self.load_skill(skill_file, source=entry.source)
+                skill = self.load_skill(skill_file, source="builtin" if entry.source == "managed" else entry.source)
                 if skill is None:
                     continue
 
+                identity = entry.manifest_refs.get(skill_file.resolve())
+                if entry.source == "managed" and identity:
+                    skill.ref = f"builtin:{identity[0]}"
+                    skill.version_id = identity[1]
+                elif entry.source == "builtin":
+                    skill.ref = f"bootstrap:{skill.name}"
+                elif entry.source == "user":
+                    skill.ref = self._user_skill_ref(skill_file.parent, skill.name)
+
+                if skill.ref:
+                    self._skills_by_ref[skill.ref] = skill
+
                 if (
-                    entry.source == "builtin"
+                    entry.source in ("builtin", "managed")
                     and entry.manifest_names is not None
                     and skill.name not in entry.manifest_names
                 ):
@@ -564,7 +603,7 @@ class SkillLoader:
 
                 self._all_skills[skill.name] = skill
 
-                if skill.name in disabled_skill_names:
+                if skill.name in disabled_skill_names or (skill.ref and skill.ref in disabled_skill_refs):
                     self.loaded_skills.pop(skill.name, None)
                     continue
 
@@ -602,6 +641,23 @@ class SkillLoader:
 
         return discovered
 
+    @staticmethod
+    def _user_skill_ref(skill_dir: Path, name: str) -> str:
+        for filename in (".skill-installation.json", ".installation.json"):
+            try:
+                raw = json.loads((skill_dir / filename).read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(raw, dict):
+                installation_id = raw.get("installationId")
+                source = raw.get("source")
+                if isinstance(installation_id, str) and installation_id:
+                    skill_id = raw.get("skillId")
+                    if source == "hub" and isinstance(skill_id, str) and skill_id:
+                        return f"hub:{skill_id}"
+                    return f"user:{installation_id}"
+        return f"user:{name}"
+
     def _skill_pool(self, include_disabled: bool = False) -> Dict[str, Skill]:
         if include_disabled:
             return getattr(self, "_all_skills", self.loaded_skills) or self.loaded_skills
@@ -616,7 +672,7 @@ class SkillLoader:
         officev3-authored skills are picked up without regenerating a manifest.
         """
         if (
-            entry.source == "builtin"
+            entry.source in ("builtin", "managed")
             and entry.manifest_names is not None
             and entry.manifest_paths is not None
         ):
@@ -627,15 +683,15 @@ class SkillLoader:
     def _load_manifest(self, entry: _SourceEntry) -> None:
         """Populate ``entry.manifest_names`` from ``_manifest.json`` if present.
 
-        Missing manifest → ``manifest_names`` stays ``None`` (no filtering),
-        preserving backward compatibility with builtin skills directories that
-        pre-date the manifest (dev trees, third-party bundles, etc.).
+        Managed sources fail closed. Legacy packaged builtin sources retain
+        compatibility with development trees that pre-date manifests.
         """
 
         manifest_path = entry.directory / MANIFEST_FILENAME
         if not manifest_path.is_file():
-            entry.manifest_names = None
-            entry.manifest_paths = None
+            entry.manifest_names = set() if entry.source == "managed" else None
+            entry.manifest_paths = tuple() if entry.source == "managed" else None
+            entry.manifest_refs = {}
             entry.manifest_loaded = True
             return
 
@@ -644,10 +700,11 @@ class SkillLoader:
         except (OSError, json.JSONDecodeError) as exc:
             _warn(
                 f"⚠️  Failed to read builtin skills manifest at {manifest_path}: {exc}. "
-                f"Falling back to unfiltered discovery."
+                f"{'Loading zero managed skills.' if entry.source == 'managed' else 'Falling back to unfiltered discovery.'}"
             )
-            entry.manifest_names = None
-            entry.manifest_paths = None
+            entry.manifest_names = set() if entry.source == "managed" else None
+            entry.manifest_paths = tuple() if entry.source == "managed" else None
+            entry.manifest_refs = {}
             entry.manifest_loaded = True
             return
 
@@ -655,31 +712,75 @@ class SkillLoader:
         if not isinstance(raw_skills, list):
             _warn(
                 f"⚠️  Builtin skills manifest {manifest_path} is malformed "
-                f"(missing 'skills' list); falling back to unfiltered discovery."
+                f"(missing 'skills' list)."
             )
-            entry.manifest_names = None
-            entry.manifest_paths = None
+            entry.manifest_names = set() if entry.source == "managed" else None
+            entry.manifest_paths = tuple() if entry.source == "managed" else None
+            entry.manifest_refs = {}
             entry.manifest_loaded = True
             return
 
         names: Set[str] = set()
         paths: list[Path] = []
+        refs: Dict[Path, Tuple[str, Optional[str]]] = {}
         all_paths_known = True
+        ids: Set[str] = set()
+        invalid = False
+        root = entry.directory.resolve()
         for item in raw_skills:
             if isinstance(item, dict) and isinstance(item.get("name"), str):
+                name = item["name"].strip()
+                raw_id = item.get("id")
+                if not name or name in names or (raw_id is not None and (not isinstance(raw_id, str) or not raw_id or raw_id in ids)):
+                    invalid = True
+                    break
                 if not self._manifest_item_is_available(item):
                     continue
-                names.add(item["name"])
+                names.add(name)
+                if isinstance(raw_id, str):
+                    ids.add(raw_id)
                 raw_path = item.get("path")
                 if isinstance(raw_path, str) and raw_path.strip():
-                    paths.append(entry.directory / raw_path)
+                    if entry.source == "managed" and ("\\" in raw_path or Path(raw_path).is_absolute()):
+                        invalid = True
+                        break
+                    candidate = (entry.directory / raw_path).resolve()
+                    try:
+                        candidate.relative_to(root)
+                    except ValueError:
+                        invalid = True
+                        break
+                    if entry.source == "managed" and (candidate.name != "SKILL.md" or not candidate.is_file()):
+                        invalid = True
+                        break
+                    paths.append(candidate)
+                    if entry.source == "managed" and isinstance(raw_id, str):
+                        version_id = item.get("versionId")
+                        refs[candidate] = (raw_id, version_id if isinstance(version_id, str) else None)
                 else:
+                    if entry.source == "managed":
+                        invalid = True
+                        break
                     all_paths_known = False
             elif isinstance(item, str):
+                if entry.source == "managed" or item in names:
+                    invalid = True
+                    break
                 names.add(item)
                 all_paths_known = False
+            else:
+                invalid = True
+                break
+        if invalid:
+            _warn(f"⚠️  Managed skills manifest {manifest_path} is invalid; loading zero managed skills.")
+            entry.manifest_names = set()
+            entry.manifest_paths = tuple()
+            entry.manifest_refs = {}
+            entry.manifest_loaded = True
+            return
         entry.manifest_names = names
         entry.manifest_paths = tuple(paths) if all_paths_known else None
+        entry.manifest_refs = refs
         entry.manifest_loaded = True
 
     @staticmethod
@@ -747,7 +848,7 @@ class SkillLoader:
             candidates.append(manifest)
 
         if (
-            entry.source == "builtin"
+            entry.source in ("builtin", "managed")
             and entry.manifest_names is not None
             and entry.manifest_paths is not None
         ):
@@ -789,6 +890,8 @@ class SkillLoader:
         Returns:
             True if a reload was performed, False otherwise.
         """
+        if self._frozen:
+            return False
         changed = False
         if hasattr(self, "_skill_settings_path"):
             if (
@@ -809,6 +912,32 @@ class SkillLoader:
     def get_skill(self, name: str, *, include_disabled: bool = False) -> Optional[Skill]:
         """Get a loaded skill by name."""
         return self._skill_pool(include_disabled=include_disabled).get(name)
+
+    def get_skill_by_ref(self, ref: str, *, include_disabled: bool = False) -> Optional[Skill]:
+        skill = self._skills_by_ref.get(ref)
+        if skill is None:
+            return None
+        if not include_disabled and (
+            ref in self._disabled_skill_refs or skill.name in self._disabled_skill_names
+        ):
+            return None
+        return skill
+
+    def require_skill_refs(self, refs: List[str], *, include_disabled: bool = False) -> None:
+        missing = [ref for ref in refs if not self.get_skill_by_ref(ref, include_disabled=include_disabled)]
+        if missing:
+            raise ValueError("依赖的 Skill 当前不可用: " + ", ".join(missing))
+
+    def snapshot(self) -> "SkillLoader":
+        clone = SkillLoader(sources=[(entry.directory, entry.source) for entry in self._sources], skill_settings_path=self._skill_settings_path)
+        clone.loaded_skills = dict(self.loaded_skills)
+        clone._all_skills = dict(self._all_skills)
+        clone._skills_by_ref = dict(self._skills_by_ref)
+        clone._disabled_skill_names = set(self._disabled_skill_names)
+        clone._disabled_skill_refs = set(self._disabled_skill_refs)
+        clone._skill_settings_signature = self._skill_settings_signature
+        clone._frozen = True
+        return clone
 
     def list_skills(self, *, include_disabled: bool = False) -> List[str]:
         """List all loaded skill names."""
@@ -989,7 +1118,7 @@ class SkillLoader:
                 # one of these.
                 broken_prefix = "⚠️ " if skill.broken else ""
                 prompt_parts.append(
-                    f"- {broken_prefix}`{skill.name}` ({skill.source}): {skill.description}{routing_suffix}"
+                    f"- {broken_prefix}`{skill.ref or skill.name}` ({skill.source}, name={skill.name}): {skill.description}{routing_suffix}"
                 )
 
         return "\n".join(prompt_parts)

--- a/box_agent/tools/skill_tool.py
+++ b/box_agent/tools/skill_tool.py
@@ -83,9 +83,10 @@ class GetSkillTool(Tool):
         # Auto-reload if the user skills directory has been touched since last scan
         self.skill_loader.maybe_reload()
 
-        skill = self.skill_loader.get_skill(
-            skill_name,
-            include_disabled=self.include_disabled,
+        skill = (
+            self.skill_loader.get_skill_by_ref(skill_name, include_disabled=self.include_disabled)
+            if ":" in skill_name
+            else self.skill_loader.get_skill(skill_name, include_disabled=self.include_disabled)
         )
 
         if not skill:

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -566,6 +566,35 @@ def test_skill_settings_change_triggers_reload():
         assert loader.get_skill("toggle-skill") is None
 
 
+def test_frozen_snapshot_refreshes_settings_without_reloading_skill_content(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "toggle-skill"
+    skill_dir.mkdir(parents=True)
+    create_test_skill(skill_dir, "toggle-skill", "toggle desc", "original content")
+    settings_path = tmp_path / "skill-settings.json"
+    settings_path.write_text('{"disabledSkillNames":[]}', encoding="utf-8")
+
+    loader = SkillLoader(skills_dir, skill_settings_path=settings_path)
+    loader.discover_skills()
+    frozen = loader.snapshot()
+
+    settings_path.write_text(
+        '{"disabledSkillNames":["toggle-skill"]}', encoding="utf-8"
+    )
+    assert frozen.maybe_reload() is True
+    assert frozen.get_skill("toggle-skill") is None
+
+    create_test_skill(skill_dir, "toggle-skill", "new desc", "new content")
+    assert frozen.maybe_reload() is False
+
+    settings_path.write_text('{"disabledSkillNames":[]}', encoding="utf-8")
+    assert frozen.maybe_reload() is True
+    restored = frozen.get_skill("toggle-skill")
+    assert restored is not None
+    assert restored.description == "toggle desc"
+    assert "original content" in restored.content
+
+
 def test_missing_manifest_fails_closed():
     """No manifest in a builtin dir must load zero managed skills."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -626,15 +655,30 @@ def test_managed_manifest_exposes_stable_ref_and_snapshot_pins_version(tmp_path)
         }),
         encoding="utf-8",
     )
-    loader = SkillLoader(sources=[(builtin_dir, "managed")])
+    settings_path = tmp_path / "skill-settings.json"
+    settings_path.write_text('{"disabledSkillRefs":[]}', encoding="utf-8")
+    loader = SkillLoader(
+        sources=[(builtin_dir, "managed")],
+        skill_settings_path=settings_path,
+    )
     loader.discover_skills()
     skill = loader.get_skill_by_ref("builtin:skill-id")
     assert skill is not None
     assert skill.version_id == "version-id"
     frozen = loader.snapshot()
+
+    settings_path.write_text(
+        '{"disabledSkillRefs":["builtin:skill-id"]}', encoding="utf-8"
+    )
+    assert frozen.maybe_reload() is True
+    assert frozen.get_skill_by_ref("builtin:skill-id") is None
+
     (builtin_dir / "_manifest.json").unlink()
-    assert frozen.maybe_reload() is False
-    assert frozen.get_skill_by_ref("builtin:skill-id").skill_path == skill.skill_path
+    settings_path.write_text('{"disabledSkillRefs":[]}', encoding="utf-8")
+    assert frozen.maybe_reload() is True
+    restored = frozen.get_skill_by_ref("builtin:skill-id")
+    assert restored is not None
+    assert restored.skill_path == skill.skill_path
 
 
 def test_required_stable_ref_never_falls_back_to_same_name(tmp_path):

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -343,7 +343,7 @@ def test_builtin_manifest_filters_orphan_skills():
             create_test_skill(sd, name, f"{name} desc", f"{name} content")
         _write_manifest(builtin_dir, ["kept"])
 
-        loader = SkillLoader(sources=[(builtin_dir, "builtin")])
+        loader = SkillLoader(sources=[(builtin_dir, "managed")])
         loader.discover_skills()
 
         assert loader.get_skill("kept") is not None
@@ -404,7 +404,7 @@ def test_builtin_manifest_reload_signature_ignores_resource_files():
         asset.write_text("bundle v1", encoding="utf-8")
         _write_manifest(builtin_dir, ["kept"])
 
-        loader = SkillLoader(sources=[(builtin_dir, "builtin")])
+        loader = SkillLoader(sources=[(builtin_dir, "managed")])
         loader.discover_skills()
 
         asset.write_text("bundle v2 with unrelated resource changes", encoding="utf-8")
@@ -566,8 +566,8 @@ def test_skill_settings_change_triggers_reload():
         assert loader.get_skill("toggle-skill") is None
 
 
-def test_missing_manifest_falls_back_to_unfiltered():
-    """No manifest in builtin dir → behave like before (load everything)."""
+def test_missing_manifest_fails_closed():
+    """No manifest in a builtin dir must load zero managed skills."""
     with tempfile.TemporaryDirectory() as tmpdir:
         builtin_dir = Path(tmpdir) / "builtin"
         builtin_dir.mkdir()
@@ -577,14 +577,14 @@ def test_missing_manifest_falls_back_to_unfiltered():
         create_test_skill(sd, "any-skill", "x", "x")
         # no _manifest.json written
 
-        loader = SkillLoader(sources=[(builtin_dir, "builtin")])
+        loader = SkillLoader(sources=[(builtin_dir, "managed")])
         loader.discover_skills()
 
-        assert loader.get_skill("any-skill") is not None
+        assert loader.get_skill("any-skill") is None
 
 
-def test_malformed_manifest_falls_back_to_unfiltered():
-    """Malformed manifest → warn + load everything (don't break startup)."""
+def test_malformed_manifest_fails_closed():
+    """Malformed builtin manifest must not expose orphan packages."""
     with tempfile.TemporaryDirectory() as tmpdir:
         builtin_dir = Path(tmpdir) / "builtin"
         builtin_dir.mkdir()
@@ -594,7 +594,123 @@ def test_malformed_manifest_falls_back_to_unfiltered():
         create_test_skill(sd, "any-skill", "x", "x")
         (builtin_dir / "_manifest.json").write_text("not json {", encoding="utf-8")
 
-        loader = SkillLoader(sources=[(builtin_dir, "builtin")])
+        loader = SkillLoader(sources=[(builtin_dir, "managed")])
         loader.discover_skills()
 
-        assert loader.get_skill("any-skill") is not None
+        assert loader.get_skill("any-skill") is None
+
+
+def test_manifest_path_escape_fails_closed(tmp_path):
+    builtin_dir = tmp_path / "builtin"
+    outside = tmp_path / "outside"
+    builtin_dir.mkdir()
+    outside.mkdir()
+    create_test_skill(outside, "escaped", "x", "x")
+    (builtin_dir / "_manifest.json").write_text(
+        json.dumps({"schemaVersion": 2, "skills": [{"id": "id", "name": "escaped", "path": "../outside/SKILL.md"}]}),
+        encoding="utf-8",
+    )
+    loader = SkillLoader(sources=[(builtin_dir, "managed")])
+    assert loader.discover_skills() == []
+
+
+def test_managed_manifest_exposes_stable_ref_and_snapshot_pins_version(tmp_path):
+    builtin_dir = tmp_path / "managed"
+    skill_dir = builtin_dir / "packages" / "skill-id" / "version-id"
+    skill_dir.mkdir(parents=True)
+    create_test_skill(skill_dir, "stable", "x", "x")
+    (builtin_dir / "_manifest.json").write_text(
+        json.dumps({
+            "schemaVersion": 2,
+            "skills": [{"id": "skill-id", "name": "stable", "versionId": "version-id", "path": "packages/skill-id/version-id/SKILL.md"}],
+        }),
+        encoding="utf-8",
+    )
+    loader = SkillLoader(sources=[(builtin_dir, "managed")])
+    loader.discover_skills()
+    skill = loader.get_skill_by_ref("builtin:skill-id")
+    assert skill is not None
+    assert skill.version_id == "version-id"
+    frozen = loader.snapshot()
+    (builtin_dir / "_manifest.json").unlink()
+    assert frozen.maybe_reload() is False
+    assert frozen.get_skill_by_ref("builtin:skill-id").skill_path == skill.skill_path
+
+
+def test_required_stable_ref_never_falls_back_to_same_name(tmp_path):
+    user_dir = tmp_path / "user"
+    user_skill = user_dir / "stable"
+    user_skill.mkdir(parents=True)
+    create_test_skill(user_skill, "stable", "user", "user")
+    loader = SkillLoader(sources=[(user_dir, "user")])
+    loader.discover_skills()
+    with pytest.raises(ValueError, match="依赖的 Skill 当前不可用"):
+        loader.require_skill_refs(["builtin:missing"])
+
+
+def test_stable_ref_resolves_exact_source_when_user_and_managed_names_collide(tmp_path):
+    user_dir = tmp_path / "user"
+    user_skill = user_dir / "stable"
+    user_skill.mkdir(parents=True)
+    create_test_skill(user_skill, "stable", "user", "user content")
+
+    managed_dir = tmp_path / "managed"
+    managed_skill = managed_dir / "packages" / "managed-id" / "version-id"
+    managed_skill.mkdir(parents=True)
+    create_test_skill(managed_skill, "stable", "managed", "managed content")
+    (managed_dir / "_manifest.json").write_text(
+        json.dumps({
+            "schemaVersion": 2,
+            "skills": [{
+                "id": "managed-id", "name": "stable", "versionId": "version-id",
+                "path": "packages/managed-id/version-id/SKILL.md",
+            }],
+        }),
+        encoding="utf-8",
+    )
+
+    loader = SkillLoader(sources=[(user_dir, "user"), (managed_dir, "managed")])
+    loader.discover_skills()
+    assert "user content" in loader.get_skill("stable").content
+    exact = loader.get_skill_by_ref("builtin:managed-id")
+    assert exact is not None
+    assert "managed content" in exact.content
+    loader.require_skill_refs(["builtin:managed-id"])
+
+
+def test_managed_skill_takes_over_bootstrap_and_bootstrap_remains_offline_fallback(tmp_path):
+    managed_dir = tmp_path / "managed"
+    managed_skill = managed_dir / "packages" / "managed-id" / "version-id"
+    managed_skill.mkdir(parents=True)
+    create_test_skill(managed_skill, "shared", "managed", "managed content")
+    (managed_dir / "_manifest.json").write_text(
+        json.dumps({
+            "schemaVersion": 2,
+            "skills": [{
+                "id": "managed-id",
+                "name": "shared",
+                "versionId": "version-id",
+                "path": "packages/managed-id/version-id/SKILL.md",
+            }],
+        }),
+        encoding="utf-8",
+    )
+
+    bootstrap_dir = tmp_path / "bootstrap"
+    bootstrap_skill = bootstrap_dir / "shared"
+    bootstrap_skill.mkdir(parents=True)
+    create_test_skill(bootstrap_skill, "shared", "bootstrap", "bootstrap content")
+    (bootstrap_dir / "_manifest.json").write_text(
+        json.dumps({"skills": [{"name": "shared", "path": "shared/SKILL.md"}]}),
+        encoding="utf-8",
+    )
+
+    loader = SkillLoader(sources=[(managed_dir, "managed"), (bootstrap_dir, "builtin")])
+    loader.discover_skills()
+    assert loader.get_skill("shared").ref == "builtin:managed-id"
+    assert "managed content" in loader.get_skill("shared").content
+
+    (managed_dir / "_manifest.json").unlink()
+    loader.discover_skills()
+    assert loader.get_skill("shared").ref == "bootstrap:shared"
+    assert "bootstrap content" in loader.get_skill("shared").content

--- a/tests/test_skill_tool.py
+++ b/tests/test_skill_tool.py
@@ -61,6 +61,10 @@ async def test_get_skill_tool(skill_loader):
     assert "Test skill 0 description" in result.content
     assert "Test skill 0 content" in result.content
 
+    by_ref = await tool.execute(skill_name="bootstrap:test-skill-0")
+    assert by_ref.success
+    assert "Test skill 0 content" in by_ref.content
+
 
 @pytest.mark.asyncio
 async def test_get_skill_tool_returns_short_context_when_skill_is_preloaded(skill_loader):


### PR DESCRIPTION
## TPR

### Task

- What changed: add manifest-governed managed builtin Skill discovery, stable source references, source-aware disabled-Skill handling, and live disabled-setting refresh for frozen ACP session snapshots.
- Why: officev3 needs managed, bootstrap, Hub, and user Skills to have stable identities while a user can still disable a preloaded Skill during an active session.
- Affected entry points: `SkillLoader`, ACP session Skill preloading, expert Skill resolution, runtime setup, and Skill tests.
- Out of scope: Electron catalog/download implementation, runtime package rebuilding, and SkillHub installation flow changes.

### Proof

- Syntax check: `uv run python -m compileall -q box_agent/tools/skill_loader.py tests/test_skill_loader.py` — passed.
- Focused tests: `uv run pytest -q tests/test_skill_filter.py tests/test_acp.py::test_acp_unloads_auto_preloaded_skill_after_it_is_disabled tests/test_skill_loader.py::test_frozen_snapshot_refreshes_settings_without_reloading_skill_content tests/test_skill_loader.py::test_managed_manifest_exposes_stable_ref_and_snapshot_pins_version` — 35 passed.
- Nearby suites: `uv run pytest -q tests/test_skill_loader.py tests/test_skill_tool.py tests/test_acp.py` — 154 passed.
- Full suite: `uv run pytest tests/ -q` — 3108 passed, 19 skipped.
- Runtime smoke: a real `SkillLoader` snapshot observed disabling and re-enabling `pptx` through the settings file without rediscovering the Skill directory — passed.
- Lint: not run because `ruff` is not installed in the repository environment.
- CI: `teamwork/local-ci` and GitGuardian both passed for the current head.
- Logs/screenshots/manifests: no UI output; no built-in Skill package content changed, so `_manifest.json` regeneration is not applicable.

### Risk

- Compatibility: managed directories intentionally fail closed without a valid manifest. Legacy name-based disabled settings remain supported alongside stable refs.
- Packaging/runtime impact: changes runtime Skill discovery used by officev3. No Electron rebuild, packaged-runtime install, or integration probe was run in this PR.
- Config, secrets, or migration: no secrets or data migration; settings may gain `disabledSkillRefs` when written by the caller.
- Rollback: revert `11c3f83` and `a5414ba`.
- Cross-repository follow-up: officev3 must provide the managed directory/manifest and perform packaged-runtime validation before release.

### Design and architecture impact

- Affected layers and owners: shared loader owns source identity, manifest filtering, and dynamic enablement policy; ACP remains an adapter that refreshes the session view each turn.
- Contract, schema, or protocol impact: managed source manifests provide stable builtin identity/version; disabled settings may refer to `builtin:`, `bootstrap:`, `hub:`, or `user:` identities.
- Documentation updated: no. This is a runtime integration change with the detailed managed-Skill contract maintained in officev3; Box-Agent contributor documentation has not been updated in this branch.

### Target branch consistency

- Base branch and reviewed Head SHA: `main` at `3a1be8e764415dce2c0497e51250cb7b953e54b8`; head `11c3f83f58fc8ee49a968beca94c0d71fc8ef3ab`.
- Relevant target-branch changes considered: branch was fast-forwarded to the latest `main`; the ACP conflict was resolved by retaining both current fast-profile filtering and the preloaded-Skill hash tracking.
- Rebase, compatibility, or historical-fix risk: `main` is the merge base of the current head; no merge commit from `main` exists in the feature branch. The codebase graph baseline predates relevant upstream structural changes, so current source and focused tests were treated as authoritative.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from current source; `.understand-anything` was used as an index, but its relevant region predates upstream changes.
- [x] Shared behavior is implemented in shared loader logic, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior.
- [x] Broader tests passed for shared runtime behavior.
- [ ] Documentation was updated; not included because this branch does not change a user-facing surface, but the cross-repository runtime contract needs release validation.
- [x] Built-in Skill changes did not require regenerating `box_agent/skills/_manifest.json`.
- [x] Packaged runtime impact is stated; rebuild/install/probe was not run.
- [x] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [x] This branch is based on the latest `main`; `main` was not merged into the feature branch.
- [x] Design and target-branch consistency evidence is included above.
- [x] `teamwork/local-ci` passed for the current Head SHA.

