### PR TITLE
fix: preserve dynamic tools under completion gates

### DIFF
--- a/box_agent/completion.py
+++ b/box_agent/completion.py
@@ -10,7 +10,7 @@ from typing import Final
 from .artifacts import OUTPUT_SUBDIR
 from .config import ToolLimitsConfig
 from .delivery import (
-    has_deliverable_intent,
+    extract_deliverable_clauses,
     is_meta_prompt_rewrite_request,
     strip_negated_format_clauses,
 )
@@ -277,9 +277,10 @@ def build_auto_completion_gate(
             max_continuations=completion_limits.max_continuations,
             deadline_seconds=completion_limits.deadline_seconds,
         )
+    deliverable_clauses = extract_deliverable_clauses(user_text)
     if (
         not confirmed_presentation
-        and not has_deliverable_intent(user_text)
+        and not deliverable_clauses
         and not requires_host_receipt
     ):
         return None
@@ -307,7 +308,7 @@ def build_auto_completion_gate(
             execution_result_criteria_count=execution_result_criteria_count,
         )
 
-    text = user_text.strip().lower()
+    text = "\n".join(deliverable_clauses).strip().lower()
     positive_format_text = strip_negated_format_clauses(text)
     native_image_generation = _is_native_image_generation_request(
         text,

--- a/box_agent/completion.py
+++ b/box_agent/completion.py
@@ -285,6 +285,7 @@ def build_auto_completion_gate(
     ):
         return None
 
+    deliverable_text = "\n".join(deliverable_clauses).strip()
     presentation_gate = (
         build_presentation_completion_gate(
             user_text,
@@ -292,6 +293,9 @@ def build_auto_completion_gate(
             confirmed_presentation=confirmed_presentation,
             tool_limits=effective_tool_limits,
             execution_profile=execution_profile,
+            routing_text=(
+                user_text if confirmed_presentation else deliverable_text
+            ),
         )
         if allow_controlled_presentation
         else None
@@ -308,7 +312,7 @@ def build_auto_completion_gate(
             execution_result_criteria_count=execution_result_criteria_count,
         )
 
-    text = "\n".join(deliverable_clauses).strip().lower()
+    text = deliverable_text.lower()
     positive_format_text = strip_negated_format_clauses(text)
     native_image_generation = _is_native_image_generation_request(
         text,

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -4015,7 +4015,10 @@ async def run_agent_loop(
                     if tool.name in pending_required_tools
                     or (
                         tool_exposure_manager is not None
-                        and tool.name == "tool_search"
+                        and (
+                            tool.name == "tool_search"
+                            or tool.name in offered_mcp_generations
+                        )
                     )
                 ]
         offered_tools_by_name = {tool.name: tool for tool in tool_list}

--- a/box_agent/delivery.py
+++ b/box_agent/delivery.py
@@ -33,6 +33,59 @@ DELIVERABLE_INTENT_KEYWORDS: Final[tuple[str, ...]] = (
     "finish",
 )
 
+_DELIVERABLE_CLAUSE_RE: Final[re.Pattern[str]] = re.compile(r"[^。！？!?；;\n]+")
+_DELIVERABLE_ACTION_RE: Final[re.Pattern[str]] = re.compile(
+    "|".join(
+        re.escape(keyword)
+        for keyword in sorted(DELIVERABLE_INTENT_KEYWORDS, key=len, reverse=True)
+    ),
+    re.IGNORECASE,
+)
+_ACTION_CONNECTOR_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:然后|随后|接着|之后|再|并且|并|\b(?:and\s+then|then|afterwards)\b)",
+    re.IGNORECASE,
+)
+_INFORMATIONAL_ACTION_PREFIXES: Final[tuple[str, ...]] = (
+    "如何",
+    "怎么",
+    "怎样",
+    "介绍",
+    "文档",
+    "教程",
+    "能力",
+    "用法",
+    "阅读",
+    "了解",
+    "学习",
+    "掌握",
+    "研究",
+    "查阅",
+    "说明",
+    "how to",
+    "learn",
+    "read",
+    "understand",
+    "explain",
+    "documentation",
+    "guide",
+)
+_NEGATED_ACTION_PREFIXES: Final[tuple[str, ...]] = (
+    "不要",
+    "不用",
+    "无需",
+    "禁止",
+    "避免",
+    "do not",
+    "don't",
+    "without",
+    "avoid",
+    "never",
+)
+_INFORMATIONAL_ACTION_SUFFIX_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\s*(?:的)?(?:模型)?(?:的)?(?:介绍|能力|文档|教程|用法|方法|说明)",
+    re.IGNORECASE,
+)
+
 NEGATED_FORMAT_CLAUSE_RE: Final[re.Pattern[str]] = re.compile(
     r"(?:不要|不用|禁止|避免|无需|不能|不可|别|"
     r"\b(?:do\s+not|don't|without|avoid|never|no)\b)"
@@ -90,11 +143,48 @@ _DIRECT_PRESENTATION_REMAKE_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 
+def _local_action_prefix(clause: str, action_start: int) -> str:
+    """Return text governing one action after its nearest local boundary."""
+
+    prefix = clause[:action_start]
+    boundary = max(prefix.rfind("，"), prefix.rfind(","))
+    for match in _ACTION_CONNECTOR_RE.finditer(prefix):
+        boundary = max(boundary, match.end() - 1)
+    return prefix[boundary + 1 :].strip().casefold()
+
+
+def _action_is_informational(clause: str, action: re.Match[str]) -> bool:
+    local_prefix = _local_action_prefix(clause, action.start())
+    if any(marker in local_prefix for marker in _NEGATED_ACTION_PREFIXES):
+        return True
+    if any(marker in local_prefix for marker in _INFORMATIONAL_ACTION_PREFIXES):
+        return True
+    return bool(_INFORMATIONAL_ACTION_SUFFIX_RE.match(clause[action.end() :]))
+
+
+def extract_deliverable_clauses(text: str) -> tuple[str, ...]:
+    """Extract clauses containing an executable artifact-delivery action.
+
+    Mentions such as ``如何生成图片`` or ``图片生成的介绍`` describe a
+    capability rather than requesting an artifact. A later coordinated action,
+    as in ``先阅读文档，然后生成一张图``, is evaluated independently.
+    """
+
+    clauses: list[str] = []
+    for clause_match in _DELIVERABLE_CLAUSE_RE.finditer(text):
+        clause = clause_match.group(0).strip()
+        if not clause:
+            continue
+        if any(
+            not _action_is_informational(clause, action)
+            for action in _DELIVERABLE_ACTION_RE.finditer(clause)
+        ):
+            clauses.append(clause)
+    return tuple(clauses)
+
+
 def has_deliverable_intent(text: str) -> bool:
-    normalized = text.strip().lower()
-    return bool(normalized) and any(
-        keyword in normalized for keyword in DELIVERABLE_INTENT_KEYWORDS
-    )
+    return bool(extract_deliverable_clauses(text))
 
 
 def strip_negated_format_clauses(text: str) -> str:

--- a/box_agent/delivery.py
+++ b/box_agent/delivery.py
@@ -54,6 +54,7 @@ _ACTION_CONNECTOR_RE: Final[re.Pattern[str]] = re.compile(
 )
 _ACTION_AFTER_CONNECTOR_RE: Final[re.Pattern[str]] = re.compile(r"后\s*$")
 _INFORMATIONAL_ACTION_PREFIXES: Final[tuple[str, ...]] = (
+    "关于",
     "如何",
     "怎么",
     "怎样",
@@ -158,17 +159,48 @@ _DIRECT_PRESENTATION_REMAKE_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 
-def _local_action_prefix(clause: str, action_start: int) -> str:
-    """Return text governing one action after its nearest local boundary."""
-
+def _local_action_start(
+    clause: str,
+    action_start: int,
+    *,
+    comma_is_boundary: bool,
+) -> int:
+    """Return the start governed by connectors and optional comma locality."""
     prefix = clause[:action_start]
-    boundary = max(prefix.rfind("，"), prefix.rfind(","))
+    boundary = (
+        max(prefix.rfind("，"), prefix.rfind(","))
+        if comma_is_boundary
+        else -1
+    )
     for match in _ACTION_CONNECTOR_RE.finditer(prefix):
         boundary = max(boundary, match.end() - 1)
     after_match = _ACTION_AFTER_CONNECTOR_RE.search(prefix)
     if after_match is not None:
         boundary = max(boundary, after_match.start())
-    return prefix[boundary + 1 :].strip().casefold()
+    return boundary + 1
+
+
+def _local_action_bounds(clause: str, action_start: int) -> tuple[int, int]:
+    """Return the connector-delimited delivery segment for one action."""
+    following_connector = next(
+        _ACTION_CONNECTOR_RE.finditer(clause, action_start),
+        None,
+    )
+    end = (
+        following_connector.start()
+        if following_connector is not None
+        else len(clause)
+    )
+    return (
+        _local_action_start(clause, action_start, comma_is_boundary=False),
+        end,
+    )
+
+
+def _local_action_prefix(clause: str, action_start: int) -> str:
+    """Return text governing one action after its nearest local boundary."""
+    start = _local_action_start(clause, action_start, comma_is_boundary=True)
+    return clause[start:action_start].strip().casefold()
 
 
 def _action_is_informational(clause: str, action: re.Match[str]) -> bool:
@@ -181,7 +213,7 @@ def _action_is_informational(clause: str, action: re.Match[str]) -> bool:
 
 
 def extract_deliverable_clauses(text: str) -> tuple[str, ...]:
-    """Extract clauses containing an executable artifact-delivery action.
+    """Extract local segments containing an executable artifact-delivery action.
 
     Mentions such as ``如何生成图片`` or ``图片生成的介绍`` describe a
     capability rather than requesting an artifact. A later coordinated action,
@@ -193,11 +225,13 @@ def extract_deliverable_clauses(text: str) -> tuple[str, ...]:
         clause = clause_match.group(0).strip()
         if not clause:
             continue
-        if any(
-            not _action_is_informational(clause, action)
-            for action in _DELIVERABLE_ACTION_RE.finditer(clause)
-        ):
-            clauses.append(clause)
+        for action in _DELIVERABLE_ACTION_RE.finditer(clause):
+            if _action_is_informational(clause, action):
+                continue
+            start, end = _local_action_bounds(clause, action.start())
+            segment = clause[start:end].strip(" ，,")
+            if segment and segment not in clauses:
+                clauses.append(segment)
     return tuple(clauses)
 
 

--- a/box_agent/delivery.py
+++ b/box_agent/delivery.py
@@ -25,6 +25,7 @@ DELIVERABLE_INTENT_KEYWORDS: Final[tuple[str, ...]] = (
     "create",
     "generate",
     "make",
+    "remake",
     "build",
     "export",
     "save",
@@ -34,17 +35,24 @@ DELIVERABLE_INTENT_KEYWORDS: Final[tuple[str, ...]] = (
 )
 
 _DELIVERABLE_CLAUSE_RE: Final[re.Pattern[str]] = re.compile(r"[^。！？!?；;\n]+")
+_DELIVERABLE_ACTION_PATTERN: Final[str] = "|".join(
+    (
+        rf"(?<![A-Za-z0-9_]){re.escape(keyword)}(?![A-Za-z0-9_])"
+        if keyword.isascii()
+        else re.escape(keyword)
+    )
+    for keyword in sorted(DELIVERABLE_INTENT_KEYWORDS, key=len, reverse=True)
+)
 _DELIVERABLE_ACTION_RE: Final[re.Pattern[str]] = re.compile(
-    "|".join(
-        re.escape(keyword)
-        for keyword in sorted(DELIVERABLE_INTENT_KEYWORDS, key=len, reverse=True)
-    ),
+    _DELIVERABLE_ACTION_PATTERN,
     re.IGNORECASE,
 )
 _ACTION_CONNECTOR_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:然后|随后|接着|之后|再|并且|并|\b(?:and\s+then|then|afterwards)\b)",
+    r"(?:然后|随后|接着|之后|再|并且|并|"
+    r"\b(?:and(?:\s+then)?|then|afterwards)\b)",
     re.IGNORECASE,
 )
+_ACTION_AFTER_CONNECTOR_RE: Final[re.Pattern[str]] = re.compile(r"后\s*$")
 _INFORMATIONAL_ACTION_PREFIXES: Final[tuple[str, ...]] = (
     "如何",
     "怎么",
@@ -82,7 +90,14 @@ _NEGATED_ACTION_PREFIXES: Final[tuple[str, ...]] = (
     "never",
 )
 _INFORMATIONAL_ACTION_SUFFIX_RE: Final[re.Pattern[str]] = re.compile(
-    r"^\s*(?:的)?(?:模型)?(?:的)?(?:介绍|能力|文档|教程|用法|方法|说明)",
+    r"^\s*(?:"
+    r"(?:能力(?:介绍|说明)?|用法|方法)"
+    r"|(?:的(?:模型(?:的)?)?|模型(?:的)?)"
+    r"(?:介绍|能力(?:介绍|说明)?|文档|教程|用法|方法|说明)"
+    r"|[^，,。！？!?；;\n]{1,32}?的"
+    r"(?:介绍|能力(?:介绍|说明)?|教程|用法|方法|说明)"
+    r"(?:部分|一下)?\s*$"
+    r")",
     re.IGNORECASE,
 )
 
@@ -150,6 +165,9 @@ def _local_action_prefix(clause: str, action_start: int) -> str:
     boundary = max(prefix.rfind("，"), prefix.rfind(","))
     for match in _ACTION_CONNECTOR_RE.finditer(prefix):
         boundary = max(boundary, match.end() - 1)
+    after_match = _ACTION_AFTER_CONNECTOR_RE.search(prefix)
+    if after_match is not None:
+        boundary = max(boundary, after_match.start())
     return prefix[boundary + 1 :].strip().casefold()
 
 

--- a/box_agent/workflows/presentation_routing.py
+++ b/box_agent/workflows/presentation_routing.py
@@ -210,11 +210,13 @@ def build_presentation_completion_gate(
     confirmed_presentation: bool = False,
     tool_limits: ToolLimitsConfig | None = None,
     execution_profile: ExecutionProfile = "standard",
+    routing_text: str | None = None,
 ) -> CompletionGate | None:
     """Build the presentation workflow gate, or return None for another router."""
-    if not confirmed_presentation and classify_presentation_request(user_text) is None:
+    delivery_text = user_text if routing_text is None else routing_text
+    if not confirmed_presentation and classify_presentation_request(delivery_text) is None:
         return None
-    text = user_text.strip().lower()
+    text = delivery_text.strip().lower()
     positive_format_text = strip_negated_format_clauses(text)
     effective_tool_limits = tool_limits or ToolLimitsConfig()
     completion_limits = effective_tool_limits.completion

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -9252,7 +9252,12 @@ def test_build_auto_completion_gate_ignores_non_deliverable_prompt(tmp_path):
         "介绍一下信息图生成能力，以及如何生图。",
         "学习并掌握 SenseNova U1 Fast 的生图用法。",
         "Read the documentation to learn how to create an image.",
+        "Read the documentation and saved Word document examples.",
+        "Read the documentation and finished Word document examples.",
+        "Read the documentation and builder HTML guide.",
         "阅读报告，了解表格和文档是如何生成的。",
+        "生成图片的能力介绍。",
+        "了解后端生成一张图片的实现方式。",
     ],
 )
 def test_informational_artifact_prompt_does_not_create_gate(tmp_path, prompt):
@@ -9263,8 +9268,10 @@ def test_informational_artifact_prompt_does_not_create_gate(tmp_path, prompt):
     "prompt",
     [
         "先阅读官方文档，然后生成一张 PNG 信息图。",
+        "阅读官方文档后生成一张 PNG 信息图。",
         "介绍完模型后，再帮我生成一张图片。",
         "Read the documentation and then create an image.",
+        "Read the documentation and create an image.",
     ],
 )
 def test_research_then_explicit_image_delivery_still_creates_gate(
@@ -9276,6 +9283,33 @@ def test_research_then_explicit_image_delivery_still_creates_gate(
     assert gate is not None
     assert gate.required_tools == frozenset({"generate_image"})
     assert gate.restrict_tools_until_required_succeed is True
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "生成文档。",
+        "Word 文档，请创建一份。",
+        "请帮我create一个Word文档。",
+        "创建项目的文档。",
+        "生成客户的文档。",
+        "生成产品的文档。",
+    ],
+)
+def test_direct_document_delivery_preserves_document_context(tmp_path, prompt):
+    gate = build_auto_completion_gate(prompt, tmp_path)
+
+    assert gate is not None
+    assert gate.required_tools == frozenset()
+    assert gate.required_changed_artifact_globs == ("output/**/*.docx",)
+    assert gate.restrict_tools_until_required_succeed is False
+
+
+def test_format_after_comma_remains_in_delivery_clause(tmp_path):
+    gate = build_auto_completion_gate("生成一份报告，Word 格式。", tmp_path)
+
+    assert gate is not None
+    assert "output/**/*.docx" in gate.required_changed_artifact_globs
 
 
 def test_native_image_gate_requires_standard_tool_before_alternatives(tmp_path):

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -9258,6 +9258,7 @@ def test_build_auto_completion_gate_ignores_non_deliverable_prompt(tmp_path):
         "阅读报告，了解表格和文档是如何生成的。",
         "生成图片的能力介绍。",
         "了解后端生成一张图片的实现方式。",
