### PR TITLE
fix(security): check shell parameter fallback paths

### DIFF
--- a/box_agent/tools/permissions.py
+++ b/box_agent/tools/permissions.py
@@ -543,6 +543,9 @@ _SHELL_PATH_ASSIGNMENT_RE = re.compile(
     r"([A-Za-z_][A-Za-z0-9_]*)="
     r"(?:\"([^\"]*)\"|'([^']*)'|([^\s;]+))"
 )
+_SHELL_PARAMETER_DEFAULT_RE = re.compile(
+    r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-|-)\s*([^{}]*)\}"
+)
 
 # Real shell redirect operators (`>`, `>>`, `2>`, `2>>`, ...). When followed by
 # a path, that path is what we want to extract — but we must distinguish a real
@@ -613,6 +616,24 @@ def expand_inline_shell_path_variables(command: str) -> str:
 
     path_vars: dict[str, str] = {}
 
+    def conservative_parameter_defaults(value: str) -> str:
+        """Resolve static POSIX parameter fallbacks for permission analysis.
+
+        The fallback remains a possible runtime path whenever the variable is
+        unset (or empty for ``:-``), so checking it is safer than trusting the
+        unresolved expression. Nested defaults are reduced from the inside
+        out without evaluating shell syntax or command substitutions.
+        """
+
+        for _ in range(16):
+            value, replacements = _SHELL_PARAMETER_DEFAULT_RE.subn(
+                lambda match: match.group(2),
+                value,
+            )
+            if not replacements:
+                break
+        return value
+
     def substitute_known(value: str) -> str:
         for name, resolved in path_vars.items():
             value = re.sub(rf"\$\{{{re.escape(name)}\}}|\${re.escape(name)}\b", resolved, value)
@@ -624,7 +645,7 @@ def expand_inline_shell_path_variables(command: str) -> str:
             (value for value in match.groups()[1:] if value is not None),
             "",
         )
-        expanded = substitute_known(raw_value)
+        expanded = conservative_parameter_defaults(substitute_known(raw_value))
         expanded = os.path.expanduser(expanded)
         if expanded.startswith("$HOME/"):
             expanded = str(Path.home()) + expanded[5:]

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -454,6 +454,21 @@ class TestExtractAbsolutePaths:
         assert "/tmp/deck/assets" in result
         assert "/dev/null" not in result
 
+    def test_parameter_default_absolute_path_is_expanded(self):
+        result = extract_absolute_paths(
+            'TARGET="${UNSET_TARGET:-/home/example/private}"\ncat "$TARGET/data.txt"'
+        )
+
+        assert "/home/example/private/data.txt" in result
+
+    def test_nested_parameter_default_absolute_path_is_expanded(self):
+        result = extract_absolute_paths(
+            'TARGET="${FIRST:-${SECOND:-/home/example/private}}"\n'
+            'cat "$TARGET/data.txt"'
+        )
+
+        assert "/home/example/private/data.txt" in result
+
     def test_no_paths(self):
         assert extract_absolute_paths("ls -la") == []
 
@@ -951,6 +966,25 @@ class TestBashPermissionPhase1:
 
         assert result.success is True
         assert (target / "result.txt").read_text(encoding="utf-8") == "ok"
+
+    async def test_parameter_default_outside_workspace_is_denied(
+        self,
+        workspace: Path,
+        tmp_path: Path,
+    ):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "data.txt"
+        secret.write_text("private", encoding="utf-8")
+        eng = self._make_engine(workspace)
+
+        result = await self._run_bash(
+            f'TARGET="${{UNSET_TARGET:-{outside}}}"\ncat "$TARGET/data.txt"',
+            eng,
+        )
+
+        assert result.success is False
+        assert str(secret) in (result.error or "")
 
     async def test_fd_redirect_does_not_upgrade_builtin_skill_read_to_write(
         self, workspace: Path, tmp_path: Path


### PR DESCRIPTION
## TPR

### Task

- What changed: Extend shell permission analysis to inspect path-like fallback values embedded in parameter expansion.
- Why: A command can hide an effective filesystem path behind shell fallback syntax, bypassing the intended path classification.
- Affected entry points: Shell permission checks.
- Out of scope: No execution-policy relaxation and no ACP protocol changes.

### Proof

- Tests or checks run: `uv run pytest tests/test_permissions.py -q` — 134 passed after rebasing onto current main.
- Logs, screenshots, probes, or manifests: `git diff --check upstream/main...HEAD` passed.
- Not run, with reason: Full repository preflight is pending while this PR remains a draft.

### Risk

- Compatibility: Existing safe commands remain accepted; only previously uninspected fallback paths receive normal classification.
- Packaging/runtime impact: Source-only validation so far.
- Config, secrets, or migration: None.
- Rollback: Revert the single security commit.
- Cross-repository follow-up: None.

### Design and architecture impact

- Affected layers and owners: Permission parser and its regression tests.
- Contract, schema, or protocol impact: None.
- Documentation updated: Not required for an internal safety correction.

### Target branch consistency

- Base branch and reviewed Head SHA: Latest `upstream/main`; branch rebased before PR creation.
- Relevant target-branch changes considered: Current shell permission implementation.
- Rebase, compatibility, or historical-fix risk: Main was rebased, not merged.

## Issue details

### Shell parameter fallback paths are not fully classified

- Issue: Path-like fallback operands can affect the actual command target.
- Expected result: Permission checks classify every effective path before execution.
- Actual result: The direct argument was inspected while a fallback path could be missed.
- Technical fix: Parse parameter fallback operands and feed discovered paths through the existing permission classification, with direct regression coverage.
