### PR TITLE
fix(cli): route presentation gates through Skills

### DIFF
--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -19,6 +19,7 @@ import shutil
 import subprocess
 import sys
 import threading
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter
@@ -43,7 +44,7 @@ from box_agent.agent import (
     goal_state_from_payload,
     should_continue_goal_autopilot,
 )
-from box_agent.config import Config
+from box_agent.config import Config, ToolLimitsConfig
 from box_agent.completion import build_auto_completion_gate
 from box_agent.events import StopReason
 from box_agent.schema import LLMProvider, Message
@@ -58,6 +59,7 @@ from box_agent.tools.skill_preload import (
     build_auto_loaded_skills_prompt,
     turn_preload_skill_names,
 )
+from box_agent.tools.skill_loader import SkillLoader
 from box_agent.tools.setup import (
     add_workspace_tools,
     await_mcp_tools,
@@ -84,8 +86,78 @@ from box_agent.workspace_registry import WorkspaceRegistry, WorkspaceRegistryErr
 from box_agent.workflows import (
     CONTROLLED_PRESENTATION_WORKFLOW_KIND,
     build_external_skill_completion_gate,
+    build_presentation_completion_gate,
     resolve_explicit_skill_invocation,
+    resolve_query_matched_presentation_skill_provider,
 )
+
+
+def _build_cli_skill_routed_completion_gate(
+    user_input: str,
+    workspace_dir: str | Path,
+    *,
+    skill_loader: SkillLoader | None,
+    tool_limits: ToolLimitsConfig,
+):
+    """Build a gate after Skill routing, without a CLI-only PPT classifier."""
+    explicit_skill = resolve_explicit_skill_invocation(skill_loader, user_input)
+    explicit_skill_uses_controlled_workflow = (
+        explicit_skill is not None
+        and explicit_skill.source == "builtin"
+        and explicit_skill.workflow == CONTROLLED_PRESENTATION_WORKFLOW_KIND
+    )
+    if explicit_skill is not None and not explicit_skill_uses_controlled_workflow:
+        return build_external_skill_completion_gate(
+            user_text=user_input,
+            workspace_dir=workspace_dir,
+            skill=explicit_skill,
+            tool_limits=tool_limits,
+        )
+    presentation_provider = (
+        resolve_query_matched_presentation_skill_provider(
+            skill_loader,
+            user_input,
+        )
+        if skill_loader is not None and explicit_skill is None
+        else None
+    )
+    if presentation_provider is not None:
+        presentation_skill = skill_loader.get_skill(
+            presentation_provider.skill_name
+        )
+        if (
+            presentation_provider.source != "builtin"
+            or not presentation_provider.uses_controlled_workflow
+        ):
+            return build_external_skill_completion_gate(
+                user_text=user_input,
+                workspace_dir=workspace_dir,
+                skill=presentation_skill,
+                tool_limits=tool_limits,
+            )
+    skill_selected_controlled_presentation = (
+        explicit_skill_uses_controlled_workflow
+        or presentation_provider is not None
+    )
+    if skill_selected_controlled_presentation:
+        gate = build_presentation_completion_gate(
+            user_input,
+            workspace_dir,
+            confirmed_presentation=True,
+            tool_limits=tool_limits,
+        )
+        if gate is None:
+            return None
+        return replace(
+            gate,
+            workflow_options={**gate.workflow_options, "research_mode": "auto"},
+        )
+    return build_auto_completion_gate(
+        user_input,
+        workspace_dir,
+        allow_controlled_presentation=False,
+        tool_limits=tool_limits,
+    )
 
 
 def run_setup_wizard(config_path: Path) -> bool:
@@ -2317,25 +2389,10 @@ async def run_agent(
     def _build_cli_completion_gate(user_input: str):
         if not completion_gate_enabled:
             return None
-        explicit_skill = resolve_explicit_skill_invocation(skill_loader, user_input)
-        if (
-            explicit_skill is not None
-            and explicit_skill.workflow != CONTROLLED_PRESENTATION_WORKFLOW_KIND
-        ):
-            return build_external_skill_completion_gate(
-                user_text=user_input,
-                workspace_dir=workspace_dir,
-                skill=explicit_skill,
-                tool_limits=config.tool_limits,
-            )
-        return build_auto_completion_gate(
+        return _build_cli_skill_routed_completion_gate(
             user_input,
             workspace_dir,
-            confirmed_presentation=(
-                explicit_skill is not None
-                and explicit_skill.workflow
-                == CONTROLLED_PRESENTATION_WORKFLOW_KIND
-            ),
+            skill_loader=skill_loader,
             tool_limits=config.tool_limits,
         )
 

--- a/box_agent/workflows/__init__.py
+++ b/box_agent/workflows/__init__.py
@@ -34,6 +34,7 @@ from .presentation_preflight import (
 from .presentation_provider import (
     parse_host_presentation_config,
     resolve_presentation_skill_provider,
+    resolve_query_matched_presentation_skill_provider,
 )
 from .presentation_routing import build_presentation_completion_gate
 
@@ -191,4 +192,5 @@ __all__ = [
     "recover_completion_gate",
     "resolve_explicit_skill_invocation",
     "resolve_presentation_skill_provider",
+    "resolve_query_matched_presentation_skill_provider",
 ]

--- a/box_agent/workflows/presentation_provider.py
+++ b/box_agent/workflows/presentation_provider.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from box_agent.delivery import has_deliverable_intent
 from box_agent.tools.skill_loader import Skill, SkillLoader
 
 from .presentation_contract import WORKFLOW_KIND
@@ -300,3 +301,33 @@ def resolve_presentation_skill_provider(
         ):
             declared_providers.append(candidate)
     return declared_providers[0] if declared_providers else None
+
+
+def resolve_query_matched_presentation_skill_provider(
+    skill_loader: SkillLoader,
+    query: str | None,
+) -> PresentationSkillProvider | None:
+    """Resolve a presentation provider selected by normal Skill matching.
+
+    The regular catalog filter intentionally caps the metadata shown to the
+    model. Provider routing must inspect every enabled Skill so a uniquely
+    relevant presentation provider is not dropped behind several broad
+    matches. Unlike :func:`resolve_presentation_skill_provider`, this helper
+    does not fall back to the builtin provider when the query matched no
+    presentation Skill.
+    """
+    if not query or not query.strip() or not has_deliverable_intent(query):
+        return None
+    max_skills = max(16, len(skill_loader.list_skills()))
+    matched_skill_names = tuple(
+        skill.name
+        for skill in skill_loader.filter_by_query(query, max_skills=max_skills)
+    )
+    provider = resolve_presentation_skill_provider(
+        skill_loader,
+        matched_skill_names,
+        query=query,
+    )
+    if provider is None or provider.skill_name not in matched_skill_names:
+        return None
+    return provider

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -7,7 +7,13 @@ import json
 from pathlib import Path
 
 import box_agent.cli as cli
-from box_agent.config import AgentConfig, Config, LLMConfig, ToolsConfig
+from box_agent.config import (
+    AgentConfig,
+    Config,
+    LLMConfig,
+    ToolLimitsConfig,
+    ToolsConfig,
+)
 from box_agent.schema import FunctionCall, LLMResponse, StreamEvent, ToolCall
 from box_agent.tools.base import Tool, ToolResult
 from box_agent.tools.skill_loader import Skill, SkillLoader
@@ -72,6 +78,91 @@ def test_cli_node_execution_env_preserves_user_environment(monkeypatch, tmp_path
     assert env["NPM_CONFIG_PREFIX"] == str(tmp_path / ".box-agent" / "skill-tools")
     assert "npm_config_prefix" not in env
     assert "npm_config_cache" not in env
+
+
+def test_cli_presentation_gate_requires_a_skill_selected_provider(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "plain-text",
+        description="Summarize and edit plain text",
+        keywords=["text", "summary"],
+        content="# PLAIN TEXT RULES",
+    )
+    skill_loader = SkillLoader(skills_dir)
+    skill_loader.discover_skills()
+
+    gate = cli._build_cli_skill_routed_completion_gate(
+        "请制作一份 PPT",
+        tmp_path / "workspace",
+        skill_loader=skill_loader,
+        tool_limits=ToolLimitsConfig(),
+    )
+
+    assert gate is None
+
+
+def test_cli_presentation_gate_uses_builtin_skill_provider(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "pptx",
+        description="Create editable PowerPoint presentation decks",
+        keywords=["ppt", "pptx", "slides"],
+        content="# PPTX RULES",
+    )
+    skill_loader = SkillLoader([(skills_dir, "builtin")])
+    skill_loader.discover_skills()
+
+    gate = cli._build_cli_skill_routed_completion_gate(
+        "请制作一份 PPT",
+        tmp_path / "workspace",
+        skill_loader=skill_loader,
+        tool_limits=ToolLimitsConfig(),
+    )
+
+    assert gate is not None
+    assert gate.workflow_checkpoint_kind == "controlled_presentation"
+
+
+def test_cli_skill_routing_handles_short_and_long_chinese_deck_prompts(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "pptx",
+        description="Create editable PowerPoint presentation decks",
+        keywords=["ppt", "pptx", "slides", "课件"],
+        content="# PPTX RULES",
+    )
+    skill_loader = SkillLoader([(skills_dir, "builtin")])
+    skill_loader.discover_skills()
+    cases = (
+        (
+            "我是小学科学老师，请制作一份PPT给三年级讲太阳系，"
+            "让八大行星能转起来并看清大小和远近。",
+            "auto",
+        ),
+        (
+            "帮我制作一份标题为《新能源汽车本土品牌市场动态分析》的"
+            "数据解读型PPT。请主动搜索并引用最新的中国公开数据，"
+            "所有图表均标注来源、统计时间和报告名称。",
+            "auto",
+        ),
+    )
+
+    for index, (prompt, expected_research_mode) in enumerate(cases):
+        gate = cli._build_cli_skill_routed_completion_gate(
+            prompt,
+            tmp_path / f"workspace-{index}",
+            skill_loader=skill_loader,
+            tool_limits=ToolLimitsConfig(),
+        )
+
+        assert gate is not None
+        assert gate.workflow_checkpoint_kind == "controlled_presentation"
+        assert gate.workflow_options["research_mode"] == expected_research_mode
 
 
 class _CaptureStreamLLM:

--- a/tests/test_presentation_provider.py
+++ b/tests/test_presentation_provider.py
@@ -4,6 +4,7 @@ from box_agent.tools.skill_loader import SkillLoader
 from box_agent.workflows.presentation_provider import (
     parse_host_presentation_config,
     resolve_presentation_skill_provider,
+    resolve_query_matched_presentation_skill_provider,
 )
 
 
@@ -14,6 +15,7 @@ def _write_skill(
     *,
     capabilities: str | None = None,
     workflow: str | None = None,
+    keywords: tuple[str, ...] = (),
 ) -> None:
     skill_dir = root / name
     skill_dir.mkdir(parents=True)
@@ -22,6 +24,8 @@ def _write_skill(
         lines.append(f"capabilities: [{capabilities}]")
     if workflow:
         lines.append(f"workflow: {workflow}")
+    if keywords:
+        lines.append(f"keywords: [{', '.join(keywords)}]")
     lines.extend(["---", "", "Follow this workflow."])
     skill_dir.joinpath("SKILL.md").write_text("\n".join(lines), encoding="utf-8")
 
@@ -98,6 +102,78 @@ def test_unmatched_declared_integration_does_not_become_global_default(tmp_path)
 
     assert provider is not None
     assert provider.skill_name == "pptx"
+
+
+def test_query_matched_provider_does_not_use_builtin_fallback(tmp_path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(
+        builtin_root,
+        "pptx",
+        "Create presentation files",
+        capabilities="presentation.authoring",
+        workflow="controlled_presentation",
+        keywords=("ppt", "pptx", "slides"),
+    )
+    loader = SkillLoader([(builtin_root, "builtin")])
+    loader.discover_skills()
+
+    provider = resolve_query_matched_presentation_skill_provider(
+        loader,
+        "Summarize this Python module",
+    )
+
+    assert provider is None
+
+
+def test_query_matched_provider_ignores_informational_skill_mentions(tmp_path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(
+        builtin_root,
+        "pptx",
+        "Create presentation files",
+        capabilities="presentation.authoring",
+        workflow="controlled_presentation",
+        keywords=("ppt", "pptx", "slides"),
+    )
+    loader = SkillLoader([(builtin_root, "builtin")])
+    loader.discover_skills()
+
+    provider = resolve_query_matched_presentation_skill_provider(
+        loader,
+        "解释一下 pptx 这个 Skill 的名字",
+    )
+
+    assert provider is None
+
+
+def test_query_matched_provider_is_not_dropped_by_catalog_limit(tmp_path) -> None:
+    user_root = tmp_path / "user"
+    builtin_root = tmp_path / "builtin"
+    for index in range(16):
+        _write_skill(
+            user_root,
+            f"training-noise-{index}",
+            "Create editable new employee training checklists",
+            keywords=("新员工", "入职", "培训", "可编辑", "清单"),
+        )
+    _write_skill(
+        builtin_root,
+        "pptx",
+        "Create presentation files",
+        capabilities="presentation.authoring",
+        workflow="controlled_presentation",
+        keywords=("ppt", "pptx", "slides"),
+    )
+    loader = SkillLoader([(user_root, "user"), (builtin_root, "builtin")])
+    loader.discover_skills()
+    prompt = "做一份 12 页新员工入职培训 PPT，1920×1080 可编辑"
+    assert "pptx" not in [skill.name for skill in loader.filter_by_query(prompt)]
+
+    provider = resolve_query_matched_presentation_skill_provider(loader, prompt)
+
+    assert provider is not None
+    assert provider.skill_name == "pptx"
+    assert provider.uses_controlled_workflow is True
 
 
 def test_matched_legacy_user_provider_needs_no_new_fields(tmp_path) -> None:


### PR DESCRIPTION
## TPR

### Task

- What changed: Move standalone CLI presentation-gate selection from direct prompt routing toward installed presentation Skill metadata and provider resolution.
- Why: The TUI should follow the same Skill-owned presentation selection model used by the product direction instead of maintaining a competing legacy detector.
- Affected entry points: CLI/TUI presentation provider and completion-gate setup.
- Out of scope: ACP is intentionally unchanged; the legacy detector is retained for compatibility where still referenced.

### Proof

- Tests or checks run: `uv run pytest tests/test_cli_runtime.py tests/test_presentation_provider.py -q` — 27 passed.
- Logs, screenshots, probes, or manifests: `git diff --check upstream/main...HEAD` passed.
- Not run, with reason: Full repository preflight is pending while this PR remains a draft.

### Risk

- Compatibility: Presentation routing now depends more directly on valid installed Skill metadata.
- Packaging/runtime impact: Requires a rebuilt CLI runtime.
- Config, secrets, or migration: None.
- Rollback: Revert the routing commit.
- Cross-repository follow-up: None; ACP behavior is not changed.

### Design and architecture impact

- Affected layers and owners: CLI adapter and presentation-provider resolver.
- Contract, schema, or protocol impact: No ACP or public protocol changes.
- Documentation updated: No new user-facing option was introduced.

### Target branch consistency

- Base branch and reviewed Head SHA: `upstream/main` at `e4167a98734ec2abf466510ad94f414dc2b17113`.
- Relevant target-branch changes considered: Current Skill preload and provider-selection behavior.
- Rebase, compatibility, or historical-fix risk: This isolates deprecated legacy mode-detection behavior in its own draft PR.

## Issue details

### The TUI owns a separate direct presentation detector

- Issue: CLI routing can choose a presentation workflow independently of the installed Skills.
- Expected result: Presentation-capable Skills identify the provider and workflow contract.
- Actual result: Direct prompt classification can disagree with Skill metadata and product-host behavior.
- Technical fix: Resolve the presentation provider from installed Skills and construct the CLI gate from that provider while preserving explicit Skill invocation and compatibility fallbacks.