+        "关于生成图片的文档在哪里？",
     ],
 )
 def test_informational_artifact_prompt_does_not_create_gate(tmp_path, prompt):
@@ -9283,6 +9284,27 @@ def test_research_then_explicit_image_delivery_still_creates_gate(
     assert gate is not None
     assert gate.required_tools == frozenset({"generate_image"})
     assert gate.restrict_tools_until_required_succeed is True
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "介绍如何生成 PPT，然后创建一个 Excel 表格。",
+        "创建一个 Excel 表格，并介绍如何生成 PPT。",
+    ],
+)
+def test_mixed_informational_presentation_routes_executable_spreadsheet(
+    tmp_path,
+    prompt,
+):
+    gate = build_auto_completion_gate(prompt, tmp_path)
+
+    assert gate is not None
+    assert gate.workflow_checkpoint_kind is None
+    assert gate.required_changed_artifact_globs == (
+        "output/**/*.xlsx",
+        "output/**/*.xls",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -9239,6 +9239,45 @@ def test_build_auto_completion_gate_ignores_non_deliverable_prompt(tmp_path):
     assert gate is None
 
 
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        (
+            "https://platform.sensenova.cn/docs,你现在使用了商汤的模型，"
+            "麻烦你去阅读一下官方的文档，特别是关于SenseNova U1 Fast "
+            "基于SenseNovaU1的加速版本，专供信息图(Infographics)生成的"
+            "介绍部分，要求掌握如何利用这个模型生图。"
+        ),
+        "请阅读官方文档，了解如何利用这个模型生成图片。",
+        "介绍一下信息图生成能力，以及如何生图。",
+        "学习并掌握 SenseNova U1 Fast 的生图用法。",
+        "Read the documentation to learn how to create an image.",
+        "阅读报告，了解表格和文档是如何生成的。",
+    ],
+)
+def test_informational_artifact_prompt_does_not_create_gate(tmp_path, prompt):
+    assert build_auto_completion_gate(prompt, tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "先阅读官方文档，然后生成一张 PNG 信息图。",
+        "介绍完模型后，再帮我生成一张图片。",
+        "Read the documentation and then create an image.",
+    ],
+)
+def test_research_then_explicit_image_delivery_still_creates_gate(
+    tmp_path,
+    prompt,
+):
+    gate = build_auto_completion_gate(prompt, tmp_path)
+
+    assert gate is not None
+    assert gate.required_tools == frozenset({"generate_image"})
+    assert gate.restrict_tools_until_required_succeed is True
+
+
 def test_native_image_gate_requires_standard_tool_before_alternatives(tmp_path):
     gate = build_auto_completion_gate("生成一张 PNG 信息图", tmp_path)
 

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -10,6 +10,7 @@ import pytest
 
 from box_agent.agent import Agent
 from box_agent.events import ToolCallResult, ToolCallStart
