### PR TITLE
fix(pptx): stabilize workflow routing across provider variants

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -888,6 +888,7 @@ class SessionState:
     thinking_enabled: bool = False  # extended thinking toggle from _meta.deep_think
     execution_profile: ExecutionProfile = "standard"
     explicitly_allowed_skill_names: set[str] = field(default_factory=set)
+    workflow_locked_skill_names: set[str] = field(default_factory=set)
     env_context: "EnvContext | None" = None  # cached env_context, re-applied when mode switches
     skill_runtime_context: "SkillRuntimeContext | None" = None
     skill_loader: Any | None = None  # session-local loader for expert-only recommended skills
@@ -1709,6 +1710,7 @@ class BoxACPAgent:
         preloaded_skill_hashes: dict[str, str] = {}
         skill_scratch_dir = None
         explicitly_allowed_skill_names: set[str] = set()
+        workflow_locked_skill_names: set[str] = set()
         blocked_skill_names = (
             FAST_OPTIONAL_SKILLS if execution_profile == "fast" else frozenset()
         )
@@ -1731,6 +1733,7 @@ class BoxACPAgent:
                         explicitly_allowed_skill_names=(
                             explicitly_allowed_skill_names
                         ),
+                        workflow_locked_skill_names=workflow_locked_skill_names,
                     )
                     if isinstance(tool, GetSkillTool)
                     or (
@@ -1859,6 +1862,7 @@ class BoxACPAgent:
             thinking_enabled=deep_think,
             execution_profile=execution_profile,
             explicitly_allowed_skill_names=explicitly_allowed_skill_names,
+            workflow_locked_skill_names=workflow_locked_skill_names,
             env_context=env_context,
             skill_runtime_context=skill_runtime_context,
             skill_loader=session_skill_loader,
@@ -2898,6 +2902,9 @@ class BoxACPAgent:
                 self._apply_auto_loaded_skills(state, session_id, [])
             else:
                 self._sync_cache_fingerprint_context(state)
+            state.workflow_locked_skill_names.clear()
+            if completion_gate is not None and "pptx" in state.preloaded_skill_names:
+                state.workflow_locked_skill_names.update(state.preloaded_skill_names)
 
         if image_attachment_context:
             user_text = f"{user_text}\n\n{image_attachment_context}"

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -2038,6 +2038,7 @@ async def run_agent(
         config, memory_manager=memory_mgr, llm=llm_client
     )
     cli_preloaded_skill_hashes: dict[str, str] = {}
+    cli_workflow_locked_skill_names: set[str] = set()
     if skill_loader:
         from box_agent.tools.skill_tool import GetSkillTool
 
@@ -2045,6 +2046,7 @@ async def run_agent(
             GetSkillTool(
                 skill_loader,
                 preloaded_skill_hashes=cli_preloaded_skill_hashes,
+                workflow_locked_skill_names=cli_workflow_locked_skill_names,
             )
             if isinstance(tool, GetSkillTool)
             else tool
@@ -2277,6 +2279,7 @@ async def run_agent(
 
     def _apply_cli_auto_loaded_skills(completion_gate, user_input: str) -> None:
         if skill_loader is None or skill_selector is None:
+            cli_workflow_locked_skill_names.clear()
             _sync_cli_cache_fingerprint_context()
             return
         preload_names = turn_preload_skill_names(
@@ -2286,6 +2289,7 @@ async def run_agent(
             user_input,
         )
         if not preload_names and not cli_preloaded_skill_names:
+            cli_workflow_locked_skill_names.clear()
             _sync_cli_cache_fingerprint_context()
             return
         result = build_auto_loaded_skills_prompt(
@@ -2297,6 +2301,9 @@ async def run_agent(
         cli_preloaded_skill_names[:] = list(result.loaded_names)
         cli_preloaded_skill_hashes.clear()
         cli_preloaded_skill_hashes.update(result.loaded_skill_hashes)
+        cli_workflow_locked_skill_names.clear()
+        if completion_gate is not None and "pptx" in result.loaded_names:
+            cli_workflow_locked_skill_names.update(result.loaded_names)
         _sync_cli_cache_fingerprint_context()
         for missing_name in result.missing_names:
             print(f"{Colors.YELLOW}⚠️  Skill preload target not found: {missing_name}{Colors.RESET}")

--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -122,7 +122,12 @@ def _apply_thinking_params(
         params["reasoning_effort"] = _DEEP_THINK_REASONING_EFFORT
         return
     if _is_sensenova_model(model):
-        params["reasoning_effort"] = "none"
+        # SenseNova-compatible deployments disagree on whether ``none`` is a
+        # valid enum value.  Some accept it, while others only accept
+        # low/medium/high and reject an otherwise valid request with 422.
+        # Omitting the optional field is the only value accepted by both
+        # dialects when deep thinking is disabled.
+        return
 
 
 def _tool_parameter_types(

--- a/box_agent/tools/skill_tool.py
+++ b/box_agent/tools/skill_tool.py
@@ -28,12 +28,14 @@ class GetSkillTool(Tool):
         preloaded_skill_hashes: Mapping[str, str] | None = None,
         blocked_skill_names: set[str] | frozenset[str] | None = None,
         explicitly_allowed_skill_names: MutableSet[str] | None = None,
+        workflow_locked_skill_names: MutableSet[str] | None = None,
     ):
         self.skill_loader = skill_loader
         self.include_disabled = include_disabled
         self.preloaded_skill_hashes = preloaded_skill_hashes
         self.blocked_skill_names = blocked_skill_names or frozenset()
         self.explicitly_allowed_skill_names = explicitly_allowed_skill_names
+        self.workflow_locked_skill_names = workflow_locked_skill_names
 
     @property
     def name(self) -> str:
@@ -59,6 +61,24 @@ class GetSkillTool(Tool):
     async def execute(self, skill_name: str) -> ToolResult:
         """Get detailed information about specified skill"""
         normalized_name = skill_name.strip()
+        if (
+            self.workflow_locked_skill_names
+            and not self._workflow_allows(normalized_name)
+            and (
+                self.explicitly_allowed_skill_names is None
+                or normalized_name not in self.explicitly_allowed_skill_names
+            )
+        ):
+            active = ", ".join(sorted(self.workflow_locked_skill_names))
+            return ToolResult(
+                success=False,
+                content="",
+                error=(
+                    f"Skill '{normalized_name}' cannot replace the active workflow "
+                    f"Skills ({active}). Follow the preloaded workflow and its "
+                    "declared dependencies; do not retry loading a competing Skill."
+                ),
+            )
         if (
             normalized_name in self.blocked_skill_names
             and not (
@@ -125,6 +145,25 @@ class GetSkillTool(Tool):
                 "skill_path": str(skill.skill_path) if skill.skill_path else None,
             }
         return ToolResult(success=True, content=result, raw_output=raw_output)
+
+    def _workflow_allows(self, skill_name: str) -> bool:
+        """Allow the active workflow and dependencies it explicitly declares."""
+        if not self.workflow_locked_skill_names:
+            return True
+        if skill_name in self.workflow_locked_skill_names:
+            return True
+        for active_name in self.workflow_locked_skill_names:
+            active_skill = self.skill_loader.get_skill(
+                active_name,
+                include_disabled=self.include_disabled,
+            )
+            if active_skill is None:
+                continue
+            declared = set(active_skill.required_skills or [])
+            declared.update(active_skill.related_skills or [])
+            if skill_name in declared:
+                return True
+        return False
 
 
 def create_skill_tools(

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -44,7 +44,7 @@ from box_agent.tools.base import Tool, ToolResult
 from box_agent.tools.bash_tool import BackgroundShellManager
 from box_agent.tools.jupyter_tool import MAX_EXECUTE_CODE_CHARS
 from box_agent.tools.skill_loader import SKILL_SLOT_SENTINEL, SkillLoader
-from box_agent.tools.skill_tool import create_skill_tools
+from box_agent.tools.skill_tool import GetSkillTool, create_skill_tools
 from box_agent.tools.setup import (
     SANDBOX_INFO_PROMPT,
     build_file_delivery_prompt,
@@ -4408,6 +4408,18 @@ async def test_acp_preloads_pptx_when_catalog_filter_drops_it(tmp_path):
         "Use the editable deck workflow.\n",
         encoding="utf-8",
     )
+    canvas_dir = skills_dir / "canvas-design"
+    canvas_dir.mkdir()
+    (canvas_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: canvas-design\n"
+        "description: Create visual canvases and export PDF pages.\n"
+        "keywords: [visual, canvas, pdf]\n"
+        "---\n"
+        "# CANVAS RULES\n"
+        "Export a PDF artwork.\n",
+        encoding="utf-8",
+    )
     skill_loader = SkillLoader(skills_dir)
     skill_loader.discover_skills()
     assert "pptx" not in [skill.name for skill in skill_loader.filter_by_query(prompt)]
@@ -4423,7 +4435,7 @@ async def test_acp_preloads_pptx_when_catalog_filter_drops_it(tmp_path):
         conn,
         config,
         llm,
-        [],
+        [GetSkillTool(skill_loader)],
         f"system\n\n{SKILL_SLOT_SENTINEL}",
         skill_loader=skill_loader,
     )
@@ -4442,6 +4454,9 @@ async def test_acp_preloads_pptx_when_catalog_filter_drops_it(tmp_path):
     assert "# Skill: pptx" in first_system_prompt
     assert "# PPTX FULL RULES" in first_system_prompt
     assert state.preloaded_skill_names == ["pptx"]
+    competing = await state.agent.tools["get_skill"].execute("canvas-design")
+    assert competing.success is False
+    assert "cannot replace the active workflow" in (competing.error or "")
     turn_usage_outputs = [
         update.update.rawOutput
         for update in conn.updates

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -93,7 +93,7 @@ class _CaptureStreamLLM:
         yield StreamEvent(type="finish", finish_reason="stop")
 
 
-class _PreloadedSkillThenGetSkillLLM(_CaptureStreamLLM):
+class _PreloadedPptxThenGetCompetingSkillLLM(_CaptureStreamLLM):
     async def generate_stream(self, *, messages, **kwargs):
         self.message_snapshots.append([(message.role, message.content) for message in messages])
         self.system_prompts.append(messages[0].content)
@@ -106,7 +106,7 @@ class _PreloadedSkillThenGetSkillLLM(_CaptureStreamLLM):
                         id="preloaded-skill",
                         type="function",
                         function=FunctionCall(
-                            name="get_skill", arguments={"skill_name": "pptx"}
+                            name="get_skill", arguments={"skill_name": "canvas-design"}
                         ),
                     )
                 ],
@@ -526,6 +526,13 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
         keywords=["html", "template", "visual"],
         content="# HTML TEMPLATE RULES\nSelect a Visual DNA profile.",
     )
+    _write_skill(
+        skills_dir,
+        "canvas-design",
+        description="Create visual canvases and export PDF pages.",
+        keywords=["visual", "canvas", "pdf"],
+        content="# CANVAS RULES\nExport a PDF artwork.",
+    )
     skill_loader = SkillLoader(skills_dir)
     skill_loader.discover_skills()
     assert "pptx" not in [skill.name for skill in skill_loader.filter_by_query(prompt)]
@@ -571,7 +578,7 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
         "find_config_file",
         staticmethod(lambda name: Path(name) if name == str(system_prompt_path) else None),
     )
-    monkeypatch.setattr(cli, "LLMClient", _PreloadedSkillThenGetSkillLLM)
+    monkeypatch.setattr(cli, "LLMClient", _PreloadedPptxThenGetCompetingSkillLLM)
     monkeypatch.setattr(cli, "initialize_base_tools", fake_initialize_base_tools)
     monkeypatch.setattr(cli, "add_workspace_tools", lambda *args, **kwargs: None)
     _CaptureStreamLLM.instances.clear()
@@ -596,10 +603,9 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
     snapshots = _CaptureStreamLLM.instances[0].message_snapshots
     assert len(snapshots) == 2
     tool_messages = [content for role, content in snapshots[1] if role == "tool"]
-    assert tool_messages == [
-        "Skill 'pptx' is already preloaded in this session. "
-        "Follow its system instructions directly."
-    ]
+    assert len(tool_messages) == 1
+    assert "cannot replace the active workflow" in tool_messages[0]
+    assert "canvas-design" in tool_messages[0]
     assert "# PPTX FULL RULES" not in tool_messages[0]
 
 

--- a/tests/test_skill_tool.py
+++ b/tests/test_skill_tool.py
@@ -132,6 +132,44 @@ async def test_get_skill_tool_honors_profile_block_until_user_explicitly_allows_
 
 
 @pytest.mark.asyncio
+async def test_get_skill_tool_rejects_competing_skill_during_locked_workflow(
+    skill_loader,
+):
+    locked = {"test-skill-0"}
+    explicitly_allowed: set[str] = set()
+    tool = GetSkillTool(
+        skill_loader,
+        workflow_locked_skill_names=locked,
+        explicitly_allowed_skill_names=explicitly_allowed,
+    )
+
+    blocked = await tool.execute(skill_name="test-skill-1")
+    assert blocked.success is False
+    assert "cannot replace the active workflow" in (blocked.error or "")
+    assert "do not retry" in (blocked.error or "")
+
+    explicitly_allowed.add("test-skill-1")
+    allowed = await tool.execute(skill_name="test-skill-1")
+    assert allowed.success is True
+
+
+@pytest.mark.asyncio
+async def test_get_skill_tool_allows_declared_workflow_dependency(skill_loader):
+    primary = skill_loader.get_skill("test-skill-0")
+    assert primary is not None
+    primary.related_skills = ["test-skill-1"]
+    tool = GetSkillTool(
+        skill_loader,
+        workflow_locked_skill_names={"test-skill-0"},
+    )
+
+    result = await tool.execute(skill_name="test-skill-1")
+
+    assert result.success is True
+    assert "Test skill 1 content" in result.content
+
+
+@pytest.mark.asyncio
 async def test_get_skill_tool_nonexistent(skill_loader):
     """Test getting non-existent skill"""
     tool = GetSkillTool(skill_loader)

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -124,9 +124,9 @@ async def test_openai_request_sends_high_reasoning_effort_when_enabled(monkeypat
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("thinking_enabled", "expected_effort"),
-    [(True, "high"), (False, "none")],
+    [(True, "high"), (False, None)],
 )
-async def test_sensenova_request_sends_top_level_reasoning_effort(
+async def test_sensenova_request_uses_compatible_reasoning_control(
     thinking_enabled,
     expected_effort,
     monkeypatch,
@@ -155,7 +155,10 @@ async def test_sensenova_request_sends_top_level_reasoning_effort(
     )
 
     assert "extra_body" not in captured
-    assert captured["reasoning_effort"] == expected_effort
+    if expected_effort is None:
+        assert "reasoning_effort" not in captured
+    else:
+        assert captured["reasoning_effort"] == expected_effort
 
 
 @pytest.mark.asyncio
@@ -193,7 +196,7 @@ async def test_openai_request_no_extra_body_by_default(monkeypatch):
     [
         ("gpt-5", True, None, "high"),
         ("custom-chat-model", False, None, None),
-        ("SenseNova-Flash-Lite-test", False, None, "none"),
+        ("SenseNova-Flash-Lite-test", False, None, None),
         ("SenseNova-Flash-Lite-test", True, None, "high"),
         ("SN-SenseNova-6-8-Flash-Lite", True, None, "high"),
         (
@@ -620,9 +623,9 @@ async def test_generic_openai_stream_does_not_execute_tool_markup_from_thinking(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("thinking_enabled", "expected_effort"),
-    [(True, "high"), (False, "none")],
+    [(True, "high"), (False, None)],
 )
-async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
+async def test_sensenova_sdk_uses_compatible_reasoning_control_in_wire_body(
     thinking_enabled,
     expected_effort,
 ):
@@ -678,7 +681,10 @@ async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
 
     assert "extra_body" not in captured
     assert "chat_template_kwargs" not in captured
-    assert captured["reasoning_effort"] == expected_effort
+    if expected_effort is None:
+        assert "reasoning_effort" not in captured
+    else:
+        assert captured["reasoning_effort"] == expected_effort
 
 
 @pytest.mark.asyncio
@@ -692,7 +698,7 @@ async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
         ("raccoon-405a1c", True, {"reasoning_effort": "high"}),
         ("raccoon-405a1c", False, {}),
         ("sn-sensenova-6-8-flash-lite", True, {"reasoning_effort": "high"}),
-        ("sn-sensenova-6-8-flash-lite", False, {"reasoning_effort": "none"}),
+        ("sn-sensenova-6-8-flash-lite", False, {}),
         ("sn-glm-5-2", True, {"reasoning_effort": "high"}),
         ("sn-glm-5-2", False, {}),
         (


### PR DESCRIPTION
## TPR

### Task

- What changed: Protect an active controlled presentation from an unrelated competing Skill and make disabled-thinking requests compatible with SenseNova endpoint variants.
- Why: A deck run could abandon its preloaded workflow, while one supplied SenseNova endpoint rejects `reasoning_effort=none` with HTTP 422.
- Affected entry points: CLI and ACP Skill loading plus SenseNova OpenAI-compatible request construction.
- Out of scope: Generic OpenAI, Gemini, DeepSeek, Qwen, and Anthropic provider controls remain unchanged.

### Proof

- Tests or checks run: Focused routing/provider tests passed; repository preflight passed for the current branch Head before draft creation.
- Logs, screenshots, probes, or manifests: The text endpoint returned HTTP 422 for `none` and accepted omission; the supplied vision endpoint accepted both.
- Not run, with reason: No new live deck run was required to create this draft.

### Risk

- Compatibility: Workflow locking allows active Skills and declared dependencies; provider change is limited to recognized SenseNova model prefixes.
- Packaging/runtime impact: Runtime rebuild required.
- Config, secrets, or migration: No schema migration; custom SenseNova prefixes retain existing opt-in behavior.
- Rollback: Revert the single routing commit.
- Cross-repository follow-up: Verify host-specific Skill allowance semantics during review.

### Design and architecture impact

- Affected layers and owners: Shared Skill loader tool, CLI/ACP adapter state, OpenAI-compatible provider mapping.
- Contract, schema, or protocol impact: No public protocol field changes.
- Documentation updated: No new configuration surface.

### Target branch consistency

- Base branch and reviewed Head SHA: `upstream/main` at `e4167a98734ec2abf466510ad94f414dc2b17113`.
- Relevant target-branch changes considered: Current Skill preload and provider-family thinking controls.
- Rebase, compatibility, or historical-fix risk: Draft status is retained for maintainer review of workflow-dependency allowances.

## Issue details

### A competing Skill can displace an active PPTX workflow

- Issue: `get_skill` permits loading an unrelated Skill after PPTX is preloaded.
- Expected result: The active workflow remains authoritative while still allowing its declared dependencies.
- Actual result: The model can follow a later incompatible Skill and finish without a deck.
- Technical fix: Add a workflow lock shared by CLI and ACP that accepts active Skills, declared dependencies, and host-explicit allowances while rejecting unrelated replacements.

### SenseNova endpoints disagree on disabled reasoning

- Issue: One supplied endpoint rejects `reasoning_effort=none`.
- Expected result: Disabling deep thinking produces a request accepted by both supplied SenseNova dialects.
- Actual result: The text endpoint returns HTTP 422 and permits only low, medium, or high.
- Technical fix: Omit the optional field only for recognized SenseNova models when thinking is disabled; preserve every other provider family mapping.
