### PR TITLE
fix(pptx): harden TUI authoring and vision inspection

### DIFF
--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -2101,6 +2101,8 @@ async def run_agent(
         ),
         use_output_dir=not code_workspace,
         env_context=cli_env_context,
+        image_inspection_default_strategy="native",
+        image_inspection_max_output_tokens_cap=4096,
     )
 
     if not allow_full_access:

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -3225,6 +3225,21 @@ async def run_agent_loop(
     # after exhausting the retries do we surface a user-visible error.
     truncated_tool_call_retries = 0
     oversized_tool_argument_retries = 0
+    oversized_tool_argument_repair_limit = 1
+    if workflow_policy is not None:
+        configured_repair_limit = getattr(
+            workflow_policy,
+            "tool_argument_repair_limit",
+            oversized_tool_argument_repair_limit,
+        )
+        if isinstance(configured_repair_limit, int) and not isinstance(
+            configured_repair_limit,
+            bool,
+        ):
+            oversized_tool_argument_repair_limit = max(
+                0,
+                min(configured_repair_limit, 3),
+            )
     provider_stale_retries = 0
     provider_stale_recoveries = 0
     # Resolve once per turn: env override > configured value > module default.
@@ -4375,7 +4390,10 @@ async def run_agent_loop(
             ) or "unknown tool"
             if response.content.strip():
                 messages.append(assistant_msg)
-            if oversized_tool_argument_retries < 1:
+            if (
+                oversized_tool_argument_retries
+                < oversized_tool_argument_repair_limit
+            ):
                 oversized_tool_argument_retries += 1
                 repair_text = (
                     "上一轮工具参数在流式生成阶段超过安全预算，工具没有执行。"
@@ -4395,8 +4413,9 @@ async def run_agent_loop(
                     user_visible=False,
                 )
                 _log.warning(
-                    "tool argument limit repair %d/1: %s request_id=%s",
+                    "tool argument limit repair %d/%d: %s request_id=%s",
                     oversized_tool_argument_retries,
+                    oversized_tool_argument_repair_limit,
                     rendered,
                     provider_request_id,
                 )

--- a/box_agent/tools/image_inspection_tool.py
+++ b/box_agent/tools/image_inspection_tool.py
@@ -57,7 +57,11 @@ class ImageInspectionTool(Tool):
         relative_root_dir: str | None = None,
         native_supported: bool = False,
         native_capability_llm: Any | None = None,
+        default_strategy: str = "proxy",
     ) -> None:
+        normalized_default_strategy = default_strategy.strip().lower()
+        if normalized_default_strategy not in {"proxy", "native"}:
+            raise ValueError("default_strategy must be 'proxy' or 'native'")
         self.llm = llm
         self.workspace_dir = Path(workspace_dir).absolute()
         self.relative_root_dir = (
@@ -67,6 +71,7 @@ class ImageInspectionTool(Tool):
         self._perm = permission_engine
         self.native_supported = native_supported
         self._native_capability_llm = native_capability_llm
+        self.default_strategy = normalized_default_strategy
         self._unsupported_error: str | None = None
 
     @property
@@ -75,11 +80,18 @@ class ImageInspectionTool(Tool):
 
     @property
     def description(self) -> str:
-        return (
+        description = (
             "Inspect 1-6 local PNG/JPEG images with the configured vision-capable "
             "model and answer the supplied instruction using relevant visual evidence. "
             "Reads image files and performs an LLM request; never modifies files."
         )
+        if self.default_strategy == "native":
+            return (
+                f"{description} The active TUI model accepts native image input, so "
+                "omit strategy or use native first; use proxy only if native input "
+                "cannot fit the transient request budget."
+            )
+        return description
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -111,7 +123,7 @@ class ImageInspectionTool(Tool):
                 "strategy": {
                     "type": "string",
                     "enum": ["proxy", "native"],
-                    "default": "proxy",
+                    "default": self.default_strategy,
                     "description": (
                         "proxy asks the configured vision utility model and returns text; "
                         "native attaches canonical image blocks transiently to the active "
@@ -126,7 +138,7 @@ class ImageInspectionTool(Tool):
         self,
         image_paths: list[str],
         instruction: str,
-        strategy: str = "proxy",
+        strategy: str | None = None,
     ) -> ToolResult:
         """Inspect images without modifying the filesystem."""
         if not image_paths or len(image_paths) > _MAX_IMAGES:
@@ -140,7 +152,7 @@ class ImageInspectionTool(Tool):
                 "IMAGE_INPUT_INVALID",
                 "instruction must not be empty",
             )
-        normalized_strategy = strategy.strip().lower()
+        normalized_strategy = (strategy or self.default_strategy).strip().lower()
         if normalized_strategy not in {"proxy", "native"}:
             return self._error(
                 "IMAGE_INPUT_INVALID",

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -58,14 +58,34 @@ if TYPE_CHECKING:
     from box_agent.tools.permissions import PermissionEngine
 
 
-def _image_capable_llm(llm: Any | None) -> Any | None:
+def _bounded_image_inspection_llm(
+    llm: Any,
+    max_output_tokens_cap: int | None,
+) -> Any:
+    """Keep a utility image description from reserving the main turn's budget."""
+    if max_output_tokens_cap is None:
+        return llm
+    bounded, _diagnostic = resolve_model_client(
+        llm,
+        task="分析图片内容并执行视觉质量审查",
+        strategy="utility",
+        max_output_tokens_cap=max_output_tokens_cap,
+    )
+    return bounded
+
+
+def _image_capable_llm(
+    llm: Any | None,
+    *,
+    max_output_tokens_cap: int | None = None,
+) -> Any | None:
     """Return an image-capable client, or None for known text-only bindings."""
     if llm is None:
         return None
 
     current_support = image_input_support(llm)
     if current_support is True:
-        return llm
+        return _bounded_image_inspection_llm(llm, max_output_tokens_cap)
 
     model = str(getattr(llm, "model", "") or "").strip()
     candidates = tuple(getattr(llm, "auto_model_candidates", ()) or ())
@@ -89,10 +109,15 @@ def _image_capable_llm(llm: Any | None) -> Any | None:
             auto_model_candidates=vision_candidates,
             task_tags=("vision", "analysis"),
             required_ability_level=2,
+            max_output_tokens_cap=max_output_tokens_cap,
         )
         return resolved if diagnostic.get("mode") == "auto" else None
 
-    return None if current_support is False else llm
+    return (
+        None
+        if current_support is False
+        else _bounded_image_inspection_llm(llm, max_output_tokens_cap)
+    )
 
 
 def build_sandbox_info_prompt(use_output_dir: bool = True) -> str:
@@ -537,7 +562,9 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         skill_scratch_root_dir: str | Path | None = None,
                         env_context=None,
                         process_owner_id: str | None = None,
-                        bypass_dangerous_command_approval: bool = False):
+                        bypass_dangerous_command_approval: bool = False,
+                        image_inspection_default_strategy: str = "proxy",
+                        image_inspection_max_output_tokens_cap: int | None = None):
     """Add workspace-dependent tools
 
     These tools need to know the workspace directory.
@@ -566,6 +593,10 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
             reclaim background shell processes.
         bypass_dangerous_command_approval: Skip dangerous-command approval for
             an explicitly trusted full-access session.
+        image_inspection_default_strategy: Default image handoff mode. CLI may
+            prefer native input while protocol hosts retain the proxy default.
+        image_inspection_max_output_tokens_cap: Optional utility-image response
+            cap. Protocol hosts retain their configured limit when omitted.
     """
     _out = output or print
     # Ensure workspace directory exists
@@ -720,8 +751,21 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
     # Image inspection tool — only expose it when the bound model can actually
     # accept image blocks. Known text-only endpoints otherwise invite costly,
     # futile resize/retry loops during presentation QA.
-    image_llm = _image_capable_llm(llm)
+    current_image_support = image_input_support(llm)
+    current_model_candidates = tuple(
+        getattr(llm, "auto_model_candidates", ()) or ()
+    )
+    native_supported = current_image_support is True or (
+        current_image_support is not False and not current_model_candidates
+    )
+    image_llm = _image_capable_llm(
+        llm,
+        max_output_tokens_cap=image_inspection_max_output_tokens_cap,
+    )
     if image_llm is not None:
+        default_strategy = (
+            image_inspection_default_strategy if native_supported else "proxy"
+        )
         tools.append(
             ImageInspectionTool(
                 llm=image_llm,
@@ -729,10 +773,9 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                 allow_full_access=allow_full_access,
                 permission_engine=permission_engine,
                 relative_root_dir=str(relative_root),
-                native_supported=(
-                    image_llm is llm and image_input_support(llm) is not False
-                ),
+                native_supported=native_supported,
                 native_capability_llm=llm,
+                default_strategy=default_strategy,
             )
         )
         _out(f"{Colors.GREEN}✅ Loaded image inspection tool (inspect_images){Colors.RESET}")

--- a/box_agent/workflows/controlled_presentation.py
+++ b/box_agent/workflows/controlled_presentation.py
@@ -2187,6 +2187,7 @@ class ControlledPresentationPolicy:
     checkpoint_injection_id: ClassVar[str] = CHECKPOINT_MARKER
     evidence_read_batch_size: ClassVar[int] = RESEARCH_READ_BATCH_SIZE
     evidence_read_limit: ClassVar[int] = RESEARCH_DIRECT_READ_LIMIT
+    tool_argument_repair_limit: ClassVar[int] = 2
 
     def __post_init__(self) -> None:
         """Freeze configured tool availability."""

--- a/box_agent/workflows/controlled_presentation.py
+++ b/box_agent/workflows/controlled_presentation.py
@@ -272,6 +272,12 @@ _OUTLINE_TARGET_TOOL_ERROR = (
     "artifact-relative path outline.json; never use the absolute session-workspace "
     "path. For a large outline, every ordered write_file chunk must use that same path."
 )
+_OUTLINE_JSON_TOOL_ERROR = (
+    "CONTROLLED_PRESENTATION_OUTLINE_JSON_INVALID: the proposed outline.json body "
+    "is not valid JSON ({detail}). Correct the JSON syntax and retry the same "
+    "write_file call. Use ordered chunk_index/final writes only when the complete "
+    "document cannot fit in one response."
+)
 _RESEARCH_ARTIFACT_TARGET_TOOL_ERROR = (
     "CONTROLLED_PRESENTATION_RESEARCH_ARTIFACT_TARGET_REQUIRED: keep research "
     "artifacts under the canonical presentation artifact root. Use an "
@@ -1727,6 +1733,30 @@ def _outline_target_error(
     )
 
 
+def _outline_json_error(
+    stage: str | None,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> str | None:
+    """Reject malformed single-call outline writes before replacing the artifact."""
+    if stage not in {"outline", "outline_repair"} or tool_name != "write_file":
+        return None
+    if Path(str(arguments.get("path") or "")).name != "outline.json":
+        return None
+    chunk_index = arguments.get("chunk_index", 0)
+    if chunk_index != 0 or arguments.get("final", True) is False:
+        return None
+    content = arguments.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        json.loads(content)
+    except json.JSONDecodeError as exc:
+        detail = f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        return _OUTLINE_JSON_TOOL_ERROR.format(detail=detail)
+    return None
+
+
 def _repair_artifact_name(stage: str | None) -> str | None:
     if stage == "outline_repair":
         return "outline.json"
@@ -2923,6 +2953,11 @@ class ControlledPresentationPolicy:
             self.workspace_dir,
             self.artifact_root_dir,
         )
+        outline_json_error = _outline_json_error(
+            self.stage,
+            tool_name,
+            arguments,
+        )
         research_artifact_target_error = _research_artifact_target_error(
             self.stage,
             tool_name,
@@ -2936,6 +2971,8 @@ class ControlledPresentationPolicy:
             return _IMAGE_AUTH_BLOCKED_TOOL_ERROR
         if outline_target_error is not None:
             return outline_target_error
+        if outline_json_error is not None:
+            return outline_json_error
         if research_artifact_target_error is not None:
             return research_artifact_target_error
         if handoff_error is not None:

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -493,6 +493,8 @@ def test_cli_uses_saved_code_workspace_mode(tmp_path: Path, monkeypatch) -> None
 
     assert exit_code == 0
     assert workspace_tool_options["use_output_dir"] is False
+    assert workspace_tool_options["image_inspection_default_strategy"] == "native"
+    assert workspace_tool_options["image_inspection_max_output_tokens_cap"] == 4096
     system_prompt = _CaptureStreamLLM.instances[0].system_prompts[0]
     assert "Project Workspace Mode" in system_prompt
     assert "Software Engineering Mode (code_agent)" in system_prompt

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -3924,6 +3924,42 @@ def test_controlled_repair_allows_only_staged_transaction_for_expected_artifact(
     )
 
 
+def test_controlled_outline_rejects_malformed_single_call_json_before_write(tmp_path):
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=None,
+        stage="outline",
+    )
+
+    error = policy.tool_call_error(
+        "write_file",
+        {"path": "outline.json", "content": '{"slides": [}'},
+        verified_evidence_urls=set(),
+    )
+
+    assert "CONTROLLED_PRESENTATION_OUTLINE_JSON_INVALID" in (error or "")
+    assert "line 1, column" in (error or "")
+
+
+def test_controlled_outline_json_guard_preserves_ordered_chunk_writes(tmp_path):
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=None,
+        stage="outline",
+    )
+
+    assert policy.tool_call_error(
+        "write_file",
+        {
+            "path": "outline.json",
+            "content": '{"slides": [',
+            "chunk_index": 0,
+            "final": False,
+        },
+        verified_evidence_urls=set(),
+    ) is None
+
+
 def test_controlled_apply_patch_repair_allows_bound_staged_transaction(tmp_path):
     policy = ControlledPresentationPolicy(
         workspace_dir=str(tmp_path),

--- a/tests/test_image_inspection_tool.py
+++ b/tests/test_image_inspection_tool.py
@@ -160,6 +160,59 @@ async def test_inspect_images_native_returns_request_only_canonical_blocks(
 
 
 @pytest.mark.asyncio
+async def test_inspect_images_can_default_to_native_for_tui(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    llm = FakeVisionLLM()
+    tool = _tool(
+        tmp_path,
+        llm,
+        native_supported=True,
+        default_strategy="native",
+    )
+
+    result = await tool.invoke(
+        {
+            "image_paths": ["slide.png"],
+            "instruction": "Check readability.",
+        }
+    )
+
+    assert result.success, result.error
+    assert llm.calls == 0
+    assert result.raw_output["type"] == "image_inspection_native"
+    assert result.transient_followup_content is not None
+    assert tool.parameters["properties"]["strategy"]["default"] == "native"
+    assert "active TUI model accepts native image input" in tool.description
+
+
+@pytest.mark.asyncio
+async def test_inspect_images_tui_default_keeps_explicit_proxy_fallback(tmp_path: Path):
+    image = tmp_path / "slide.png"
+    image.write_bytes(_ONE_PIXEL_PNG)
+    llm = FakeVisionLLM("Proxy inspection succeeded.")
+    tool = _tool(
+        tmp_path,
+        llm,
+        native_supported=True,
+        default_strategy="native",
+    )
+
+    result = await tool.invoke(
+        {
+            "image_paths": ["slide.png"],
+            "instruction": "Check readability.",
+            "strategy": "proxy",
+        }
+    )
+
+    assert result.success, result.error
+    assert result.content == "Proxy inspection succeeded."
+    assert llm.calls == 1
+    assert result.transient_followup_content is None
+
+
+@pytest.mark.asyncio
 async def test_inspect_images_native_rejects_before_reading_when_main_model_is_text_only(
     tmp_path: Path,
 ):
@@ -631,6 +684,64 @@ def test_add_workspace_tools_routes_inspect_images_to_catalog_vision_model(
     assert tool.llm.model == "vision-model"
     assert tool.llm.max_output_tokens == 8192
     assert tool.native_supported is False
+    assert tool.default_strategy == "proxy"
+
+
+def test_add_workspace_tools_bounds_proxy_without_disabling_native_input(
+    tmp_path: Path,
+):
+    class CloneableVisionLLM(FakeVisionLLM):
+        model = "sensenova-harness-vision-v1.0"
+        max_output_tokens = 63_999
+
+        def for_model(self, model, *, max_output_tokens=None):
+            selected = CloneableVisionLLM()
+            selected.model = model
+            selected.max_output_tokens = max_output_tokens
+            return selected
+
+    llm = CloneableVisionLLM()
+    tools = []
+
+    add_workspace_tools(
+        tools,
+        ToolConfig(),
+        tmp_path,
+        allow_full_access=False,
+        llm=llm,
+        output=lambda *_: None,
+        image_inspection_default_strategy="native",
+        image_inspection_max_output_tokens_cap=4096,
+    )
+
+    tool = next(tool for tool in tools if tool.name == "inspect_images")
+    assert tool.llm is not llm
+    assert tool.llm.max_output_tokens == 4096
+    assert tool.native_supported is True
+    assert tool.default_strategy == "native"
+
+
+def test_add_workspace_tools_preserves_protocol_host_image_defaults(tmp_path: Path):
+    class ProtocolVisionLLM(FakeVisionLLM):
+        model = "sensenova-harness-vision-v1.0"
+        max_output_tokens = 63_999
+
+    llm = ProtocolVisionLLM()
+    tools = []
+
+    add_workspace_tools(
+        tools,
+        ToolConfig(),
+        tmp_path,
+        allow_full_access=False,
+        llm=llm,
+        output=lambda *_: None,
+    )
+
+    tool = next(tool for tool in tools if tool.name == "inspect_images")
+    assert tool.llm is llm
+    assert tool.llm.max_output_tokens == 63_999
+    assert tool.default_strategy == "proxy"
 
 
 def test_explicit_text_only_current_model_routes_to_other_vision_candidate(

--- a/tests/test_length_retry_no_double_render.py
+++ b/tests/test_length_retry_no_double_render.py
@@ -93,6 +93,21 @@ class _ScriptedLLM:
         )
 
 
+class _PresentationArgumentRepairPolicy:
+    checkpoint_injection_id = "test-presentation-checkpoint"
+    evidence_read_batch_size = 1
+    tool_argument_repair_limit = 2
+
+    def build_checkpoint(self):
+        return None
+
+    def allows_completion_continuation(self):
+        return False
+
+    def suppresses_generic_final_summary(self):
+        return False
+
+
 def _msgs() -> list[Message]:
     return [
         Message(role="system", content="sys"),
@@ -411,6 +426,57 @@ async def test_repeated_tool_argument_limit_stops_after_one_repair():
     assert [e for e in events if isinstance(e, DoneEvent)][-1].stop_reason == StopReason.ERROR
     assert len([e for e in events if isinstance(e, InjectedMessageEvent)]) == 1
     assert llm.ephemeral_max_tokens_history == [None, None]
+
+
+async def test_controlled_presentation_gets_two_chunked_write_repairs():
+    oversized = {
+        "finish_reason": "tool_argument_limit",
+        "oversized_tool_calls": [
+            {"name": "execute_code", "arguments_len": 16004, "limit": 16000}
+        ],
+    }
+    llm = _ScriptedLLM(
+        [oversized, oversized, {"text": "done.", "finish_reason": "stop"}]
+    )
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={},
+            max_steps=5,
+            workflow_policy=_PresentationArgumentRepairPolicy(),
+        )
+    )
+
+    assert llm.calls == 3
+    assert [e for e in events if isinstance(e, DoneEvent)][-1].stop_reason == StopReason.END_TURN
+    assert len([e for e in events if isinstance(e, InjectedMessageEvent)]) == 2
+    assert llm.ephemeral_max_tokens_history == [None, None, None]
+
+
+async def test_controlled_presentation_stops_after_two_argument_repairs():
+    oversized = {
+        "finish_reason": "tool_argument_limit",
+        "oversized_tool_calls": [
+            {"name": "execute_code", "arguments_len": 16004, "limit": 16000}
+        ],
+    }
+    llm = _ScriptedLLM([oversized, oversized, oversized])
+
+    events = await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=_msgs(),
+            tools={},
+            max_steps=5,
+            workflow_policy=_PresentationArgumentRepairPolicy(),
+        )
+    )
+
+    assert llm.calls == 3
+    assert [e for e in events if isinstance(e, DoneEvent)][-1].stop_reason == StopReason.ERROR
+    assert len([e for e in events if isinstance(e, InjectedMessageEvent)]) == 2
 
 
 # ── Case 3 bound: continuation budget is respected ──


### PR DESCRIPTION
## TPR

### Task

- What changed:
  - Reject malformed final one-shot `outline.json` writes before replacing the current presentation checkpoint.
  - Allow controlled presentation workflows one additional bounded recovery attempt for oversized tool arguments.
  - Prefer native image inspection in the TUI when the active model supports vision, while bounding optional proxy inspection output.
- Why:
  - Recoverable model-output and vision-routing conditions could otherwise stop deck authoring or add an unnecessary second model request.
- Affected entry points:
  - Shared controlled-presentation policy and optional core recovery hook.
  - Standalone CLI/TUI image-inspection setup.
- Out of scope:
  - No ACP adapter changes.
  - No built-in Skill changes.
  - No public CLI or protocol changes.

### Proof

- Tests or checks run:
  - `uv run pytest tests/test_cli_runtime.py tests/test_completion_gate.py tests/test_image_inspection_tool.py tests/test_length_retry_no_double_render.py -q`
  - Result: `313 passed in 5.42s`
  - `git diff --check upstream/main...HEAD`
  - Result: passed
- Logs, screenshots, probes, or manifests:
  - All three commits have valid GPG signatures.
  - Branch is based on `upstream/main` at `e4167a98734ec2abf466510ad94f414dc2b17113`.
  - Remote Head is `1e0f8ea`.
- Not run, with reason:
  - Full repository preflight and packaged OfficeV3 live verification are pending while this PR remains a draft.

### Risk

- Compatibility:
  - Existing global oversized-argument recovery remains at one attempt; only controlled presentation policy opts into two.
  - `ImageInspectionTool` retains `proxy` as its constructor default; only the CLI explicitly selects `native`.
  - Explicit `strategy="proxy"` remains available.
- Packaging/runtime impact:
  - Runtime rebuild and install are required before a packaged host can consume the shared policy changes.
- Config, secrets, or migration:
  - None.
- Rollback:
  - Revert the three commits.
- Cross-repository follow-up:
  - Optional packaged-runtime installation and fresh live-task verification.

### Design and architecture impact

- Affected layers and owners:
  - `box_agent/workflows/controlled_presentation.py`: workflow-owned outline and recovery invariants.
  - `box_agent/core.py`: optional bounded recovery limit.
  - `box_agent/tools/image_inspection_tool.py` and `box_agent/tools/setup.py`: configurable inspection strategy and utility token cap.
  - `box_agent/cli.py`: TUI-specific image-inspection defaults.
- Contract, schema, or protocol impact:
  - Additive internal options with backward-compatible defaults.
  - No ACP protocol changes.
- Documentation updated:
  - No new user-facing command or configuration surface.

### Target branch consistency

- Base branch and reviewed Head SHA:
  - Base: `e4167a98734ec2abf466510ad94f414dc2b17113`
  - Head: `1e0f8ea`
- Relevant target-branch changes considered:
  - Current controlled-presentation, tool-argument recovery, and native image-inspection implementations.
- Rebase, compatibility, or historical-fix risk:
  - Branch is rebased directly onto current `upstream/main`; main was not merged.

## Issue details

### Malformed outline JSON can replace the current checkpoint

- Issue:
  - Invalid final one-shot JSON can reach the file tool before post-write outline validation.
- Expected result:
  - Syntax errors are rejected before replacement while schema, evidence, and content validation remain owned by the existing post-write validator.
- Actual result:
  - A valid previous outline can be replaced by malformed JSON, forcing avoidable recovery work.
- Technical fix:
  - Add a narrow controlled-presentation pre-execution syntax guard for final one-shot `outline.json` writes during outline stages.
  - Preserve ordered chunk writes and the existing full validator.

### One oversized-argument retry can be insufficient

- Issue:
  - The first repair response can also exceed the streamed tool-argument budget.
- Expected result:
  - Controlled presentation authoring receives one additional finite opportunity to switch to chunked writing.
- Actual result:
  - The workflow can terminate before producing an artifact after a second oversized response.
- Technical fix:
  - Add an optional workflow-policy repair limit.
  - Preserve the shared default of one and set only controlled presentations to two.
  - Clamp custom limits to a small bounded range.

### TUI vision inspection takes an unnecessary proxy path

- Issue:
  - The TUI defaults to a second proxy request even when the active model accepts native image input.
- Expected result:
  - Native transient image blocks are preferred; proxy inspection remains an explicit bounded fallback.
- Actual result:
  - The extra request adds latency and can inherit an unnecessarily large output-token reservation.
- Technical fix:
  - Configure only the CLI to default to native inspection.
  - Cap its optional proxy inspection client at 4096 output tokens.
  - Preserve protocol-host defaults and explicit proxy selection.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Focused tests cover the changed behavior.
- [x] No ACP adapter or built-in Skill files changed.
- [x] No local config, secrets, logs, or workspace artifacts are included.
- [x] The branch is based on the latest upstream main.
- [ ] Full repository preflight is pending while the PR remains a draft.
- [ ] Packaged runtime install, restart, and fresh live-task verification are pending.