+from box_agent.loop_guards import CompletionGate
 from box_agent.runtime import run_agent_loop
 from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
 from box_agent.tools import mcp_loader
@@ -820,6 +821,95 @@ async def test_search_then_real_tool_is_exposed_on_next_step() -> None:
     assert real_start.server_name == "crm"
     assert real_result.tool_id == "mcp:crm/lookup"
     assert real_result.server_name == "crm"
+
+
+@pytest.mark.asyncio
+async def test_restrictive_gate_preserves_tool_search_activation() -> None:
+    catalog = MCPToolCatalog()
+    lookup = FakeMCPTool("lookup", "crm", "Lookup")
+    catalog.replace_server("crm", [lookup])
+    activated = OrderedDict()
+    manager = MCPToolExposureManager(catalog, activated)
+    search = ToolSearchTool(catalog, activated)
+    generate_image = FakeCoreTool("generate_image")
+    fallback = FakeCoreTool("fallback")
+    llm = MockLLM(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="search-call",
+                        type="function",
+                        function=FunctionCall(
+                            name="tool_search",
+                            arguments={"query": "lookup"},
+                        ),
+                    )
+                ],
+                finish_reason="tool",
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="lookup-call",
+                        type="function",
+                        function=FunctionCall(name="lookup", arguments={}),
+                    )
+                ],
+                finish_reason="tool",
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="image-call",
+                        type="function",
+                        function=FunctionCall(
+                            name="generate_image",
+                            arguments={},
+                        ),
+                    )
+                ],
+                finish_reason="tool",
+            ),
+            LLMResponse(content="done", tool_calls=[], finish_reason="stop"),
+        ]
+    )
+
+    await _collect(
+        run_agent_loop(
+            llm=llm,
+            messages=[Message(role="system", content="test")],
+            tools={
+                "generate_image": generate_image,
+                "fallback": fallback,
+                "tool_search": search,
+            },
+            max_steps=4,
+            tool_exposure_manager=manager,
+            completion_gate=CompletionGate(
+                required_tools=frozenset({"generate_image"}),
+                restrict_tools_until_required_succeed=True,
+            ),
+        )
+    )
+
+    assert set(llm.offered_names[0]) == {"generate_image", "tool_search"}
+    assert set(llm.offered_names[1]) == {
+        "generate_image",
+        "lookup",
+        "tool_search",
+    }
+    assert "fallback" not in llm.offered_names[2]
+    assert set(llm.offered_names[3]) == {
+        "fallback",
+        "generate_image",
+        "lookup",
+        "tool_search",
+    }
+    assert lookup.calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TPR

### Task

- Preserve MCP tools activated through `tool_search` while a restrictive completion gate is waiting for its required tool.
- Temporarily refine heuristic deliverable-intent routing so informational prompts do not create artifact gates and executable prompts retain their required artifact type.
- Isolate connector-delimited executable segments before artifact/presentation classification. This prevents an informational PPT mention from stealing a later Excel request while preserving original research modifiers for presentation research-mode selection.
- Add regression coverage for Chinese/English informational prompts, direct document delivery, research-then-delivery, mixed PPT-information/Excel-execution prompts, and deferred MCP activation.

Affected layers: shared Agent tool exposure, automatic completion-gate composition, temporary text intent helpers, presentation routing input, and focused tests. A model-based intent classifier is the intended long-term replacement and is out of scope for this PR.

### Proof

Current reviewed Head: `ca2619d9f8c86455ed4082b574b9127ad32894f3`

- `uv run python -m compileall -q box_agent` — passed.
- `uv run pytest -q tests/test_completion_gate.py tests/test_mcp_tool_search.py --tb=short` — `324 passed`.
- `uv run pytest -q tests/test_core.py --tb=short` — `183 passed`.
- `uv run pytest -q tests/test_acp.py --tb=short` — `123 passed`.
- `git diff --check` — passed.
- Direct reproductions now behave as required:
  - “关于生成图片的文档在哪里？” and “生成图片的能力介绍” create no artifact gate;
  - “阅读官方文档后生成一张 PNG 信息图” and “Read the documentation and create an image” require `generate_image`;
  - informational PPT + executable Excel prompts route to xlsx/xls and not controlled presentation;
  - direct Word/report delivery retains its document formats.

Not run: packaged runtime build/install, OfficeV3 restart, or a packaged-host live task. GitHub required checks on the rebased Head provide the repository-wide validation gate.

### Risk

- The intent logic remains a bounded text heuristic. Connector and phrase coverage is deliberately narrow; model-based intent classification should replace it rather than expanding the regex indefinitely.
- Presentation routing now receives filtered executable segments for delivery classification but retains original user text for research-depth selection.
- Public schema/config/dependencies/migrations: none.
- Packaging: source changes require a future runtime build before OfficeV3 adopts them; this PR is not part of the already-published `v0.9.7` tag.
- Rollback: revert the PR #91 merge.

### Design and target consistency

- Base: `Raccoon-Office/Box-Agent:main@fa711a64872ac008955a0134247c271c2cb8a9fd`
- Head: `ca2619d9f8c86455ed4082b574b9127ad32894f3`
- The contributor branch was rebased onto current main; main was not merged into it.
- The full merge-base diff was reviewed. No generated cache, logs, credentials, local config, or workspace artifacts are included.
