### PR TITLE
feat(session): add durable JSONL recovery

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -124,6 +124,7 @@ from box_agent.llm.model_routing import normalize_auto_routing, resolve_model_cl
 from box_agent.llm.token_meter import get_token_meter, reset_token_meter, start_token_meter
 from box_agent.runtime import invoke_tool_with_permissions
 from box_agent.session_trace import SessionTraceWriter, scoped_session_trace
+from box_agent.session_log import SessionLog
 from box_agent.task_context import TaskContext, normalize_task_id
 from box_agent.session_continuation import parse_session_continuation
 from box_agent.task_registry import (
@@ -1784,6 +1785,36 @@ class BoxACPAgent:
                 f"{system_prompt.rstrip()}\n\n"
                 f"{build_image_generation_prompt(self._config)}"
             )
+        session_log: SessionLog | None = None
+        session_log_restored = False
+        if upstream_session_id:
+            for existing_handle, existing_state in list(self._sessions.items()):
+                if existing_state.upstream_session_id != upstream_session_id:
+                    continue
+                if existing_state.turn_active:
+                    raise ValueError(
+                        "cannot rebind a product Session while its turn is active"
+                    )
+                existing_log = existing_state.agent.session_log
+                if existing_log is not None:
+                    existing_log.close()
+                del self._sessions[existing_handle]
+            session_root = Path.home() / ".box-agent" / "sessions"
+            try:
+                session_log = SessionLog.open(
+                    session_root,
+                    session_id=upstream_session_id,
+                )
+            except FileNotFoundError:
+                session_log = SessionLog.create(
+                    session_root,
+                    session_id=upstream_session_id,
+                    cwd=workspace,
+                )
+            else:
+                session_log.prepare_resume()
+                session_log_restored = True
+
         agent = Agent(
             llm_client=session_llm,
             system_prompt=system_prompt,
@@ -1811,7 +1842,42 @@ class BoxACPAgent:
                 and self._config.tools.enable_mcp
                 and self._config.tools.mcp.deferred_loading_enabled
             ),
+            session_log=session_log,
         )
+
+        if agent.restored_skills:
+            try:
+                if session_skill_loader is None:
+                    raise ValueError(
+                        "persisted active Skills cannot be restored without a SkillLoader"
+                    )
+                restored_skill_prompts: list[tuple[str, str, str, int]] = []
+                for item in agent.restored_skills:
+                    name = item.get("name")
+                    prompt_hash = item.get("sha256")
+                    load_order = item.get("loadOrder")
+                    if (
+                        not isinstance(name, str)
+                        or not isinstance(prompt_hash, str)
+                        or not isinstance(load_order, int)
+                    ):
+                        raise ValueError("persisted active Skill metadata is invalid")
+                    skill = session_skill_loader.get_skill(
+                        name,
+                        include_disabled=expert_context is not None,
+                    )
+                    if skill is None:
+                        raise ValueError(
+                            f"persisted active Skill {name!r} is unavailable"
+                        )
+                    restored_skill_prompts.append(
+                        (name, skill.to_prompt(), prompt_hash, load_order)
+                    )
+                agent.restore_active_skill_instructions(restored_skill_prompts)
+            except Exception:
+                if session_log is not None:
+                    session_log.close()
+                raise
 
         if initial_goal_request is not None:
             goal_result = self._apply_goal_action(agent, initial_goal_request)
@@ -1870,6 +1936,7 @@ class BoxACPAgent:
             require_plan_approval=require_plan_approval,
             preloaded_skill_hashes=preloaded_skill_hashes,
             follow_up_suggestions_enabled=follow_up_suggestions_enabled,
+            continuation_applied=session_log_restored,
             mcp_fallback_tools=dict(self._base_mcp_fallback_tools),
         )
         trace_writer.write(

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -47,6 +47,7 @@ from .logger import AgentLogger
 from .loop_guards import CompletionGate
 from .runtime import run_agent_loop
 from .schema import Message
+from .session_log import SessionLog
 from .tools.base import Tool, ToolResult, build_tool_name_index
 from .tools.mcp_tool_catalog import get_mcp_tool_catalog
 from .tools.mcp_tool_search import (
@@ -496,6 +497,7 @@ class Agent:
         context_resource_dedup_enabled: bool = True,
         tool_limits: ToolLimitsConfig | None = None,
         deferred_mcp_loading_enabled: bool = True,
+        session_log: SessionLog | None = None,
     ):
         self.llm = llm_client
         self.tools = {
@@ -592,6 +594,8 @@ class Agent:
             # a real MCP tool becomes inheritable without exposing tool_search.
             if hasattr(tool, "set_tool_provider"):
                 tool.set_tool_provider(self._inherited_tools)
+            if session_log is not None and hasattr(tool, "set_parent_session_log"):
+                tool.set_parent_session_log(session_log)
         self.messages: list[Message] = [Message(role="system", content=system_prompt)]
         self.logger = AgentLogger()
         self.api_total_tokens: int = 0
@@ -602,6 +606,65 @@ class Agent:
         self.goal: GoalState | None = None
         self.tools["goal_read"] = _GoalReadTool(self)
         self.tools["goal_write"] = _GoalWriteTool(self)
+        self.session_log = session_log
+        if self.session_log is not None:
+            projection = self.session_log.replay()
+            self.messages.extend(projection.messages)
+            self.restore_goal(projection.goal)
+            plan_tool = self.tools.get("plan_write")
+            configure_plan = getattr(plan_tool, "configure_session_persistence", None)
+            if callable(configure_plan):
+                configure_plan(self.session_log, projection.plan)
+            todo_tool = self.tools.get("todo_write")
+            configure_todos = getattr(todo_tool, "configure_session_persistence", None)
+            if callable(configure_todos):
+                configure_todos(self.session_log, projection.todos)
+            self.restored_skills = projection.skills
+        else:
+            self.restored_skills = []
+
+    def _persist_goal(self) -> None:
+        if self.session_log is None:
+            return
+        self.session_log.append("goal/change", {"goal": goal_payload(self.goal)})
+        self.session_log.flush()
+
+    def _next_session_turn(self) -> int:
+        if self.session_log is None:
+            raise RuntimeError("session log is not configured")
+        turns = [
+            event["data"].get("turn")
+            for event in self.session_log.events
+            if event["type"] == "turn/start"
+        ]
+        numeric_turns = [turn for turn in turns if isinstance(turn, int)]
+        return max(numeric_turns, default=0) + 1
+
+    def _persist_unlogged_messages(
+        self,
+        *,
+        turn: int,
+        step: int | None,
+        tool_result_metadata: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        if self.session_log is None:
+            return
+        self.session_log.append_unlogged_messages(
+            self.messages[1:],
+            turn=turn,
+            step=step,
+            tool_result_metadata=tool_result_metadata,
+        )
+
+    @staticmethod
+    def _session_turn_reason(stop_reason: StopReason) -> dict[str, Any]:
+        if stop_reason is StopReason.END_TURN:
+            return {"kind": "completed"}
+        if stop_reason is StopReason.CANCELLED:
+            return {"kind": "aborted", "message": "cancelled"}
+        if stop_reason is StopReason.ERROR:
+            return {"kind": "error"}
+        return {"kind": stop_reason.value}
 
     def _inherited_tools(self) -> dict[str, Tool]:
         if self.mcp_tool_exposure is None:
@@ -634,6 +697,7 @@ class Agent:
         self._active_skill_sequence += 1
         self._active_skill_load_order[normalized_name] = self._active_skill_sequence
         self.set_system_prompt(self.system_prompt)
+        self._persist_active_skills()
         diagnostics = self.active_skill_diagnostics()
         if diagnostics["budget_exceeded"]:
             _log.warning(
@@ -653,6 +717,7 @@ class Agent:
         self._active_skill_hashes.pop(normalized_name, None)
         self._active_skill_load_order.pop(normalized_name, None)
         self.set_system_prompt(self.system_prompt)
+        self._persist_active_skills()
         return True
 
     def clear_active_skill_instructions(self) -> None:
@@ -662,6 +727,57 @@ class Agent:
         self._active_skill_prompts.clear()
         self._active_skill_hashes.clear()
         self._active_skill_load_order.clear()
+        self.set_system_prompt(self.system_prompt)
+        self._persist_active_skills()
+
+    def _persist_active_skills(self) -> None:
+        if self.session_log is None:
+            return
+        ordered = sorted(
+            self._active_skill_prompts,
+            key=lambda name: self._active_skill_load_order[name],
+        )
+        self.session_log.append(
+            "skill/change",
+            {
+                "skills": [
+                    {
+                        "name": name,
+                        "sha256": self._active_skill_hashes[name],
+                        "loadOrder": self._active_skill_load_order[name],
+                    }
+                    for name in ordered
+                ]
+            },
+        )
+        self.session_log.flush()
+
+    def restore_active_skill_instructions(
+        self,
+        skills: list[tuple[str, str, str, int]],
+    ) -> None:
+        """Restore loader-verified active Skill prompts without writing new events."""
+
+        restored_prompts: dict[str, str] = {}
+        restored_hashes: dict[str, str] = {}
+        restored_order: dict[str, int] = {}
+        for name, prompt, prompt_hash, load_order in sorted(
+            skills,
+            key=lambda item: item[3],
+        ):
+            actual_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+            if actual_hash != prompt_hash:
+                raise ValueError(f"active Skill {name!r} content hash changed")
+            restored_prompts[name] = prompt
+            restored_hashes[name] = prompt_hash
+            restored_order[name] = load_order
+        self._active_skill_prompts = restored_prompts
+        self._active_skill_hashes = restored_hashes
+        self._active_skill_load_order = restored_order
+        self._active_skill_sequence = max(
+            self._active_skill_load_order.values(),
+            default=0,
+        )
         self.set_system_prompt(self.system_prompt)
 
     def active_skill_diagnostics(self) -> dict[str, object]:
@@ -727,6 +843,7 @@ class Agent:
             blocked_reason=(blocked_reason or "").strip() or None,
             completed_by=(completed_by or "").strip() or None,
         )
+        self._persist_goal()
         return self.goal
 
     def pause_goal(self) -> GoalState | None:
@@ -735,6 +852,7 @@ class Agent:
             return None
         self.goal.status = "paused"
         self.goal.updated_at = datetime.now().isoformat()
+        self._persist_goal()
         return self.goal
 
     def resume_goal(self) -> GoalState | None:
@@ -744,6 +862,7 @@ class Agent:
         self.goal.status = "active"
         self.goal.blocked_reason = None
         self.goal.updated_at = datetime.now().isoformat()
+        self._persist_goal()
         return self.goal
 
     def complete_goal(
@@ -764,6 +883,7 @@ class Agent:
         if completed_by:
             self.goal.completed_by = completed_by
         self.goal.updated_at = datetime.now().isoformat()
+        self._persist_goal()
         return self.goal
 
     def update_goal_progress(
@@ -778,6 +898,7 @@ class Agent:
         _extend_goal_items(self.goal.progress, _coerce_goal_items(progress))
         _extend_goal_items(self.goal.evidence, _coerce_goal_items(evidence))
         self.goal.updated_at = datetime.now().isoformat()
+        self._persist_goal()
         return self.goal
 
     def block_goal(
@@ -798,12 +919,14 @@ class Agent:
         _extend_goal_items(self.goal.evidence, _coerce_goal_items(evidence))
         _extend_goal_items(self.goal.progress, _coerce_goal_items(progress))
         self.goal.updated_at = datetime.now().isoformat()
+        self._persist_goal()
         return self.goal
 
     def clear_goal(self) -> GoalState | None:
         """Clear the current goal and return the removed state."""
         old_goal = self.goal
         self.goal = None
+        self._persist_goal()
         return old_goal
 
     def restore_goal(self, payload: object) -> GoalState | None:
@@ -936,6 +1059,19 @@ class Agent:
         if callable(set_child_negotiator):
             set_child_negotiator(effective_options.permission_negotiator)
 
+        session_turn: int | None = None
+        session_step: int | None = None
+        session_turn_open = False
+        session_step_open = False
+        if self.session_log is not None:
+            session_turn = self._next_session_turn()
+            self.session_log.append(
+                "turn/start",
+                {"turn": session_turn},
+            )
+            session_turn_open = True
+            self._persist_unlogged_messages(turn=session_turn, step=None)
+
         events = run_agent_loop(
             llm=effective_options.llm,
             summary_llm=effective_options.summary_llm,
@@ -987,22 +1123,119 @@ class Agent:
             context_resource_dedup_enabled=self.context_resource_dedup_enabled,
             tool_exposure_manager=self.mcp_tool_exposure,
             tool_result_storage=self.tool_result_storage,
+            session_log=self.session_log,
+            session_turn=session_turn,
         )
-        async for event in events:
-            # Track token usage on Agent instance for backward compat
-            if isinstance(event, TokenUsageEvent):
-                self.api_total_tokens = event.total_tokens
-            if isinstance(event, DoneEvent):
-                write_tool = self.tools.get("write_file")
-                cleanup = getattr(write_tool, "cleanup_pending_writes", None)
-                if callable(cleanup):
-                    discarded = cleanup()
-                    if discarded:
-                        _log.info(
-                            "write_file discarded incomplete transactions: %s",
-                            discarded,
+        try:
+            async for event in events:
+                if self.session_log is not None and session_turn is not None:
+                    if isinstance(event, (ContentEvent, ThinkingEvent)):
+                        self.session_log.append(
+                            "assistant/chunk",
+                            {
+                                "turn": session_turn,
+                                "step": session_step,
+                                "kind": (
+                                    "thinking"
+                                    if isinstance(event, ThinkingEvent)
+                                    else "text"
+                                ),
+                                "content": event.content,
+                            },
                         )
-            yield event
+                    elif isinstance(event, StepStart):
+                        session_step = event.step
+                        self._persist_unlogged_messages(
+                            turn=session_turn,
+                            step=session_step,
+                        )
+                        self.session_log.append(
+                            "step/start",
+                            {"turn": session_turn, "step": session_step},
+                        )
+                        session_step_open = True
+                    elif isinstance(event, ToolCallResult):
+                        self._persist_unlogged_messages(
+                            turn=session_turn,
+                            step=session_step,
+                            tool_result_metadata={
+                                event.tool_call_id: {
+                                    "success": event.success,
+                                    "content": event.content,
+                                    "error": event.error,
+                                    "rawOutput": event.raw_output,
+                                    "policyDecision": event.policy_decision,
+                                }
+                            },
+                        )
+                    elif isinstance(event, StepEnd):
+                        self._persist_unlogged_messages(
+                            turn=session_turn,
+                            step=event.step,
+                        )
+                        if session_step_open:
+                            self.session_log.append(
+                                "step/end",
+                                {"turn": session_turn, "step": event.step},
+                            )
+                            self.session_log.flush()
+                            session_step_open = False
+                    elif isinstance(event, DoneEvent):
+                        self._persist_unlogged_messages(
+                            turn=session_turn,
+                            step=session_step,
+                        )
+                        if session_step_open:
+                            self.session_log.append(
+                                "step/end",
+                                {"turn": session_turn, "step": session_step},
+                            )
+                            session_step_open = False
+                        self.session_log.append(
+                            "turn/end",
+                            {
+                                "turn": session_turn,
+                                "reason": self._session_turn_reason(event.stop_reason),
+                            },
+                        )
+                        self.session_log.flush()
+                        session_turn_open = False
+
+                # Track token usage on Agent instance for backward compat
+                if isinstance(event, TokenUsageEvent):
+                    self.api_total_tokens = event.total_tokens
+                if isinstance(event, DoneEvent):
+                    write_tool = self.tools.get("write_file")
+                    cleanup = getattr(write_tool, "cleanup_pending_writes", None)
+                    if callable(cleanup):
+                        discarded = cleanup()
+                        if discarded:
+                            _log.info(
+                                "write_file discarded incomplete transactions: %s",
+                                discarded,
+                            )
+                yield event
+        finally:
+            if (
+                self.session_log is not None
+                and session_turn is not None
+                and session_turn_open
+                and not self.session_log.failed
+            ):
+                self._persist_unlogged_messages(
+                    turn=session_turn,
+                    step=session_step,
+                )
+                if session_step_open:
+                    self.session_log.append(
+                        "step/end",
+                        {"turn": session_turn, "step": session_step},
+                    )
+                self.session_log.append(
+                    "turn/end",
+                    {"turn": session_turn, "reason": {"kind": "interrupted"}},
+                )
+                self.session_log.flush()
 
     # ── Backward-compatible run() ───────────────────────────
 

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -78,6 +78,7 @@ from .llm.capabilities import image_input_support
 from .llm.debug_logging import reset_llm_debug_sink, set_llm_debug_sink
 from .model_history import is_model_history_placeholder
 from .session_trace import emit_session_trace
+from .session_log import SessionLog, SessionLogDurabilityError
 from .loop_guards import (
     EMPTY_ARGS_LIMIT,
     FINAL_SUMMARY_EXCLUDED_TOOLS,
@@ -1944,6 +1945,9 @@ async def _maybe_summarize(
     summary_llm: Any | None = None,
     workflow_checkpoint: str | None = None,
     allow_llm_summary: bool = True,
+    session_log: SessionLog | None = None,
+    session_turn: int | None = None,
+    session_step: int | None = None,
 ) -> CompactionOutcome:
     """Compact once when the complete next request exceeds its safe limit."""
     if skip_check:
@@ -2042,6 +2046,23 @@ async def _maybe_summarize(
         for index, message in enumerate(messages)
         if index > 0 and index not in retained_indices
     ]
+
+    if session_log is not None and session_turn is not None and session_step is not None:
+        session_log.append_unlogged_messages(
+            messages[1:],
+            turn=session_turn,
+            step=session_step,
+        )
+        session_log.append(
+            "compaction/start",
+            {
+                "turn": session_turn,
+                "step": session_step,
+                "estimatedBefore": estimated,
+                "tokenLimit": token_limit,
+            },
+        )
+        session_log.flush()
 
     summary_calls = 0
     error: str | None = None
@@ -2876,6 +2897,8 @@ async def run_agent_loop(
     context_resource_dedup_enabled: bool = True,
     tool_exposure_manager: Any | None = None,
     tool_result_storage: ToolResultStorage | None = None,
+    session_log: SessionLog | None = None,
+    session_turn: int | None = None,
 ) -> AsyncIterator[AgentEvent]:
     """Execute the agent loop, yielding structured events.
 
@@ -3633,6 +3656,9 @@ async def run_agent_loop(
             summary_llm=summary_llm,
             workflow_checkpoint=checkpoint_text,
             allow_llm_summary=summary_failure_cooldown_steps == 0,
+            session_log=session_log,
+            session_turn=session_turn,
+            session_step=step + 1,
         )
         if result.mode == "fallback" and result.summary_calls > 0 and result.error:
             summary_failure_cooldown_steps = (
@@ -3659,6 +3685,58 @@ async def run_agent_loop(
                         turn_id=memory_turn_id,
                     )
                 )
+            if session_log is not None and session_turn is not None:
+                if result.mode == "checkpoint":
+                    session_log.append(
+                        "compaction/prune",
+                        {
+                            "turn": session_turn,
+                            "step": step + 1,
+                            "mode": result.mode,
+                            "estimatedBefore": est_before,
+                            "estimatedAfter": result.estimated_after,
+                        },
+                    )
+                else:
+                    session_log.append(
+                        "compaction/summary",
+                        {
+                            "turn": session_turn,
+                            "step": step + 1,
+                            "mode": result.mode,
+                            "message": new_msgs[1].model_dump(
+                                mode="json",
+                                exclude_none=True,
+                            ),
+                            "estimatedBefore": est_before,
+                            "estimatedAfter": result.estimated_after,
+                            "error": result.error,
+                        },
+                    )
+                session_log.replace_surface(
+                    new_msgs[1:],
+                    turn=session_turn,
+                    step=step + 1,
+                )
+                if result.mode != "checkpoint":
+                    session_log.append(
+                        "compaction/end",
+                        {
+                            "turn": session_turn,
+                            "step": step + 1,
+                            "mode": result.mode,
+                            "error": result.error,
+                        },
+                    )
+                session_log.flush()
+            messages.clear()
+            messages.extend(new_msgs)
+            if resource_ledger is not None:
+                resource_ledger.rotate_epoch()
+                _log.info(
+                    "context_resource/epoch_rotated transform=summary epoch=%d",
+                    resource_ledger.epoch,
+                )
             yield SummarizationEvent(
                 estimated_tokens=est_before,
                 api_tokens=api_prompt_tokens,
@@ -3671,14 +3749,6 @@ async def run_agent_loop(
                 error_type=result.error_type,
                 trigger_source=result.trigger_source,
             )
-            messages.clear()
-            messages.extend(new_msgs)
-            if resource_ledger is not None:
-                resource_ledger.rotate_epoch()
-                _log.info(
-                    "context_resource/epoch_rotated transform=summary epoch=%d",
-                    resource_ledger.epoch,
-                )
         tool_budget_checkpoint_required = (
             workflow_policy is not None
             and completion_gate is not None
@@ -3729,6 +3799,39 @@ async def run_agent_loop(
                     pause_checkpoint.schema_version,
                     pause_checkpoint.artifact_count,
                 )
+                original_message_count = len(messages)
+                retained_messages = [
+                    message for message in messages if message.role == "system"
+                ]
+                retained_system_count = len(retained_messages)
+                retained_messages.append(
+                    Message(role="assistant", content=pause_message)
+                )
+                removed_message_count = original_message_count - retained_system_count
+                if session_log is not None and session_turn is not None:
+                    session_log.append_unlogged_messages(
+                        messages[1:],
+                        turn=session_turn,
+                        step=step + 1,
+                    )
+                    session_log.append(
+                        "compaction/prune",
+                        {
+                            "turn": session_turn,
+                            "step": step + 1,
+                            "mode": "workflow_checkpoint",
+                        },
+                    )
+                    session_log.replace_surface(
+                        retained_messages[1:],
+                        turn=session_turn,
+                        step=step + 1,
+                    )
+                    session_log.flush()
+                messages.clear()
+                messages.extend(retained_messages)
+                if resource_ledger is not None:
+                    resource_ledger.rotate_epoch()
                 yield ContextCheckpointEvent(
                     checkpoint_id=pause_checkpoint.checkpoint_id,
                     workflow_kind=pause_checkpoint.workflow_kind,
@@ -3740,19 +3843,6 @@ async def run_agent_loop(
                     artifact_count=pause_checkpoint.artifact_count,
                     artifact_set_sha256=pause_checkpoint.artifact_set_sha256,
                 )
-                original_message_count = len(messages)
-                retained_messages = [
-                    message for message in messages if message.role == "system"
-                ]
-                retained_system_count = len(retained_messages)
-                retained_messages.append(
-                    Message(role="assistant", content=pause_message)
-                )
-                removed_message_count = original_message_count - retained_system_count
-                messages.clear()
-                messages.extend(retained_messages)
-                if resource_ledger is not None:
-                    resource_ledger.rotate_epoch()
                 _log.info(
                     "workflow_checkpoint/history_reset checkpoint_id=%s "
                     "removed_messages=%d retained_messages=%d",
@@ -3918,6 +4008,49 @@ async def run_agent_loop(
                     workflow_action.tool_name,
                 )
                 workflow_action = None
+
+        if session_log is not None and session_turn is not None:
+            request_provider = getattr(llm, "provider", None)
+            if not isinstance(request_provider, str):
+                request_provider = None
+            request_model = getattr(llm, "model", None)
+            if not isinstance(request_model, str):
+                request_model = None
+            request_max_output = getattr(llm, "max_output_tokens", None)
+            if not isinstance(request_max_output, int):
+                request_max_output = None
+            session_log.append_unlogged_messages(
+                messages[1:],
+                turn=session_turn,
+                step=step + 1,
+            )
+            session_log.append(
+                "request/header",
+                {
+                    "turn": session_turn,
+                    "step": step + 1,
+                    "header": {
+                        "config": {
+                            "provider": request_provider,
+                            "model": request_model,
+                            "maxOutputTokens": request_max_output,
+                        },
+                        "system": messages[0].content,
+                        "tools": [tool.to_schema() for tool in tool_list],
+                    },
+                },
+            )
+            session_log.append(
+                "request/context",
+                {
+                    "turn": session_turn,
+                    "step": step + 1,
+                    "provider": request_provider,
+                    "model": request_model,
+                    "tokenLimit": token_limit,
+                },
+            )
+            session_log.flush()
 
         def _tool_target_identity(tool_name: str) -> tuple[str | None, str | None]:
             tool = offered_tools_by_name.get(tool_name)
@@ -4638,6 +4771,12 @@ async def run_agent_loop(
 
         # ── Append assistant message (non-truncated path) ───
         messages.append(assistant_msg)
+        if session_log is not None and session_turn is not None:
+            session_log.append_unlogged_messages(
+                messages[1:],
+                turn=session_turn,
+                step=step + 1,
+            )
 
         # Reset the retry counter now that a clean turn landed — a future
         # truncation on a later step should get its own fresh budget.
@@ -4780,6 +4919,38 @@ async def run_agent_loop(
                         pause_checkpoint.schema_version,
                         pause_checkpoint.artifact_count,
                     )
+                    original_message_count = len(messages)
+                    retained_messages = [
+                        message for message in messages if message.role == "system"
+                    ]
+                    retained_system_count = len(retained_messages)
+                    retained_messages.append(
+                        Message(role="assistant", content=pause_message)
+                    )
+                    if session_log is not None and session_turn is not None:
+                        session_log.append_unlogged_messages(
+                            messages[1:],
+                            turn=session_turn,
+                            step=step + 1,
+                        )
+                        session_log.append(
+                            "compaction/prune",
+                            {
+                                "turn": session_turn,
+                                "step": step + 1,
+                                "mode": "workflow_checkpoint",
+                            },
+                        )
+                        session_log.replace_surface(
+                            retained_messages[1:],
+                            turn=session_turn,
+                            step=step + 1,
+                        )
+                        session_log.flush()
+                    messages.clear()
+                    messages.extend(retained_messages)
+                    if resource_ledger is not None:
+                        resource_ledger.rotate_epoch()
                     yield ContextCheckpointEvent(
                         checkpoint_id=pause_checkpoint.checkpoint_id,
                         workflow_kind=pause_checkpoint.workflow_kind,
@@ -4791,18 +4962,6 @@ async def run_agent_loop(
                         artifact_count=pause_checkpoint.artifact_count,
                         artifact_set_sha256=pause_checkpoint.artifact_set_sha256,
                     )
-                    original_message_count = len(messages)
-                    retained_messages = [
-                        message for message in messages if message.role == "system"
-                    ]
-                    retained_system_count = len(retained_messages)
-                    retained_messages.append(
-                        Message(role="assistant", content=pause_message)
-                    )
-                    messages.clear()
-                    messages.extend(retained_messages)
-                    if resource_ledger is not None:
-                        resource_ledger.rotate_epoch()
                     _log.info(
                         "workflow_checkpoint/history_reset checkpoint_id=%s "
                         "removed_messages=%d retained_messages=%d",
@@ -5409,6 +5568,23 @@ async def run_agent_loop(
                 fn_args = await hook_mgr.fire_tool_start(
                     tool_call_id=tc_id, tool_name=fn_name, arguments=fn_args,
                 )
+            if (
+                session_log is not None
+                and session_turn is not None
+                and allowed_to_execute
+                and fn_name in offered_tools_by_name
+            ):
+                session_log.append(
+                    "tool/call",
+                    {
+                        "turn": session_turn,
+                        "step": step + 1,
+                        "callId": tc_id,
+                        "name": fn_name,
+                        "arguments": fn_args,
+                    },
+                )
+                session_log.flush()
             tool_started_at = perf_counter()
             emit_session_trace(
                 "tool.request",
@@ -5460,6 +5636,8 @@ async def run_agent_loop(
                                     parent_tool_call_id=tc_id,
                                 ),
                             )
+                        except SessionLogDurabilityError:
+                            raise
                         except Exception as exc:
                             detail = f"{type(exc).__name__}: {exc!s}"
                             trace = traceback.format_exc()
@@ -5543,6 +5721,8 @@ async def run_agent_loop(
                                 },
                             )
                     except asyncio.CancelledError:
+                        raise
+                    except SessionLogDurabilityError:
                         raise
                     except Exception as exc:
                         detail = f"{type(exc).__name__}: {exc!s}"
@@ -5872,6 +6052,7 @@ async def run_agent_loop(
             par_user_visible: dict[str, bool] = {}
             par_browser_snapshot_targets: dict[str, Path | None] = {}
             par_started_at: dict[str, float] = {}
+            durable_parallel_calls = False
             for tc in parallel_calls:
                 par_fn_args = tc.function.arguments
                 (
@@ -5959,6 +6140,23 @@ async def run_agent_loop(
                     )
                 par_args_map[tc.id] = par_fn_args
                 par_started_at[tc.id] = perf_counter()
+                if (
+                    session_log is not None
+                    and session_turn is not None
+                    and allowed_to_execute
+                    and tc.function.name in offered_tools_by_name
+                ):
+                    session_log.append(
+                        "tool/call",
+                        {
+                            "turn": session_turn,
+                            "step": step + 1,
+                            "callId": tc.id,
+                            "name": tc.function.name,
+                            "arguments": par_fn_args,
+                        },
+                    )
+                    durable_parallel_calls = True
                 emit_session_trace(
                     "tool.request",
                     turn_id=turn_id,
@@ -5976,6 +6174,9 @@ async def run_agent_loop(
                 )
                 if not allowed_to_execute:
                     par_budget_errors[tc.id] = internal_skip_error or ""
+
+            if durable_parallel_calls and session_log is not None:
+                session_log.flush()
 
             # Shared event queue for EventEmittingTool progress. Parent call ids
             # are passed per execution so parallel sub-agents do not race on
@@ -6023,6 +6224,8 @@ async def run_agent_loop(
                         else:
                             r = await _invoke_parallel_tool(tc)
                 except asyncio.CancelledError:
+                    raise
+                except SessionLogDurabilityError:
                     raise
                 except Exception as exc:
                     detail = f"{type(exc).__name__}: {exc!s}"

--- a/box_agent/session_log.py
+++ b/box_agent/session_log.py
@@ -1,0 +1,676 @@
+"""Durable append-only JSONL state for one logical Agent session."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from .schema import Message
+
+
+SESSION_LOG_VERSION = 1
+TOOL_NOT_STARTED = "TOOL_NOT_STARTED"
+TOOL_OUTCOME_UNKNOWN = "TOOL_OUTCOME_UNKNOWN"
+KNOWN_EVENT_TYPES = frozenset(
+    {
+        "turn/start",
+        "turn/end",
+        "step/start",
+        "step/end",
+        "user/message",
+        "assistant/chunk",
+        "assistant/message",
+        "tool/call",
+        "tool/result",
+        "request/header",
+        "request/context",
+        "session/end-seed",
+        "goal/change",
+        "plan/write",
+        "todo/write",
+        "skill/change",
+        "compaction/start",
+        "compaction/summary",
+        "compaction/prune",
+        "compaction/end",
+        "subagent/descriptor",
+    }
+)
+
+
+class SessionLogCorrupted(ValueError):
+    """The stored JSONL is not a valid committed Session Log prefix."""
+
+
+class SessionLogDurabilityError(OSError):
+    """A canonical Session Log write or fsync failed."""
+
+
+class SessionLogInUseError(RuntimeError):
+    """Another writer owns this Session Log."""
+
+
+@dataclass(frozen=True, slots=True)
+class SessionProjection:
+    """Values reconstructed from one committed Session Log prefix."""
+
+    messages: list[Message]
+    goal: dict[str, Any] | None
+    plan: dict[str, Any] | None
+    todos: list[dict[str, Any]]
+    skills: list[dict[str, Any]]
+
+
+def _encode_record(record: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            record,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _session_dir(root: Path, session_id: str) -> Path:
+    key = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return root / key
+
+
+def _acquire_writer_lock(path: Path) -> BinaryIO:
+    handle = path.open("a+b")
+    try:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        handle.close()
+        if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+            raise SessionLogInUseError(
+                "session already has an active writer"
+            ) from exc
+        raise
+    return handle
+
+
+def _release_writer_lock(handle: BinaryIO) -> None:
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+class SessionLog:
+    """Own JSONL encoding, ordered append, durability, and replay."""
+
+    def __init__(
+        self,
+        path: Path,
+        header: dict[str, Any],
+        events: list[dict[str, Any]],
+        handle: BinaryIO,
+        lock_handle: BinaryIO,
+    ) -> None:
+        self.path = path
+        self.header = dict(header)
+        self._events = events
+        self._handle = handle
+        self._lock_handle = lock_handle
+        self._closed = False
+        self._failed = False
+
+    @property
+    def events(self) -> tuple[dict[str, Any], ...]:
+        """Return detached committed and pending events in log order."""
+
+        return tuple(deepcopy(self._events))
+
+    @property
+    def failed(self) -> bool:
+        return self._failed
+
+    @classmethod
+    def create(
+        cls,
+        root: str | Path,
+        *,
+        session_id: str,
+        cwd: str | Path,
+        parent_session: str | None = None,
+        origin: str | None = None,
+        delegation_depth: int = 0,
+    ) -> "SessionLog":
+        if not session_id:
+            raise ValueError("session_id must not be empty")
+        root_path = Path(root)
+        directory = _session_dir(root_path, session_id)
+        directory.mkdir(parents=True, exist_ok=False, mode=0o700)
+        path = directory / "session.jsonl"
+        lock_handle = _acquire_writer_lock(directory / ".writer.lock")
+        header: dict[str, Any] = {
+            "type": "session",
+            "version": SESSION_LOG_VERSION,
+            "id": session_id,
+            "createdAt": int(time.time() * 1000),
+            "cwd": str(Path(cwd).resolve()),
+        }
+        if parent_session is not None:
+            header["parentSession"] = parent_session
+        if origin is not None:
+            header["origin"] = origin
+        if delegation_depth:
+            header["delegationDepth"] = delegation_depth
+        try:
+            handle = path.open("xb+")
+            try:
+                handle.write(_encode_record(header))
+                handle.flush()
+                os.fsync(handle.fileno())
+            except BaseException:
+                handle.close()
+                raise
+        except BaseException:
+            _release_writer_lock(lock_handle)
+            raise
+        return cls(path, header, [], handle, lock_handle)
+
+    @classmethod
+    def open(
+        cls,
+        root: str | Path,
+        *,
+        session_id: str,
+    ) -> "SessionLog":
+        directory = _session_dir(Path(root), session_id)
+        path = directory / "session.jsonl"
+        lock_handle = _acquire_writer_lock(directory / ".writer.lock")
+        try:
+            handle = path.open("r+b")
+            try:
+                raw = handle.read()
+                if raw and not raw.endswith(b"\n"):
+                    committed_end = raw.rfind(b"\n") + 1
+                    if committed_end == 0:
+                        raise ValueError("session log has no complete header")
+                    handle.truncate(committed_end)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                    raw = raw[:committed_end]
+                raw_lines = raw.splitlines()
+                if not raw_lines:
+                    raise ValueError("session log is empty")
+                records: list[Any] = []
+                for index, line in enumerate(raw_lines):
+                    try:
+                        records.append(json.loads(line))
+                    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                        raise SessionLogCorrupted(
+                            f"session log record {index} is invalid JSON"
+                        ) from exc
+                header = records[0]
+                if not isinstance(header, dict) or header.get("type") != "session":
+                    raise SessionLogCorrupted("session log header is invalid")
+                if header.get("version") != SESSION_LOG_VERSION:
+                    raise ValueError("session log version is unsupported")
+                if header.get("id") != session_id:
+                    raise ValueError("session log id does not match requested session")
+                events = records[1:]
+                for seq, event in enumerate(events):
+                    if not isinstance(event, dict):
+                        raise SessionLogCorrupted(
+                            f"session log record {seq + 1} is not an event object"
+                        )
+                    if event.get("seq") != seq:
+                        raise SessionLogCorrupted(
+                            f"session log record {seq + 1} has non-contiguous seq"
+                        )
+                    event_type = event.get("type")
+                    if not isinstance(event_type, str) or not event_type:
+                        raise SessionLogCorrupted(
+                            f"session log record {seq + 1} has an invalid event type"
+                        )
+                    if (
+                        event_type not in KNOWN_EVENT_TYPES
+                        and event.get("ignorable") is not True
+                    ):
+                        raise SessionLogCorrupted(
+                            f"session log contains unknown required event {event_type!r}"
+                        )
+                    if not isinstance(event.get("data"), dict):
+                        raise SessionLogCorrupted(
+                            f"session log record {seq + 1} has invalid event data"
+                        )
+                handle.seek(0, os.SEEK_END)
+            except BaseException:
+                handle.close()
+                raise
+        except BaseException:
+            _release_writer_lock(lock_handle)
+            raise
+        return cls(path, header, events, handle, lock_handle)
+
+    def append(
+        self,
+        event_type: str,
+        data: dict[str, Any],
+        *,
+        surface_op: str | dict[str, Any] | None = None,
+        source_event_seqs: list[int] | None = None,
+        ignorable: bool = False,
+    ) -> dict[str, Any]:
+        if self._closed:
+            raise RuntimeError("session log is closed")
+        if self._failed:
+            raise SessionLogDurabilityError("session log is unusable after an I/O failure")
+        event: dict[str, Any] = {
+            "type": event_type,
+            "seq": len(self._events),
+            "time": int(time.time() * 1000),
+            "data": data,
+        }
+        if ignorable:
+            event["ignorable"] = True
+        if surface_op is not None:
+            event["surfaceOp"] = surface_op
+        if source_event_seqs is not None:
+            event["sourceEventSeqs"] = source_event_seqs
+        encoded = _encode_record(event)
+        try:
+            self._handle.write(encoded)
+        except OSError as exc:
+            self._failed = True
+            raise SessionLogDurabilityError("session log append failed") from exc
+        self._events.append(event)
+        return dict(event)
+
+    def flush(self) -> None:
+        if self._closed:
+            raise RuntimeError("session log is closed")
+        try:
+            self._handle.flush()
+            os.fsync(self._handle.fileno())
+        except OSError as exc:
+            self._failed = True
+            raise SessionLogDurabilityError("session log flush failed") from exc
+
+    def append_unlogged_messages(
+        self,
+        messages: list[Message],
+        *,
+        turn: int,
+        step: int | None,
+        tool_result_metadata: dict[str, dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Append the live Surface suffix, rejecting divergent in-memory state."""
+
+        persisted = self.replay().messages
+        persisted_payloads = [
+            message.model_dump(mode="json", exclude_none=True) for message in persisted
+        ]
+        live_payloads = [
+            message.model_dump(mode="json", exclude_none=True) for message in messages
+        ]
+        if live_payloads[: len(persisted_payloads)] != persisted_payloads:
+            raise SessionLogCorrupted(
+                "live conversation is not an append-only extension of the Session Log Surface"
+            )
+
+        appended: list[dict[str, Any]] = []
+        for message, payload in zip(
+            messages[len(persisted_payloads) :],
+            live_payloads[len(persisted_payloads) :],
+        ):
+            if message.role == "user":
+                appended.append(
+                    self.append(
+                        "user/message",
+                        payload,
+                        surface_op="append",
+                    )
+                )
+            elif message.role == "assistant":
+                appended.append(
+                    self.append(
+                        "assistant/message",
+                        {"turn": turn, "step": step, "message": payload},
+                        surface_op="append",
+                    )
+                )
+            elif message.role == "tool":
+                data: dict[str, Any] = {
+                    "turn": turn,
+                    "step": step,
+                    "message": payload,
+                }
+                if (
+                    message.tool_call_id is not None
+                    and tool_result_metadata is not None
+                    and message.tool_call_id in tool_result_metadata
+                ):
+                    data["result"] = tool_result_metadata[message.tool_call_id]
+                appended.append(
+                    self.append(
+                        "tool/result",
+                        data,
+                        surface_op="append",
+                    )
+                )
+        return appended
+
+    def _surface_nodes(self) -> list[tuple[int, Message]]:
+        surface: list[tuple[int, Message]] = []
+        for event in self._events:
+            if event["type"] not in {
+                "user/message",
+                "assistant/message",
+                "tool/result",
+            }:
+                continue
+            data = event["data"]
+            message_data = data if event["type"] == "user/message" else data["message"]
+            message = Message.model_validate(message_data)
+            operation = event.get("surfaceOp")
+            node = (event["seq"], message)
+            if operation == "append":
+                surface.append(node)
+                continue
+            if isinstance(operation, dict) and operation.get("op") == "replace":
+                positions = {seq: index for index, (seq, _) in enumerate(surface)}
+                start_index = positions[operation["start"]]
+                end_index = positions[operation["end"]]
+                surface[start_index : end_index + 1] = [node]
+        return surface
+
+    def _append_surface_message(
+        self,
+        message: Message,
+        *,
+        turn: int,
+        step: int,
+        surface_op: str | dict[str, Any],
+        source_event_seqs: list[int] | None = None,
+    ) -> dict[str, Any]:
+        payload = message.model_dump(mode="json", exclude_none=True)
+        if message.role == "user":
+            return self.append(
+                "user/message",
+                payload,
+                surface_op=surface_op,
+                source_event_seqs=source_event_seqs,
+            )
+        if message.role == "assistant":
+            return self.append(
+                "assistant/message",
+                {"turn": turn, "step": step, "message": payload},
+                surface_op=surface_op,
+                source_event_seqs=source_event_seqs,
+            )
+        if message.role == "tool":
+            return self.append(
+                "tool/result",
+                {"turn": turn, "step": step, "message": payload},
+                surface_op=surface_op,
+                source_event_seqs=source_event_seqs,
+            )
+        raise ValueError(f"role {message.role!r} cannot enter the Session Surface")
+
+    def replace_surface(
+        self,
+        messages: list[Message],
+        *,
+        turn: int,
+        step: int,
+    ) -> list[dict[str, Any]]:
+        """Append a replacement whose replay is exactly ``messages``."""
+
+        if not messages:
+            raise ValueError("replacement Surface must not be empty")
+        old_nodes = self._surface_nodes()
+        appended: list[dict[str, Any]] = []
+        if old_nodes:
+            source_seqs = [seq for seq, _ in old_nodes]
+            appended.append(
+                self._append_surface_message(
+                    messages[0],
+                    turn=turn,
+                    step=step,
+                    surface_op={
+                        "op": "replace",
+                        "start": source_seqs[0],
+                        "end": source_seqs[-1],
+                    },
+                    source_event_seqs=source_seqs,
+                )
+            )
+            remaining = messages[1:]
+        else:
+            remaining = messages
+        for message in remaining:
+            appended.append(
+                self._append_surface_message(
+                    message,
+                    turn=turn,
+                    step=step,
+                    surface_op="append",
+                )
+            )
+        return appended
+
+    def replay(self) -> SessionProjection:
+        surface: list[tuple[int, Message]] = []
+        goal: dict[str, Any] | None = None
+        plan: dict[str, Any] | None = None
+        todos: list[dict[str, Any]] = []
+        skills: list[dict[str, Any]] = []
+        for event in self._events:
+            event_type = event.get("type")
+            data = event["data"]
+            if event_type == "goal/change":
+                value = data.get("goal")
+                goal = deepcopy(value) if isinstance(value, dict) else None
+                continue
+            if event_type == "plan/write":
+                value = data.get("plan")
+                plan = deepcopy(value) if isinstance(value, dict) else None
+                continue
+            if event_type == "todo/write":
+                value = data.get("todos")
+                if not isinstance(value, list):
+                    raise SessionLogCorrupted(
+                        f"todo/write event {event['seq']} has invalid todos"
+                    )
+                todos = deepcopy(value)
+                continue
+            if event_type == "skill/change":
+                value = data.get("skills")
+                if not isinstance(value, list):
+                    raise SessionLogCorrupted(
+                        f"skill/change event {event['seq']} has invalid skills"
+                    )
+                skills = deepcopy(value)
+                continue
+            if event_type not in {
+                "user/message",
+                "assistant/message",
+                "tool/result",
+            }:
+                continue
+            message_data = (
+                data
+                if event_type == "user/message"
+                else data.get("message")
+            )
+            try:
+                message = Message.model_validate(message_data)
+            except Exception as exc:
+                raise SessionLogCorrupted(
+                    f"session event {event['seq']} has an invalid message"
+                ) from exc
+            operation = event.get("surfaceOp")
+            node = (event["seq"], message)
+            if operation == "append":
+                surface.append(node)
+                continue
+            if not isinstance(operation, dict) or operation.get("op") != "replace":
+                raise SessionLogCorrupted(
+                    f"surface event {event['seq']} has an invalid surfaceOp"
+                )
+            start = operation.get("start")
+            end = operation.get("end")
+            positions = {seq: index for index, (seq, _) in enumerate(surface)}
+            if start not in positions or end not in positions:
+                raise SessionLogCorrupted(
+                    f"surface replacement {event['seq']} names a missing node"
+                )
+            start_index = positions[start]
+            end_index = positions[end]
+            if start_index > end_index:
+                raise SessionLogCorrupted(
+                    f"surface replacement {event['seq']} has a reversed range"
+                )
+            surface[start_index : end_index + 1] = [node]
+        return SessionProjection(
+            messages=[message for _, message in surface],
+            goal=goal,
+            plan=plan,
+            todos=todos,
+            skills=skills,
+        )
+
+    def repair_interrupted_turn(self) -> list[dict[str, Any]]:
+        """Append deterministic normal events that close one crash-open turn."""
+
+        open_turn: int | None = None
+        open_step: int | None = None
+        pending_calls: dict[str, dict[str, Any]] = {}
+        for event in self._events:
+            event_type = event.get("type")
+            data = event.get("data", {})
+            if event_type == "turn/start":
+                open_turn = data.get("turn")
+                open_step = None
+                pending_calls.clear()
+            elif event_type == "turn/end":
+                open_turn = None
+                open_step = None
+                pending_calls.clear()
+            elif event_type == "step/start":
+                open_step = data.get("step")
+            elif event_type == "step/end":
+                open_step = None
+                pending_calls.clear()
+            elif event_type == "assistant/message":
+                message = Message.model_validate(data.get("message"))
+                for call in message.tool_calls or []:
+                    pending_calls[call.id] = {
+                        "step": data.get("step"),
+                        "name": call.function.name,
+                        "call_seq": None,
+                    }
+            elif event_type == "tool/call":
+                call = pending_calls.get(str(data.get("callId")))
+                if call is not None:
+                    call["call_seq"] = event["seq"]
+            elif event_type == "tool/result":
+                message = Message.model_validate(data.get("message"))
+                if message.tool_call_id is not None:
+                    pending_calls.pop(message.tool_call_id, None)
+
+        if open_turn is None:
+            return []
+
+        closers: list[dict[str, Any]] = []
+        for call_id, pending in pending_calls.items():
+            started = pending["call_seq"] is not None
+            code = TOOL_OUTCOME_UNKNOWN if started else TOOL_NOT_STARTED
+            content = (
+                "The tool call was durably dispatched, but no result was recorded. "
+                "Its outcome is unknown; verify external state before retrying."
+                if started
+                else "The tool call was not durably dispatched and may be retried if needed."
+            )
+            event = self.append(
+                "tool/result",
+                {
+                    "turn": open_turn,
+                    "step": pending["step"],
+                    "message": Message(
+                        role="tool",
+                        content=content,
+                        tool_call_id=call_id,
+                        name=pending["name"],
+                    ).model_dump(mode="json", exclude_none=True),
+                    "error": {
+                        "name": (
+                            "ToolOutcomeUnknownError"
+                            if started
+                            else "ToolNotStartedError"
+                        ),
+                        "code": code,
+                    },
+                },
+                surface_op="append",
+                source_event_seqs=(
+                    [pending["call_seq"]] if started else None
+                ),
+            )
+            closers.append(event)
+        if open_step is not None:
+            closers.append(
+                self.append(
+                    "step/end",
+                    {"turn": open_turn, "step": open_step},
+                )
+            )
+        closers.append(
+            self.append(
+                "turn/end",
+                {"turn": open_turn, "reason": {"kind": "interrupted"}},
+            )
+        )
+        return closers
+
+    def prepare_resume(self) -> list[dict[str, Any]]:
+        """Close a crash-open lifecycle and durably delimit the loaded prefix."""
+
+        appended = self.repair_interrupted_turn()
+        appended.append(self.append("session/end-seed", {}))
+        self.flush()
+        return appended
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._handle.close()
+        finally:
+            try:
+                _release_writer_lock(self._lock_handle)
+            finally:
+                self._closed = True

--- a/box_agent/tools/plan_tool.py
+++ b/box_agent/tools/plan_tool.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from itertools import count
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .base import Tool, ToolResult
+
+if TYPE_CHECKING:
+    from ..session_log import SessionLog
 
 
 _VALID_PLAN_STATUSES = ("draft", "active", "revised", "complete")
@@ -135,12 +138,36 @@ class PlanStore:
     def get(self) -> dict[str, Any] | None:
         return self._plan
 
+    def restore(self, plan: dict[str, Any] | None) -> None:
+        self._plan = dict(plan) if plan is not None else None
+        plan_id = self._plan.get("id") if self._plan else None
+        next_id = int(plan_id) + 1 if isinstance(plan_id, str) and plan_id.isdigit() else 1
+        self._counter = count(next_id)
+
 
 class PlanWriteTool(Tool):
     """Create, replace, or clear the current user-visible plan."""
 
     def __init__(self, store: PlanStore):
         self._store = store
+        self._session_log: SessionLog | None = None
+
+    def configure_session_persistence(
+        self,
+        session_log: SessionLog,
+        plan: dict[str, Any] | None,
+    ) -> None:
+        self._session_log = session_log
+        self._store.restore(plan)
+
+    def _persist(self) -> None:
+        if self._session_log is None:
+            return
+        self._session_log.append(
+            "plan/write",
+            {"plan": self._store.get()},
+        )
+        self._session_log.flush()
 
     @property
     def name(self) -> str:
@@ -242,6 +269,7 @@ class PlanWriteTool(Tool):
 
         if normalized_action == "clear":
             self._store.clear()
+            self._persist()
             return ToolResult(
                 success=True,
                 content="Cleared the current plan.",
@@ -270,6 +298,7 @@ class PlanWriteTool(Tool):
             risks=risks,
             assumptions=assumptions,
         )
+        self._persist()
         return ToolResult(
             success=True,
             content=f"Set plan #{plan['id']}: {plan['title']}",

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -19,18 +19,22 @@ from uuid import uuid4
 from ..config import AgentConfig, ToolLimitsConfig
 from ..events import (
     ArtifactEvent,
+    ContentEvent,
     DoneEvent,
     ErrorEvent,
     LLMOutputEvent,
     ProgressEvent,
+    StepEnd,
     StepStart,
     SubAgentEvent,
     ToolCallResult,
     ToolCallStart,
+    ThinkingEvent,
     WebSearchEvent,
 )
 from ..llm.model_routing import resolve_model_client
 from ..schema import Message
+from ..session_log import SessionLog
 from .base import EventEmittingTool, Tool, ToolResult
 from .schema_validation import ToolArgumentIssue
 from .safety import detect_dangerous_command
@@ -294,6 +298,42 @@ class SubAgentTool(EventEmittingTool):
         # Inherit the parent's provider-stale cutoff so slow-model configs also
         # apply to child agents. None lets run_agent_loop resolve env/default.
         self._provider_stale_seconds = provider_stale_seconds
+        self._parent_session_log: SessionLog | None = None
+
+    def set_parent_session_log(self, session_log: SessionLog) -> None:
+        """Attach the parent's canonical log so children can persist lineage."""
+
+        self._parent_session_log = session_log
+
+    def _create_child_session_log(
+        self,
+        *,
+        child_session_id: str,
+        title: str,
+        messages: list[Message],
+    ) -> SessionLog | None:
+        parent = self._parent_session_log
+        if parent is None:
+            return None
+        child = SessionLog.create(
+            parent.path.parent.parent,
+            session_id=child_session_id,
+            cwd=self._workspace_dir or parent.header["cwd"],
+            parent_session=parent.header["id"],
+            origin="subagent",
+            delegation_depth=int(parent.header.get("delegationDepth", 0)) + 1,
+        )
+        child.append("turn/start", {"turn": 1})
+        child.append_unlogged_messages(messages[1:], turn=1, step=None)
+        descriptor = {
+            "version": 1,
+            "mode": "one-shot",
+            "provider": "local",
+        }
+        if title:
+            descriptor["label"] = title
+        child.append("subagent/descriptor", descriptor)
+        return child
 
     def set_parent_system_prompt(self, system_prompt: str) -> None:
         """Attach parent constraints without advertising parent-only MCP search."""
@@ -709,6 +749,7 @@ class SubAgentTool(EventEmittingTool):
         task_preview: str,
         sub_agent_id: str,
         title: str,
+        session_log: SessionLog | None = None,
     ) -> ToolResult:
         # Import lazily because the runtime facade initializes the core, which
         # imports tool contracts while this module may still be loading.
@@ -719,6 +760,9 @@ class SubAgentTool(EventEmittingTool):
         model_calls = 0
         tool_calls = 0
         usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        step_open = False
+        current_step: int | None = None
+        turn_open = session_log is not None
         try:
             async for event in run_agent_loop(
                 llm=llm,
@@ -739,7 +783,87 @@ class SubAgentTool(EventEmittingTool):
                     "resolved_skills": diagnostic.get("resolved_skills", []),
                 },
                 call_kind="subagent_step",
+                session_log=session_log,
+                session_turn=1 if session_log is not None else None,
             ):
+                if session_log is not None:
+                    if isinstance(event, (ContentEvent, ThinkingEvent)):
+                        session_log.append(
+                            "assistant/chunk",
+                            {
+                                "turn": 1,
+                                "step": current_step,
+                                "kind": (
+                                    "thinking"
+                                    if isinstance(event, ThinkingEvent)
+                                    else "text"
+                                ),
+                                "content": event.content,
+                            },
+                        )
+                    elif isinstance(event, StepStart):
+                        current_step = event.step
+                        session_log.append(
+                            "step/start",
+                            {"turn": 1, "step": event.step},
+                        )
+                        step_open = True
+                    elif isinstance(event, StepEnd):
+                        session_log.append_unlogged_messages(
+                            messages[1:],
+                            turn=1,
+                            step=event.step,
+                        )
+                        if step_open:
+                            session_log.append(
+                                "step/end",
+                                {"turn": 1, "step": event.step},
+                            )
+                            session_log.flush()
+                            step_open = False
+                    elif isinstance(event, ToolCallResult):
+                        session_log.append_unlogged_messages(
+                            messages[1:],
+                            turn=1,
+                            step=current_step,
+                            tool_result_metadata={
+                                event.tool_call_id: {
+                                    "success": event.success,
+                                    "content": event.content,
+                                    "error": event.error,
+                                    "rawOutput": event.raw_output,
+                                    "policyDecision": event.policy_decision,
+                                }
+                            },
+                        )
+                    elif isinstance(event, DoneEvent):
+                        session_log.append_unlogged_messages(
+                            messages[1:],
+                            turn=1,
+                            step=current_step,
+                        )
+                        if step_open:
+                            session_log.append(
+                                "step/end",
+                                {"turn": 1, "step": current_step},
+                            )
+                            step_open = False
+                        session_log.append(
+                            "turn/end",
+                            {
+                                "turn": 1,
+                                "reason": {
+                                    "kind": (
+                                        "completed"
+                                        if event.stop_reason.value == "end_turn"
+                                        else event.stop_reason.value
+                                    )
+                                },
+                            },
+                        )
+                        session_log.flush()
+                        turn_open = False
+
                 if isinstance(event, ToolCallStart):
                     pending_child_tc[event.tool_call_id] = event.tool_name
                     if event.user_visible:
@@ -791,6 +915,12 @@ class SubAgentTool(EventEmittingTool):
                     "usage": usage,
                 },
             )
+        finally:
+            if session_log is not None:
+                if turn_open:
+                    session_log.repair_interrupted_turn()
+                    session_log.flush()
+                session_log.close()
 
         raw_output = {
             **diagnostic,
@@ -819,9 +949,32 @@ class SubAgentTool(EventEmittingTool):
         task_preview: str,
         sub_agent_id: str,
         title: str,
+        session_log: SessionLog | None = None,
     ) -> ToolResult:
         files = list(bundle.spec.files)
         read_tool = bundle.tools["read_file"]
+        if session_log is not None:
+            session_log.append("step/start", {"turn": 1, "step": 1})
+
+        def finish(result: ToolResult) -> ToolResult:
+            if session_log is None:
+                return result
+            if result.success and result.content:
+                messages.append(Message(role="assistant", content=result.content))
+                session_log.append_unlogged_messages(messages[1:], turn=1, step=1)
+            session_log.append("step/end", {"turn": 1, "step": 1})
+            session_log.append(
+                "turn/end",
+                {
+                    "turn": 1,
+                    "reason": {
+                        "kind": "completed" if result.success else "error",
+                    },
+                },
+            )
+            session_log.flush()
+            session_log.close()
+            return result
 
         async def read_one(path: str) -> tuple[str, ToolResult | Exception]:
             try:
@@ -941,12 +1094,12 @@ class SubAgentTool(EventEmittingTool):
                 "tool_calls": len(files),
                 "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
             }
-            return ToolResult(
+            return finish(ToolResult(
                 success=False,
                 content="",
                 error=json.dumps(payload, ensure_ascii=False, sort_keys=True),
                 raw_output=payload,
-            )
+            ))
 
         blocks = [
             "## Untrusted local file contents",
@@ -964,6 +1117,36 @@ class SubAgentTool(EventEmittingTool):
                 ]
             )
         messages[-1].content = f"{messages[-1].content}\n\n" + "\n".join(blocks)
+
+        if session_log is not None:
+            session_log.replace_surface(messages[1:], turn=1, step=1)
+            provider = getattr(llm, "provider", None)
+            model = getattr(llm, "model", None)
+            session_log.append(
+                "request/header",
+                {
+                    "turn": 1,
+                    "step": 1,
+                    "header": {
+                        "config": {
+                            "provider": provider if isinstance(provider, str) else None,
+                            "model": model if isinstance(model, str) else None,
+                        },
+                        "system": messages[0].content,
+                        "tools": [],
+                    },
+                },
+            )
+            session_log.append(
+                "request/context",
+                {
+                    "turn": 1,
+                    "step": 1,
+                    "provider": provider if isinstance(provider, str) else None,
+                    "model": model if isinstance(model, str) else None,
+                },
+            )
+            session_log.flush()
 
         self._put_sub_event(
             queue,
@@ -1002,14 +1185,14 @@ class SubAgentTool(EventEmittingTool):
                 "tool_calls": len(files),
                 "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
             }
-            return ToolResult(
+            return finish(ToolResult(
                 success=False,
                 content="",
                 error=json.dumps(payload, ensure_ascii=False, sort_keys=True),
                 raw_output=payload,
-            )
+            ))
         except Exception as exc:
-            return ToolResult(
+            return finish(ToolResult(
                 success=False,
                 content="",
                 error=f"Sub-agent batch synthesis failed: {type(exc).__name__}: {exc}",
@@ -1019,7 +1202,7 @@ class SubAgentTool(EventEmittingTool):
                     "tool_calls": len(files),
                     "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                 },
-            )
+            ))
 
         content = getattr(response, "content", "") or ""
         usage = self._usage_payload(getattr(response, "usage", None))
@@ -1050,13 +1233,13 @@ class SubAgentTool(EventEmittingTool):
             "aggregate_chars": aggregate_chars,
         }
         if not content.strip():
-            return ToolResult(
+            return finish(ToolResult(
                 success=False,
                 content="",
                 error="Sub-agent batch synthesis produced no output.",
                 raw_output=raw_output,
-            )
-        return ToolResult(success=True, content=content, raw_output=raw_output)
+            ))
+        return finish(ToolResult(success=True, content=content, raw_output=raw_output))
 
     def _resolve_task_llm(
         self,
@@ -1179,6 +1362,13 @@ class SubAgentTool(EventEmittingTool):
         )
         diagnostic["model_routing"] = model_routing
         messages = self._explicit_messages(parsed, resolved)
+        child_session_log = self._create_child_session_log(
+            child_session_id=sub_agent_id,
+            title=sub_title,
+            messages=messages,
+        )
+        if child_session_log is not None:
+            diagnostic["child_session_id"] = sub_agent_id
         if parsed.strategy == "batch_files":
             return await self._run_batch_files(
                 llm=child_llm,
@@ -1190,6 +1380,7 @@ class SubAgentTool(EventEmittingTool):
                 task_preview=task_preview,
                 sub_agent_id=sub_agent_id,
                 title=sub_title,
+                session_log=child_session_log,
             )
 
         return await self._run_general_loop(
@@ -1204,4 +1395,5 @@ class SubAgentTool(EventEmittingTool):
             task_preview=task_preview,
             sub_agent_id=sub_agent_id,
             title=sub_title,
+            session_log=child_session_log,
         )

--- a/box_agent/tools/todo_tool.py
+++ b/box_agent/tools/todo_tool.py
@@ -15,9 +15,12 @@ import json
 from datetime import datetime
 from itertools import count
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from .base import Tool, ToolResult
+
+if TYPE_CHECKING:
+    from ..session_log import SessionLog
 
 
 _VALID_STATUSES = ("pending", "in_progress", "completed")
@@ -229,6 +232,7 @@ class TodoStore:
         self._items: dict[str, dict] = {}
         self._counter = count(1)
         self._persist_path = persist_path
+        self._change_sink: Callable[[list[dict]], None] | None = None
         if persist_path and persist_path.exists():
             self._load()
 
@@ -271,6 +275,21 @@ class TodoStore:
         _validate_todo_items(items)
         self._items = {str(item["id"]): dict(item) for item in items}
         self._save()
+        if self._change_sink is not None:
+            self._change_sink(self.list())
+
+    def restore(self, items: list[dict]) -> None:
+        candidate = [dict(item) for item in items]
+        _validate_todo_items(candidate)
+        self._items = {item["id"]: item for item in candidate}
+        max_id = max((int(item["id"]) for item in candidate), default=0)
+        self._counter = count(max_id + 1)
+
+    def set_change_sink(
+        self,
+        sink: Callable[[list[dict]], None] | None,
+    ) -> None:
+        self._change_sink = sink
 
     # -- public API --------------------------------------------------------
 
@@ -477,6 +496,19 @@ class TodoWriteTool(Tool):
 
     def __init__(self, store: TodoStore):
         self._store = store
+
+    def configure_session_persistence(
+        self,
+        session_log: SessionLog,
+        items: list[dict],
+    ) -> None:
+        self._store.restore(items)
+
+        def persist(current: list[dict]) -> None:
+            session_log.append("todo/write", {"todos": current})
+            session_log.flush()
+
+        self._store.set_change_sink(persist)
 
     def _result(
         self,

--- a/docs/SESSION_RECOVERY_HANDOFF_CN.md
+++ b/docs/SESSION_RECOVERY_HANDOFF_CN.md
@@ -1,0 +1,903 @@
+# Session 重建与上下文持久化 Handoff
+
+> 状态：设计与实施交接文档，尚未实现。
+> 涉及仓库：`box-agent`、`officev3`。
+> 目标宿主：officev3 本地 Agent（ACP stdio）。
+> 本文描述目标契约、改动位置、迁移、验证和风险；当前源码与测试仍是已实现行为的事实来源。
+
+## 1. 执行摘要
+
+当前 officev3 会把一个稳定的产品会话映射到 Box-Agent 进程内的 ACP Session。ACP Session
+被取消超时强拆、运行时重启、配置切换或进程异常清理后，映射随内存状态一起消失。下一次发送会
+调用 `session/new`，Box-Agent 创建全新的 `Agent`，最多再从宿主提供的最近 12 条
+user/assistant 文本构造语义 continuation。这不是完整恢复：Goal、工具协议、Plan/Todo、Skill、
+工作流和中断状态均可能丢失。
+
+本方案不把 ACP handle 持久化，也不引入前端可见的 epoch。它采用以下最小模型：
+
+- officev3 的产品 `sessionId` 是稳定的逻辑 Session 身份；
+- ACP `sessionId` 是可丢弃的运行时 handle；
+- `turnId` 标识 Session 下的一次用户请求，并用于幂等；
+- Box-Agent 按稳定产品 Session 身份持久化模型执行状态；
+- ACP handle 重建时，先按当前配置创建运行时对象，再恢复持久化语义状态；
+- cancel 只终止当前 Turn，不删除逻辑 Session；
+- 无法恢复时明确失败，不静默创建空会话；
+- 固定 12 条 continuation 只作为旧会话迁移 Adapter，不再承担正常恢复。
+
+第一版不要求实现标准 ACP `session/load`。officev3 已经在 `session/new._meta.session_id`
+传递稳定产品 Session 身份，因此新的 ACP handle 可以通过相同产品 Session 身份自动恢复。
+未来若支持其他 ACP Host，可把 `session/load` 做成复用同一持久化 Module 的新 Adapter。
+
+## 2. 要解决的问题
+
+### 2.1 用户主动取消后的续聊
+
+用户取消的语义应该是“停止当前请求”，而不是“删除会话”。取消完成后：
+
+- 已完成的历史上下文仍然存在；
+- 当前 Turn 标记为 `cancelled`；
+- 当前 Turn 不会被自动重跑；
+- 用户下一条消息仍在同一个逻辑 Session 中执行。
+
+### 2.2 ACP handle 被强拆后的恢复
+
+当模型或工具不及时响应取消，officev3 会丢弃当前 ACP handle 以释放前端锁。下一次发送可以
+创建新的 ACP handle，但必须恢复相同逻辑 Session 的执行状态，不能只注入最近 12 条文本。
+
+### 2.3 Box-Agent 进程重启后的恢复
+
+运行时升级、配置变化、应用退出或崩溃都会清空 Box-Agent 内存。进程重启后必须从磁盘恢复，
+而不是依赖旧进程内的 `_sessions`。
+
+### 2.4 中断工具调用的安全性
+
+进程可能在工具已经产生副作用、但工具结果尚未写入消息历史时终止。恢复后不能盲目重跑未知
+状态的副作用工具，否则可能重复写文件、发送消息、创建外部资源或执行交易。
+
+### 2.5 重试幂等
+
+宿主、IPC 或传输层可能重试同一个 Turn。相同 `turnId` 不能重复追加用户消息、重复调用模型或
+重复执行工具。
+
+### 2.6 生命周期和隐私
+
+持久化状态必须随用户明确删除会话而删除。cancel、强拆、进程退出和普通缓存淘汰均不得删除
+逻辑 Session；业务会话删除则必须清理执行快照和关联运行时文件。
+
+## 3. 当前行为与已确认根因
+
+### 3.1 Box-Agent Session 只在内存中
+
+`box_agent/acp/__init__.py` 中的 `_sessions` 是进程内字典。`newSession()` 每次生成新的 ACP
+Session ID，并创建新的 `Agent`。初始化能力当前声明 `loadSession=False`。
+
+结果是：只要 ACP 进程退出或内存映射被清理，完整 Agent 状态就不可恢复。
+
+### 3.2 officev3 会主动清理运行时映射
+
+`electron/main/boxAgentManager.ts` 中维护：
+
+```text
+officeSessions: product session id -> OfficeSessionState
+acpToOffice: ACP session id -> product session id
+```
+
+取消等待超时、运行时 dispose、进程失败和 renderer 销毁等路径会清理这些映射。清理本身是合理
+的运行时资源释放；问题在于系统把这些缓存误当成了唯一会话状态来源。
+
+### 3.3 当前 continuation 不是完整恢复
+
+officev3 的 `src/lib/agent/localAgentContinuation.ts` 与 Box-Agent 的
+`box_agent/session_continuation.py` 只传递有界的 user/assistant 语义文本：
+
+- 最多 12 条消息；
+- 单条最多 12,000 字符；
+- 总计最多 48,000 字符；
+- 不包含工具调用和工具结果；
+- 不包含 Goal、Plan、Todo、Skill 和 ACP 运行状态。
+
+Box-Agent 的 `Agent.seed_continuation_messages()` 也明确只向新 Agent 注入语义消息，不恢复工具
+协议状态。
+
+### 3.4 取消超时会放大重建概率
+
+officev3 的取消等待上限为 8 秒；Box-Agent 静默 provider 流的活动心跳为 15 秒，取消检查位于
+流消费点。因此 provider 在一段时间内不返回 chunk 时，普通取消也可能被宿主误判为卡死，进而
+强拆 ACP handle。
+
+### 3.5 前端存在重复 cancel 调用
+
+`src/lib/agent/localAgentStream.ts` 的 abort handler 会调用本地 Agent cancel；
+`src/components/AI/hooks/useChatSession.ts` 的 `handleCancel` 在触发 abort 后又调用一次 cancel。
+这不是上下文丢失的唯一根因，但会增加取消竞态和诊断噪音。
+
+### 3.6 未知 ACP handle 会被静默替换
+
+Box-Agent 当前在 `prompt()` 找不到 ACP Session 时，会自动调用 `newSession()` 并使用新 ID。
+该路径没有稳定产品 Session 元数据，无法正确恢复原会话，而且会掩盖状态丢失。目标实现必须改为
+明确返回 `ACP_SESSION_NOT_FOUND`。
+
+## 4. 第一性原理与目标不变量
+
+### 4.1 最小概念
+
+| 概念 | 含义 | 是否持久化 | 是否对宿主可见 |
+| --- | --- | --- | --- |
+| 逻辑 Session | 一个产品会话的长期执行上下文 | 是 | 是，使用产品 `sessionId` |
+| ACP handle | 当前 ACP 连接中的运行时对象句柄 | 否 | 是，ACP `sessionId` |
+| Turn | Session 下的一次用户请求 | 是 | 是，使用 `turnId` |
+| generation | 防止旧实例迟到写回的新旧代数 | 仅内部需要 | 否 |
+
+`generation` 不是新的协议 ID。当前 officev3 已经通过对象身份守卫忽略迟到的旧请求；目标实现
+只需把这一思想延伸到持久化 checkpoint，防止旧 ACP handle 在新 handle 建立后覆盖新状态。
+
+### 4.2 必须满足的不变量
+
+1. 稳定产品 `sessionId` 在 ACP handle、进程和配置重建之间不变。
+2. 一个 Session 可以包含多个 Turn；一个 Turn 只能有一个终态。
+3. 相同 `turnId` 不得重复产生模型调用或外部副作用。
+4. cancel 终止 Turn，不删除 Session。
+5. 进程内对象和 Map 都是缓存，不是持久化事实来源。
+6. 当前运行时配置、system prompt、权限和工具实例必须重新构造，不能从快照反序列化。
+7. 进入模型历史的 assistant tool call 必须有匹配的 tool result。
+8. 状态未知的副作用工具不得自动重跑。
+9. 恢复失败必须显式可见，不能静默切换为空会话。
+10. 用户删除业务会话后，持久化执行状态最终必须删除。
+
+## 5. 设计决策
+
+### 5.1 使用产品 Session ID 作为恢复键
+
+officev3 已在 `session/new._meta.session_id` 传递稳定的产品 `sessionId`，Box-Agent 已保存为
+`SessionState.upstream_session_id`。目标实现直接以该值作为逻辑 Session 键；内部文件名使用
+安全规范化或 hash，避免路径穿越和跨用户冲突。
+
+如果一个 Box-Agent 数据目录可能被多个用户或多个 Host 共用，内部键应至少包含：
+
+```text
+hash(client identity + product session id)
+```
+
+第一版不增加独立 `agentSessionId`。
+
+### 5.2 ACP handle 保持临时
+
+ACP `session/new` 仍可返回 `sess-N-xxxx` 一类当前连接内 handle。强拆或进程重启后 handle 可以
+变化；只要新的 `session/new` 带有相同稳定产品 Session ID，Box-Agent 就恢复同一个逻辑 Session。
+
+### 5.3 统一恢复，不设正常恢复等级
+
+正常 Interface 只有以下结果：
+
+```text
+成功恢复
+不存在（新 Session 或旧版本待迁移）
+快照损坏
+schema 不兼容
+当前 writer 已失效
+```
+
+“重新构造 system prompt、工具和 Skill，再注入语义状态”是所有恢复都会执行的标准过程，不是
+一个恢复等级。语义 continuation 是无快照旧会话的一次性迁移，不是正常运行时自动降级。
+
+### 5.4 Box-Agent 执行快照是模型执行状态的权威来源
+
+officev3 SQLite 继续是用户可见聊天记录的权威来源；Box-Agent 快照是模型执行状态的权威来源。
+两者不是同一个数据模型：
+
+- officev3 保存 UI stage、可见 partial、文件行和展示状态；
+- Box-Agent 保存 provider-neutral 的模型消息、Goal、工具协议和执行状态。
+
+恢复时不从 officev3 UI transcript 重建正常执行状态。只有旧会话迁移时才使用 continuation。
+
+### 5.5 持久化逻辑必须是深 Module
+
+新增 `box_agent/session_state.py`，将 schema、校验、原子 I/O、revision、generation fencing、
+消息清洗、状态捕获和恢复放在一个 Module 内。ACP 是 Adapter，只在稳定 Seam 上调用：
+
+```python
+load(session_id) -> SessionSnapshot | None
+save(session_id, snapshot, *, expected_generation) -> int
+delete(session_id) -> None
+```
+
+测试通过同一 Interface 使用临时目录 Adapter，不为测试暴露额外生产接口。
+
+### 5.6 第一版采用原子 JSON
+
+建议路径：
+
+```text
+~/.box-agent/sessions/<safe-session-key>/session-state.json
+```
+
+要求：
+
+- schema version；
+- payload SHA256；
+- 临时文件独占创建；
+- `flush + fsync + os.replace`；
+- 目录权限 `0700`，文件权限 `0600`；
+- 单进程内每个 Session 串行保存；
+- 新 ACP handle 激活后，旧 generation 的保存请求被拒绝。
+
+第一版假设 officev3 对一个用户只维护一个 Box-Agent 进程。若未来允许多个进程同时写同一数据
+目录，应在不改变 Interface 的前提下切换到支持跨进程事务/锁的 Implementation，例如 SQLite。
+
+## 6. 目标结构
+
+```text
+officev3 产品 sessionId（稳定）
+        |
+        | session/new._meta.session_id
+        v
+Box-Agent ACP Adapter
+        |
+        | load/save/delete
+        v
+Durable Session Module --------------------+
+        |                                   |
+        | 恢复模型执行状态                    | 原子 checkpoint
+        v                                   v
+当前 Agent + 当前工具 + 当前 system prompt   ~/.box-agent/sessions/.../session-state.json
+        |
+        | session/prompt._meta.turn_id
+        v
+Turn: running -> completed/cancelled/interrupted
+```
+
+ACP handle 只指向当前内存 `SessionState`。它消失时，持久化逻辑 Session 不受影响。
+
+## 7. 持久化数据模型
+
+建议 schema v1 的逻辑形状如下。实际字段命名可调整，但语义和校验要求不可省略。
+
+```json
+{
+  "schema_version": 1,
+  "session_id": "office-session-id",
+  "revision": 17,
+  "generation": 3,
+  "created_at": "2026-08-26T10:00:00Z",
+  "updated_at": "2026-08-26T10:05:00Z",
+  "runtime_compatibility": {
+    "workspace_identity": "...",
+    "artifact_mode": "output",
+    "session_mode": "general"
+  },
+  "messages": [],
+  "goal": null,
+  "active_skills": [
+    {"name": "skill-name", "sha256": "..."}
+  ],
+  "stateful_tools": {
+    "plan": {},
+    "todo": {}
+  },
+  "session_state": {
+    "turn_counter": 4,
+    "current_task_id": "task-1",
+    "source_text": "...",
+    "pending_plan_approval": null,
+    "pending_completion_gate": null,
+    "waiting_for_user_input": false,
+    "last_checkpoint": null
+  },
+  "current_turn": {
+    "turn_id": "local_...",
+    "status": "completed",
+    "partial_assistant_text": "",
+    "stop_reason": "end_turn",
+    "started_at": "...",
+    "updated_at": "...",
+    "tool_calls": []
+  },
+  "recent_terminal_turns": [],
+  "payload_sha256": "..."
+}
+```
+
+### 7.1 Messages
+
+保存 `Agent.messages` 中除 system message 之外的 provider-neutral `Message`：
+
+- user；
+- assistant；
+- tool；
+- assistant thinking（如果当前策略允许其进入持久历史）；
+- tool calls、tool call ID、usage 和 `request_only_input_tokens`。
+
+不得保存：
+
+- 当前 system prompt；
+- `trace_redact_content=True` 的 request-only 内容；
+- 原始图片字节或 data URL；
+- 临时权限文本和运行时密钥；
+- 仅为一次 provider 请求构造的覆盖层。
+
+恢复时始终保留新 Agent 当前生成的 system message，并把快照中的非 system 消息追加到其后。
+
+### 7.2 Goal
+
+复用 `agent.py` 中现有 `goal_payload()` 和 `restore_goal()`。Goal 的 objective、status、progress、
+evidence、blocked reason 和 completion metadata 均应恢复。
+
+### 7.3 Active Skills
+
+只保存 Skill 名称、加载顺序和内容 hash，不把旧 Skill 指令文本当作可执行配置反序列化。恢复时：
+
+1. 使用当前 SkillLoader 按名称重新加载；
+2. 重新计算 hash；
+3. 一致则激活；
+4. 不存在或发生变化时记录明确诊断，并使用当前可信版本或拒绝不兼容恢复。
+
+### 7.4 有状态工具
+
+PlanStore、TodoStore 等工具通过统一内部 Interface 暴露：
+
+```python
+export_session_state() -> dict
+restore_session_state(payload: object) -> None
+```
+
+Durable Session Module 只处理实现该 Interface 的工具，不针对工具名称维护分支。运行时连接类工具
+不实现该 Interface，恢复时重新创建。
+
+### 7.5 Turn 状态
+
+允许的持久状态：
+
+```text
+running
+completed
+cancel_requested
+cancelled
+interrupted
+error
+```
+
+加载快照时，如果最后状态为 `running` 或 `cancel_requested`，说明上一个 writer 没有正常落终态，
+应转换为 `interrupted`，不得直接继续执行该 Turn。
+
+`recent_terminal_turns` 保存有界的最近 Turn 幂等收据，至少包含 `turn_id`、终态、stop reason 和
+终态 revision。相同 `turnId` 再次到达时返回已有终态，不重新执行。
+
+## 8. Checkpoint 时机
+
+### 8.1 Turn 开始
+
+ACP 完成输入校验并调用 `state.agent.add_user_message(user_text)` 后，执行第一次 checkpoint：
+
+```text
+current_turn.status = running
+保存用户消息
+保存 turn_id/task_id
+revision + 1
+```
+
+在写入用户消息前必须先检查 `turnId` 幂等收据，防止重复追加。
+
+### 8.2 Assistant/工具安全边界
+
+ACP 已在 `_run_turn()` 中消费共享 Agent events。以下事件发生后保存：
+
+- `ToolCallStartEvent`：保存 assistant tool call 意图；
+- `ToolCallResultEvent`：保存匹配 tool result；
+- `ContextCheckpointEvent`：保存工作流 checkpoint；
+- Goal、Plan、Todo 或 active Skill 状态发生变化；
+- `DoneEvent`：保存 Turn 终态。
+
+### 8.3 流式 partial
+
+流式文本不应每 token 写盘。ACP 可以在内存累计当前 Turn 的 partial，并按时间或字符阈值刷新，
+例如每秒或每 4 KiB。partial 单独保存在 `current_turn.partial_assistant_text`，不能伪装成已经完成的
+assistant message。
+
+用户主动取消后，partial 可用于 UI/诊断，但下一轮模型上下文不能把它当作完整答案。进程异常时，
+partial 与 `interrupted` 状态一起保留。
+
+### 8.4 保存失败
+
+保存失败不能被当成普通日志后继续承诺“可恢复”。至少应：
+
+- 记录结构化错误；
+- 在 prompt response `_meta` 标记持久化失败；
+- 对即将执行有副作用工具但尚未保存调用意图的情况 fail closed；
+- 不覆盖最后一份有效快照。
+
+## 9. 工具调用安全
+
+### 9.1 协议完整性
+
+恢复前验证消息历史。任何 assistant tool call 必须存在相同 ID 的 tool result。若进程在 tool result
+写入前终止，恢复逻辑为缺失结果生成受控的 interrupted stub，保持 provider 协议合法，并同时把
+调用标记为 `unknown`。
+
+现有 `core.py` 已有 dangling tool call 清理逻辑，但 Durable Session Module 不能依赖私有 helper
+的偶然行为；应提取或实现稳定、可直接测试的恢复校验。
+
+### 9.2 副作用分类
+
+恢复时按保守策略处理：
+
+| 状态 | 行为 |
+| --- | --- |
+| tool result 已持久化 | 直接恢复，不重跑 |
+| 调用未开始 | 不自动执行，等待新 Turn |
+| 只读工具，状态 unknown | 第一版仍不自动续跑；以后可显式加入安全重试策略 |
+| 有副作用工具，状态 unknown | 禁止自动重跑；检查 artifact/workspace 或等待用户决定 |
+
+第一版的简单且安全策略是：任何异常终止的 Turn 都不自动续跑。恢复 Session 后，由用户下一条消息
+决定是否继续；模型会看到受控 interrupted receipt，而不是重复执行旧工具。
+
+## 10. 生命周期流程
+
+### 10.1 首次创建
+
+```text
+officev3 session/new（携带稳定 product session_id）
+  -> Box-Agent 创建当前运行时 Agent
+  -> 快照不存在
+  -> 返回 resumed=false
+  -> 第一个 prompt 正常运行并生成正式快照
+```
+
+### 10.2 正常下一轮
+
+```text
+officev3 复用 ACP handle
+  -> prompt 携带新 turn_id
+  -> Box-Agent 校验幂等
+  -> checkpoint running
+  -> 执行
+  -> checkpoint completed/error/cancelled
+```
+
+### 10.3 用户主动取消
+
+```text
+session/cancel
+  -> 设置当前 Turn 的取消信号
+  -> checkpoint cancel_requested
+  -> 执行循环尽快退出
+  -> checkpoint cancelled
+  -> 保留 ACP handle（若运行时健康）
+  -> 下一条消息使用同一逻辑 Session
+```
+
+不得自动重跑被取消 Turn。
+
+### 10.4 取消超时强拆
+
+```text
+officev3 等待超时
+  -> 只删除 live ACP 映射
+  -> 下一次发送调用 session/new
+  -> 携带相同产品 session_id
+  -> Box-Agent 激活新 generation
+  -> 旧 handle 的迟到 checkpoint 被拒绝
+  -> 加载最后有效快照
+  -> 未正常结束的 Turn 标记 interrupted
+```
+
+### 10.5 Box-Agent 进程重启
+
+```text
+旧进程退出，内存缓存消失
+  -> 新进程收到 session/new
+  -> 重新构造当前 LLM/工具/system prompt/权限
+  -> 加载稳定产品 session_id 的快照
+  -> 返回 resumed=true + revision
+```
+
+### 10.6 配置、模型或 workspace 变化
+
+配置变化可以创建新的 ACP handle，但仍恢复同一逻辑 Session。当前宿主配置优先，旧快照中的运行时
+配置只用于兼容性校验和诊断。不得从快照恢复旧权限、旧连接或旧 system prompt。
+
+若 workspace identity 变化导致工具结果路径或工作流 checkpoint 无法安全解释，应返回明确的
+`SESSION_INCOMPATIBLE` 或将相关状态标记为不可用；不能在新 workspace 静默执行旧副作用。
+
+### 10.7 未知 ACP handle
+
+`session/prompt` 找不到当前 ACP handle 时返回 `ACP_SESSION_NOT_FOUND`。宿主重新调用
+`session/new` 并携带稳定产品 Session ID。Box-Agent 不在 prompt 路径自动创建空 Session。
+
+### 10.8 损坏或不兼容快照
+
+```text
+checksum 错误 -> SESSION_CORRUPTED
+schema 不支持 -> SESSION_INCOMPATIBLE
+```
+
+不得把损坏文件覆盖成新空快照，也不得静默回退 continuation。可保留原文件用于诊断，并向宿主
+提供明确错误和人工恢复选项。
+
+### 10.9 用户明确新建会话
+
+officev3 创建新的产品 `sessionId`。由于恢复键变化，Box-Agent 创建全新逻辑 Session。无需额外
+`forceFresh` 标志。
+
+### 10.10 用户删除会话
+
+officev3 删除本地会话记录时调用 Box-Agent 的受控 `_session/purge` 扩展方法。Box-Agent：
+
+- 删除持久化 snapshot；
+- 删除该 Session 的 tool-results 等执行状态；
+- 清理相关 live ACP handle；
+- 不删除用户 project workspace 或产物，除非现有产品删除契约另有明确规定。
+
+如果 Box-Agent 当时不可用，officev3 必须记录 pending deletion，并在运行时恢复后重试。恢复功能
+本身不需要修改现有 `sessions` 表；可靠删除队列可以增加独立 tombstone 表。
+
+## 11. 取消链路修复
+
+### 11.1 Box-Agent
+
+`core._stream_with_activity()` 应同时等待 provider 下一 chunk、取消信号和原有活动心跳。取消轮询
+应明显短于 officev3 的 8 秒超时，但不能通过把 15 秒活动 heartbeat 降到高频来实现，否则会
+制造无意义事件。
+
+建议由 `asyncio.Event` 触发取消，并在等待 provider `__anext__()` 时与该 Event 竞争。取消后关闭
+provider stream，并通过现有 `DoneEvent(CANCELLED)` 落终态。
+
+### 11.2 officev3
+
+stream abort 和 UI 停止按钮必须共享同一个 cancellation promise，确保只发一次 IPC cancel，
+同时允许 UI 等待主进程确认 Turn 已停止。不能简单删除 abort handler，因为页面销毁和会话切换也
+可能通过 abort 触发后端取消。
+
+8 秒超时继续作为卡死工具的最后保护，但正常静默 provider cancel 应远早于该阈值完成。
+
+## 12. ACP/Host 契约变化
+
+### 12.1 `session/new` 入站
+
+沿用现有：
+
+```json
+{
+  "cwd": "...",
+  "mcpServers": [],
+  "_meta": {
+    "session_id": "stable-office-session-id"
+  }
+}
+```
+
+`_meta.session_id` 是恢复所需的稳定逻辑身份。utility/one-shot Session 不应参与持久恢复，除非产品
+以后明确要求。
+
+### 12.2 `session/new` 出站
+
+在现有 `_meta` 中增加 additive 字段：
+
+```json
+{
+  "resumed": true,
+  "session_revision": 17
+}
+```
+
+`resumed=false` 只表示没有找到已有快照，不代表恢复失败。损坏和不兼容必须返回明确错误，而不是
+`resumed=false`。
+
+### 12.3 `session/prompt`
+
+沿用现有 `_meta.turn_id`。宿主生成的 `turnId` 在一次请求的所有重试中必须保持不变。
+
+### 12.4 删除扩展
+
+增加受控扩展方法，例如：
+
+```text
+_session/purge { session_id }
+```
+
+该方法只用于业务删除，不用于 cancel、dispose 或强拆。
+
+### 12.5 `session/load`
+
+第一版保持 `AgentCapabilities(loadSession=False)`。未来实现标准 ACP load 时，必须复用同一个
+Durable Session Module，不能维护第二份恢复逻辑。
+
+## 13. 兼容与迁移
+
+### 13.1 已有但尚无快照的会话
+
+部署后的旧会话首次重建时：
+
+1. `session/new` 返回 `resumed=false`；
+2. officev3 继续发送现有 `session_continuation/v1`；
+3. Box-Agent 只在新 Agent 且没有快照时应用 continuation；
+4. 应用后立即或在 Turn start 时写入正式 snapshot；
+5. 后续恢复走 snapshot，不再依赖 continuation。
+
+### 13.2 已成功恢复的会话
+
+officev3 看到 `resumed=true` 后不再发送 continuation，避免把 UI 历史重复注入模型上下文。
+
+### 13.3 continuation 保留范围
+
+以下文件继续保留，但定位调整为迁移 Adapter：
+
+- officev3 `src/lib/agent/localAgentContinuation.ts`；
+- Box-Agent `box_agent/session_continuation.py`。
+
+### 13.4 回滚
+
+回滚旧运行时时，新版本快照不会被旧代码读取。旧代码仍按当前 continuation 行为运行。快照 schema
+必须使用新文件名并保持未知文件无害；回滚不得删除用户快照。再次升级后继续恢复。
+
+## 14. Box-Agent 改动位置
+
+### 14.1 新增文件
+
+| 文件 | 改动 |
+| --- | --- |
+| `box_agent/session_state.py` | Durable Session Module：schema、原子 I/O、校验、revision、generation、capture/restore/delete |
+| `tests/test_session_state.py` | Module Interface 的持久化、损坏、迁移、安全和删除测试 |
+
+### 14.2 修改文件
+
+| 文件 | 改动 |
+| --- | --- |
+| `box_agent/acp/__init__.py` | 注入 store；`newSession` 恢复；prompt 幂等/checkpoint；cancel 状态；删除 prompt auto-create；`resumed` metadata；purge 扩展 |
+| `box_agent/agent.py` | 增加受控 `restore_history()`；复用 Goal 恢复；确保当前 system prompt 保留 |
+| `box_agent/tools/plan_tool.py` | PlanStore 导出/恢复 Session 状态 |
+| `box_agent/tools/todo_tool.py` | TodoStore 导出/恢复 Session 状态并保持现有校验 |
+| `box_agent/tools/setup.py` | 保持 Plan/Todo Store 可被 Agent Session 捕获；不复制持久化策略 |
+| `box_agent/core.py` | provider 静默期间可立即响应取消；必要时提取稳定的 dangling tool history 校验 |
+| `tests/test_acp.py` | ACP 重建、取消、幂等、metadata、未知 handle、迁移和 purge 回归 |
+| `tests/test_core.py` | 静默 provider 快速取消及协议完整性回归 |
+| `tests/test_session_continuation.py` | continuation 只作为无快照迁移输入的兼容测试 |
+
+不应把完整持久化策略直接写进 `acp/__init__.py`，也不应把 officev3 产品字段写入 `core.py`。
+
+## 15. officev3 改动位置
+
+| 文件 | 改动 |
+| --- | --- |
+| `electron/main/boxAgentManager.ts` | 读取 `resumed/session_revision`；保留稳定 `session_id`；强拆只丢 live handle；增加 purge；更新日志 |
+| `src/lib/agent/localAgentStream.ts` | `resumed=true` 时不构造 continuation；统一 stream cancel promise |
+| `src/components/AI/hooks/useChatSession.ts` | UI 停止复用 stream cancellation promise，不再次发送 cancel IPC |
+| `electron/main/localApi.ts` | 删除本地 Session 时触发 Box-Agent purge；失败时记录 pending deletion |
+| `electron/main/localChatStorage/schema.ts` | 仅在实现可靠 pending deletion queue 时增加 tombstone 表；恢复本身不修改 Session schema |
+| `electron/main/boxAgentManager.spec.ts` | 强拆后新 handle、稳定产品 ID、resumed metadata、Map 重建、单次 cancel |
+| `src/lib/agent/localAgentStream.spec.ts` | resumed 时跳过 continuation、未恢复时保留迁移、取消只调用一次 |
+| `src/lib/agent/localAgentContinuation.spec.ts` | 保留旧会话迁移兼容测试 |
+| `electron/main/localApi.spec.ts` | 业务删除触发 purge 和 pending deletion 重试 |
+
+officev3 不需要新增 `agentSessionId`，也不需要持久化 ACP handle。现有 SQLite `sessions.id` 和
+消息 `turn_id/run_id/external_idempotency_key` 已足以承载产品身份与 UI 幂等。
+
+## 16. 实施顺序
+
+### 阶段 A：持久化 Module 与回合边界恢复
+
+1. 新增 `session_state.py` 和直接测试；
+2. 增加 Agent history、Plan、Todo 的受控恢复；
+3. ACP `newSession` 按 `upstream_session_id` 加载；
+4. Turn start、tool result 和 Done 后 checkpoint；
+5. 未知 ACP handle 明确失败；
+6. 添加 `resumed/revision` metadata；
+7. 运行 Box-Agent focused tests。
+
+阶段 A 完成后，正常取消结束、ACP handle 重建和进程重启后的已完成上下文应可恢复。
+
+### 阶段 B：中断安全与取消时延
+
+1. provider 静默流和 cancel event 竞争；
+2. ToolCallStart 时保存调用意图；
+3. dangling tool call 恢复为 interrupted receipt；
+4. generation fencing 拒绝旧 ACP handle 的迟到保存；
+5. partial assistant 有界刷新；
+6. officev3 统一 cancel 所有者；
+7. 运行 Core/ACP/officev3 取消测试与真实静默流 probe。
+
+### 阶段 C：迁移、删除和宿主收尾
+
+1. officev3 根据 `resumed` 决定是否发送 continuation；
+2. continuation 首次迁移后生成正式快照；
+3. 实现 `_session/purge`；
+4. 删除本地 Session 时调用 purge；
+5. 实现 pending deletion 重试或等价的可靠清理；
+6. 完成跨仓库集成测试和打包运行时验证。
+
+建议三个阶段分别形成可审查的提交或 PR，避免持久化、取消和删除生命周期混在一个巨大 diff 中。
+
+## 17. 测试矩阵
+
+### 17.1 Durable Session Module
+
+- 新 Session 不存在快照；
+- 保存后完整加载；
+- 原子替换不会留下半文件；
+- checksum 损坏明确失败；
+- schema 不兼容明确失败；
+- system prompt 不从快照恢复；
+- request-only 图片/脱敏内容不落盘；
+- Goal、Plan、Todo、Skill 名称和 Session 状态恢复；
+- 旧 generation 不能覆盖新 generation；
+- delete 幂等并只删除 Session 自有状态。
+
+### 17.2 ACP
+
+- 同一产品 Session 创建两个不同 ACP handle，第二个恢复第一个上下文；
+- 不同产品 Session 不共享上下文；
+- 正常 cancel 后下一 Turn 保留历史；
+- 强拆后重建保留历史；
+- 进程重建模拟后恢复 Goal、Plan、Todo 和工具结果；
+- 相同 `turnId` 重试不重复模型/工具调用；
+- unknown ACP handle 不自动新建；
+- resumed Session 不应用 continuation；
+- 无快照 Session 可应用一次 continuation 并转成快照；
+- corrupted/incompatible snapshot 不静默新建；
+- purge 清理快照和 live handle。
+
+### 17.3 Core/工具安全
+
+- provider 永不产出新 chunk 时，cancel 在 officev3 超时前完成；
+- cancel 后 provider stream 被关闭；
+- tool call 后、tool result 前中断，恢复历史仍满足 provider 协议；
+- unknown 副作用工具不会自动重跑；
+- Plan/Todo 恢复后 read 与中断前一致；
+- 大工具结果引用在恢复后仍可读取。
+
+### 17.4 officev3
+
+- `session/new` 始终携带稳定产品 `session_id`；
+- `session/prompt` 携带稳定 `turn_id`；
+- `resumed=true` 不发送 continuation；
+- `resumed=false` 允许旧会话迁移；
+- 强拆删除 live Map，下一次 send 自动重建 handle；
+- abort/UI stop 只发一次 cancel；
+- 删除会话触发 purge；
+- Box-Agent 不可用时删除请求进入可靠重试队列。
+
+### 17.5 故障注入
+
+至少在以下位置强制终止并恢复：
+
+1. 用户消息持久化之前；
+2. 用户消息持久化之后、模型调用之前；
+3. assistant tool call 持久化之后、工具执行之前；
+4. 工具产生副作用之后、tool result 持久化之前；
+5. tool result 持久化之后、下一次模型调用之前；
+6. 流式 partial 生成期间；
+7. Turn terminal checkpoint 期间；
+8. 新 ACP handle 激活后旧 handle 迟到返回。
+
+每个测试都要证明：快照不损坏、不会重复副作用、下一 Turn 行为明确。
+
+## 18. 验收标准
+
+以下全部满足才算完成：
+
+1. 用户正常取消后，下一条消息仍使用同一逻辑 Session 和完整已完成上下文。
+2. officev3 强拆 ACP handle 后，新 handle 能恢复消息、Goal、Plan、Todo 和已完成工具结果。
+3. Box-Agent 进程重启后恢复行为与 handle 强拆一致。
+4. 相同 `turnId` 不会导致第二次模型调用或副作用工具执行。
+5. 异常中断的工具调用不会形成非法 provider 消息序列。
+6. 状态未知的副作用工具不会自动重跑。
+7. 损坏或不兼容快照返回明确错误，不静默开新会话。
+8. 已恢复 Session 不再注入 12 条 continuation；旧会话仍可一次性迁移。
+9. 正常静默 provider cancel 在 officev3 8 秒强拆阈值前完成。
+10. UI 停止动作只发送一次 cancel IPC。
+11. 用户删除业务会话后，Box-Agent 执行状态最终被清除。
+12. stdout 仍只输出 ACP JSON-RPC，持久化诊断走 stderr/log。
+
+## 19. 验证和运行时交付
+
+源码验证至少包括：
+
+```bash
+uv run pytest tests/test_session_state.py -v
+uv run pytest tests/test_acp.py -v
+uv run pytest tests/test_core.py -v
+```
+
+根据实际改动范围补充 Plan/Todo、workflow checkpoint、tool result storage 和 full suite。
+
+officev3 运行对应 Vitest focused tests，并做一个真实 stdio ACP probe：
+
+```text
+创建 Session -> 完成一轮 -> 取消静默流 -> 强拆 handle
+-> 新 handle 使用同一产品 sessionId -> 下一轮验证上下文
+```
+
+运行时交付必须分开报告：
+
+```text
+source changed
+-> source tests passed
+-> runtime built
+-> runtime installed into officev3 development environment
+-> ACP probe passed
+-> officev3 restarted
+-> fresh live task verified
+```
+
+源码测试不能替代打包、安装、宿主重启和真实任务验证。
+
+## 20. 安全、隐私和保留策略
+
+- Session ID 只能用于安全 hash/规范化后的路径段；禁止直接拼接未经验证的用户输入。
+- snapshot 不得包含 token、API key、权限 promise、原始图片字节或 request-only overlay。
+- 文件权限默认 `0600`，目录 `0700`。
+- 日志只记录 session hash、revision、状态和错误，不打印完整消息或工具结果。
+- purge 只能删除 Box-Agent 自有 Session 状态，不递归删除 workspace/project root。
+- 需要定义孤儿 snapshot 的保留/清理策略；在策略明确前不能把自动 TTL 当作业务删除替代品。
+- schema 迁移必须保留原快照直到新快照原子写入成功。
+
+## 21. 主要风险和缓解
+
+| 风险 | 缓解 |
+| --- | --- |
+| 旧 handle 迟到覆盖新状态 | generation fencing；每次保存校验当前 writer |
+| 快照包含不应持久化的数据 | allowlist serializer；redacted/request-only 回归测试 |
+| tool call/result 不完整 | 恢复校验和 interrupted stub；禁止自动续跑旧 Turn |
+| 相同 turn 重复副作用 | 持久化 Turn 收据；执行前幂等检查 |
+| JSON 全量重写影响性能 | 先测真实 Session 大小；Interface 保持不变，必要时换 SQLite |
+| Skill 更新后旧指令不一致 | 只保存名称/hash；重新加载当前可信 Skill 并显式诊断 |
+| workspace 变化导致旧路径失效 | 当前 host 配置优先；workspace identity 校验；fail closed |
+| 删除时 Box-Agent 不在线 | officev3 pending deletion tombstone 和重试 |
+| continuation 与快照重复注入 | `resumed=true` 时宿主不发送；Box-Agent 恢复后 turn_counter 非零 |
+| 取消仍超过宿主超时 | cancel event 与 provider stream 竞争；真实静默流 probe |
+
+## 22. 非目标
+
+第一版不包括：
+
+- 把 ACP handle 设计成全局永久 ID；
+- 对外暴露 epoch/generation；
+- 正常恢复时在多个“恢复等级”间静默降级；
+- 序列化 MCP/浏览器/Jupyter/asyncio 等运行时对象；
+- 自动续跑异常中断的旧 Turn；
+- 从 UI transcript 完整重建 Box-Agent 工具协议；
+- 同时支持多个 Box-Agent 进程写同一 Session 数据目录；
+- 修改用户 workspace/project 产物的删除语义。
+
+## 23. 实施者快速检查清单
+
+- [ ] 使用稳定 `upstream_session_id`，不使用 ACP handle 作为磁盘恢复键。
+- [ ] 当前 system prompt 和 runtime 配置重新构造，不从快照覆盖。
+- [ ] Turn start 在副作用发生前持久化。
+- [ ] ToolCallStart 和 ToolCallResult 都有 checkpoint。
+- [ ] 相同 `turnId` 在执行前去重。
+- [ ] cancel 只结束 Turn。
+- [ ] unknown ACP handle 明确失败。
+- [ ] 旧 generation 无法写入。
+- [ ] snapshot 损坏不被新空状态覆盖。
+- [ ] resumed Session 不注入 continuation。
+- [ ] 业务删除调用 purge，并有离线重试。
+- [ ] focused tests、full suite 和真实 ACP/officev3 probe 分别记录。
+
+## 24. 参考实现位置
+
+Box-Agent：
+
+- `box_agent/acp/__init__.py`：SessionState、newSession、prompt、cancel、Agent event Adapter；
+- `box_agent/agent.py`：Agent messages、Goal、active Skill 和运行入口；
+- `box_agent/schema/schema.py`：provider-neutral Message schema；
+- `box_agent/core.py`：共享取消和 tool history 不变量；
+- `box_agent/workflow_owner_store.py`：稳定产品 Session 下的原子 JSON 模式参考；
+- `box_agent/workflow_checkpoint_store.py`：schema/hash/原子 checkpoint 模式参考；
+- `box_agent/tool_result_storage.py`：Session 级大工具结果引用；
+- `box_agent/session_continuation.py`：旧会话语义迁移 Adapter。
+
+officev3：
+
+- `electron/main/boxAgentManager.ts`：产品 Session 与 ACP handle 的运行时映射、强拆和 `session/new`；
+- `src/lib/agent/localAgentStream.ts`：turnId、continuation 和 abort cancel；
+- `src/components/AI/hooks/useChatSession.ts`：UI 停止行为；
+- `electron/main/localChatStorage/schema.ts`：产品 Session/UI 消息持久化；
+- `electron/main/localApi.ts`：本地 Session 删除；
+- `src/lib/agent/localAgentContinuation.ts`：最近 12 条语义迁移。
+
+## 25. 代码图谱说明
+
+本次分析使用 `.understand-anything/knowledge-graph.json` 作为导航索引，但其基线 commit
+`bb52addbae8a77a0e032a4f8f9d2c6ecedaae500` 早于当前源码 commit
+`e4167a98734ec2abf466510ad94f414dc2b17113`。本文的现状结论已通过当前源码直接核对；图谱不作为
+实现真相。若后续改动范围继续扩大，建议在代码落地后统一刷新 graph、meta 和 fingerprints。

--- a/docs/SESSION_RECOVERY_HANDOFF_V2_CN.md
+++ b/docs/SESSION_RECOVERY_HANDOFF_V2_CN.md
@@ -1,0 +1,576 @@
+# Session Log、恢复与上下文持久化 Handoff V2
+
+> 状态：源码审核后的实现方案，首版已实现。
+> 持久化格式：每个 Session 一个 append-only JSONL 文件；不使用 SQLite。
+> 与 V1 的关系：本文是独立 V2，不修改 `SESSION_RECOVERY_HANDOFF_CN.md`。
+
+## 1. 本文的事实边界
+
+本文只包含三类内容：
+
+1. DeepSeek Harness 源码中已经存在的机制；
+2. Box-Agent 当前源码中已经存在的状态和执行位置；
+3. 为把前两者接起来，Box-Agent 必须新增的最小实现。
+
+不在本文中设计后台 subagent、durable mailbox、SQLite、Snapshot、hash chain、多 writer 合并、跨文件
+事务、审计 UI、日志分段或新的 ACP 私有接口。多进程同时写同一 Session 不受支持，由单 writer
+排他所有权直接拒绝。
+
+源码基线：
+
+- DeepSeek Harness：`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`；
+- Box-Agent：`e4167a98734ec2abf466510ad94f414dc2b17113` 加当前工作区变更；
+- `.understand-anything` 图谱基线为 `bb52addbae8a77a0e032a4f8f9d2c6ecedaae500`，早于当前
+  Box-Agent 源码，因此只用于导航，结论以直接读取源码为准。
+
+## 2. 审核后删除的过度设计
+
+上一版草案中的以下内容没有足够源码依据，或不是首版持久化所必需，全部移除：
+
+- `session/repair` Event；
+- `session/activation`、持久化 generation、expected-head fencing；
+- `event_id`、`prev_hash`、`event_hash` 和 hash chain；
+- `turn/cancel-requested`、Turn receipt 和 exactly-once Turn 协议；
+- `context/replace` Event；
+- `subagent/link`、`subagent/established`、`subagent/report-sent`、`subagent/settled`；
+- `inbox.jsonl` 和 Durable Mailbox；
+- `snapshot.json`、索引和 sealed segment；
+- 内容寻址 blob 改造；
+- `_session/purge`、pending deletion 等新 ACP 接口；
+- 首版不需要的 approval、interaction、workflow Session Event。
+
+其中一些机制未来可能有价值，但不能写成 DeepSeek 或 Box-Agent 当前已经具有的能力。
+
+## 3. DeepSeek Harness 源码确认的设计
+
+### 3.1 一个 Session 对应一个 append-only 逻辑 JSONL 日志
+
+DeepSeek 的 JSONL 后端为每个 Session 保存一个逻辑日志。第一条是不可变 Session Header，后续每条
+是一个 Session Event。关闭压缩时是原始 `.jsonl`；默认的 `.jsonl.zstd` 只是相同逻辑记录的压缩
+存储形式。
+
+Header 的源码字段为：
+
+```text
+type = "session"
+version
+id
+createdAt
+cwd?
+parentSession?
+seedLength?
+origin?
+delegationDepth?
+agentPreset?
+```
+
+Event envelope 的源码字段为：
+
+```text
+type
+seq
+time
+data
+ignorable?
+surfaceOp?
+sourceEventSeqs?
+```
+
+DeepSeek 的 Session Event 没有 hash chain、event ID 或持久化 writer generation。`seq` 连续递增，
+`time` 不负责排序。
+
+### 3.2 Surface 是日志投影，不是另一份历史
+
+只有以下事件直接产生模型消息：
+
+```text
+user/message
+assistant/message
+tool/result
+```
+
+这些事件通过 `surfaceOp` 追加或替换 Surface。其他事件保留在日志中，但不会直接进入下一次模型
+请求。进程重启后重新回放日志即可得到当前 Surface。
+
+### 3.3 耐久检查点
+
+DeepSeek 将 JSONL 后端与检查点策略分开。检查点策略在以下语义位置等待 Session flush：
+
+- 模型请求真正交给 provider 之前；
+- 顶层工具真正开始执行之前；
+- 下一 Step 开始前，确保上一步 Assistant Message 和工具结果已经持久化。
+
+因此，硬崩溃最多丢失尚未越过语义检查点的尾部事件；工具产生外部副作用前，其 `tool/call` 已经
+进入耐久前缀。
+
+### 3.4 Repair 的真实含义
+
+Repair 是“加载持久日志时补齐中断尾部”的恢复过程，不是名为 `session/repair` 的 Event。
+
+DeepSeek 的 `interruptedTurnClosers()` 扫描最后一个未闭合 Turn，并追加普通事件：
+
+1. Assistant Message 中有 tool call，但没有对应 `tool/call`：追加错误 `tool/result`，错误码为
+   `TOOL_NOT_STARTED`；
+2. 已有 `tool/call`，但没有对应 `tool/result`：追加错误 `tool/result`，错误码为
+   `TOOL_OUTCOME_UNKNOWN`；
+3. 如果 Step 未闭合，追加 `step/end`；
+4. 追加 `turn/end`，reason 为 `interrupted`。
+
+这些补齐事件继续使用正常 Event vocabulary。它们持久化成功后，Session 才对运行时可见。
+
+JSONL 文件自己的 torn tail 修复是另一件事：后端把不完整尾部截断到最后一个已提交字节位置，再
+追加可恢复的完整事件。中间损坏不能按尾部中断处理。
+
+### 3.5 上下文压缩
+
+DeepSeek 的压缩日志使用：
+
+```text
+compaction/start
+compaction/summary
+compaction/prune        # 仅实际发生无模型裁剪时
+compaction/end
+```
+
+真正改变 Surface 的不是 `context/replace` Event，而是一条带
+`surfaceOp: {op: "replace", start, end}` 的 Surface Event。摘要压缩通常写入一条替换范围的
+`user/message`。被替换的旧事件仍保留在 append-only 日志中，因此既能恢复压缩后的上下文，也能
+审计压缩前历史。
+
+恢复 Session 时，DeepSeek 还会追加 `session/end-seed`，标记“从磁盘加载的历史到这里结束”。如果
+旧日志尾部有未配对的 `compaction/start`，但它位于最新 `session/end-seed` 之前，压缩模块把它视为
+旧进程遗留的未完成尝试，不再把它当作当前压缩锁。
+
+### 3.6 Subagent
+
+DeepSeek 的本地 subagent 使用独立 Session。Child Header 使用 `parentSession`、`origin=subagent`、
+`delegationDepth` 和可选 `seedLength` 表示 lineage；Child 自己记录普通 Turn、Message、Tool 和
+Compaction Event。
+
+Child 日志中还有 `subagent/descriptor`。当前源码中 one-shot descriptor 的持久字段只有：
+
+```text
+version
+mode = "one-shot"
+provider
+label?
+```
+
+continuable descriptor 才额外保存恢复 composition 所需的 provider/model/persona/tool filter。
+DeepSeek 没有用 `subagent/link`、`subagent/established` 或 `subagent/settled` 作为父子持久化协议。
+`subagent/start`、`subagent/end` 是运行观察事件，不是 Session Log 的恢复事实。
+
+## 4. Box-Agent 当前源码事实
+
+### 4.1 当前可恢复性
+
+- `Agent.messages` 是进程内模型历史；
+- ACP 的 `_sessions` 是进程内 handle 映射；
+- `session_continuation/v1` 只能从 Host 注入有限历史，不是完整 Session replay；
+- `session_trace.py` 是 best-effort 诊断 JSONL，写入失败不会影响 Agent，因此不能作为恢复事实；
+- `SummarizationEvent` 是 Host 展示事件，实际上下文替换发生在 `core.py` 对 `messages` 执行
+  `clear()`/`extend()` 时；
+- `workflow_checkpoint_store.py` 已经是独立持久域；
+- `tool_result_storage.py` 已经负责大工具结果处理。
+
+### 4.2 当前需要恢复的 Session 状态
+
+首版 Session Log 只接管会影响后续模型请求的状态：
+
+- `Agent.messages`；
+- `Agent.goal`；
+- `PlanStore`；
+- `TodoStore`；
+- active Skill 的名称、内容 hash 和加载顺序；
+- 当前 Turn/Step 和工具调用配对状态；
+- 已提交的上下文压缩结果。
+
+以下内容不迁入 Session Log：
+
+- workflow checkpoint：继续由 `workflow_checkpoint_store.py` 管理；
+- Memory：继续由现有 Memory 持久域管理；
+- session trace：继续只用于诊断；
+- ToolResultStorage 文件：沿用现有实现；
+- LLM、Tool、SkillLoader、asyncio Task/Queue 等运行时对象：重启后重新构造；
+- `ProgressEvent`、`LLMActivityEvent`、`LogFileEvent` 等展示或心跳事件。
+
+### 4.3 当前 subagent 行为
+
+`sub_agent_tool.py` 当前创建 `subagent-<uuid>`，构造独立 messages，并直接调用
+`run_agent_loop()`。它把嵌套运行事件包装为 `SubAgentEvent` 发给 Host，父 Agent 最终只接收
+`ToolResult`。Child 没有独立耐久 Session。
+
+首版只处理当前已有的同步 one-shot subagent；不引入 background 或 continuable subagent。
+
+## 5. Box-Agent V2 最小实现
+
+### 5.1 存储布局
+
+```text
+~/.box-agent/sessions/<safe-session-key>/
+├── session.jsonl
+└── .writer.lock
+```
+
+`safe-session-key` 从稳定产品 Session ID 生成，不能直接信任外部 ID 作为路径。`session.jsonl` 是
+唯一 canonical Session 状态文件；`.writer.lock` 是不承载 Header、Event 或恢复状态的操作锁文件。
+不创建 SQLite、Snapshot 或第二份 Session 状态文件。
+
+### 5.2 Header
+
+首行沿用 DeepSeek 已验证的最小结构：
+
+```json
+{"type":"session","version":1,"id":"product-session-id","createdAt":0,"cwd":"/workspace"}
+```
+
+本地 subagent 只增加源码已有 lineage 字段：
+
+```json
+{"type":"session","version":1,"id":"subagent-id","createdAt":0,"cwd":"/workspace","parentSession":"product-session-id","origin":"subagent","delegationDepth":1}
+```
+
+没有真实值的字段不写，不填占位值。Header 创建后不可修改。
+
+### 5.3 Event envelope
+
+沿用 DeepSeek 的直接 Event 结构，不再包一层 `record: event`：
+
+```json
+{"type":"tool/call","seq":12,"time":0,"data":{"turn":2,"step":1,"callId":"call-1","name":"bash","arguments":"{...}"}}
+```
+
+规则：
+
+- `seq` 从 0 连续递增；
+- 每行必须是 lossless JSON；
+- 未识别且没有 `ignorable: true` 的 Event 导致恢复失败；
+- Surface Event 才能携带 `surfaceOp` 和 `sourceEventSeqs`；
+- 首版不增加 hash、event ID、generation 或 revision 字段。
+
+### 5.4 首版 Event vocabulary
+
+与 DeepSeek 同义、直接采用：
+
+| Event | 用途 |
+| --- | --- |
+| `turn/start`、`turn/end` | Turn 边界和终态 |
+| `step/start`、`step/end` | 一次模型请求及其工具周期 |
+| `user/message` | 用户或运行时注入的完整模型消息 |
+| `assistant/chunk` | 原始流式输出，服务完整审计 |
+| `assistant/message` | 组装后的模型消息 |
+| `tool/call`、`tool/result` | 工具调用及模型可见结果 |
+| `request/header` | 当次实际 system prompt、tools 和模型参数 |
+| `request/context` | provider/model/context window 等路由事实 |
+| `session/end-seed` | 标记恢复前缀结束，隔离旧生命周期遗留的开放 bracket |
+| `goal/change` | `Agent.goal` 变化 |
+| `todo/write` | 完整 TodoStore，last write wins |
+| `compaction/start`、`compaction/summary`、`compaction/prune`、`compaction/end` | 压缩审计 |
+| `subagent/descriptor` | Child 的 one-shot 身份 |
+
+Box-Agent 为当前已有状态新增，但 DeepSeek 没有同名通用 Event：
+
+| Event | 为什么必须新增 |
+| --- | --- |
+| `plan/write` | `PlanStore` 会影响后续执行，必须能从日志恢复完整当前值 |
+| `skill/change` | active Skill 会改变后续 system prompt，必须恢复名称、hash 和加载顺序 |
+
+除这两个明确的 Box-Agent 扩展外，首版不再新增其他 Event 名称。
+
+### 5.5 Surface replay
+
+Surface 只处理：
+
+```text
+user/message
+assistant/message
+tool/result
+```
+
+普通消息使用 `surfaceOp: "append"`。压缩后的摘要或 checkpoint Message 使用 replace operation，并
+通过 `sourceEventSeqs` 引用被遮蔽的 Surface Event。回放得到的 Surface 写入运行时
+`Agent.messages`；`Agent.messages` 不再单独作为恢复事实。
+
+Box-Agent 的 system message 不属于 Surface。恢复时先从当前可信配置、恢复后的 active Skill 和
+现有 prompt builder 重新构造 system message，再拼接 replay 得到的 Surface。旧 `request/header`
+只用于审计当时实际请求，不能恢复成当前权限或工具配置。
+
+### 5.6 写入和 flush
+
+Session Log Module 只需要向调用方暴露四类能力：创建或加载、append、flush、close。JSON 编码、
+连续 seq、单 Session 串行写和 torn tail 处理都留在 Module 内部，Core 和 ACP 不直接写文件。
+
+创建或加载时，Module 必须先非阻塞取得 `.writer.lock` 的操作系统排他锁，再读取、校验或修复
+`session.jsonl`。同一 Session 已有 owner 时立即抛出 `SessionLogInUseError`，不等待、不合并 Event，
+也不引入 generation。锁持续到 `close()`；进程退出时由操作系统释放。锁文件残留不表示 Session
+仍被占用，恢复不读取它的内容。
+
+首版写入顺序：
+
+```text
+Turn 接纳：
+append turn/start + user/message
+
+模型请求前：
+append step/start + request/header/request/context
+-> flush + fsync
+-> 调用 provider
+
+顶层工具执行前：
+append assistant/message + tool/call
+-> flush + fsync
+-> tool.invoke()
+
+下一 Step 前：
+append tool/result + step/end
+-> flush + fsync
+-> 进入下一次模型请求
+
+Turn 结束：
+append turn/end
+-> flush + fsync
+-> 返回 ACP PromptResponse
+```
+
+`assistant/chunk` 可以批量 append，不要求每个 chunk 单独 fsync，但越过下一语义检查点前必须被
+drain。任何检查点失败都必须阻止后续 provider 请求或工具副作用。
+
+### 5.7 冷恢复与中断闭合
+
+恢复流程：
+
+```text
+读取并校验 Header
+-> 扫描完整 JSONL records
+-> 如最后一条 record 不完整，截断到最后一个完整 record
+-> 校验 seq 和必需 Event vocabulary
+-> 回放 Surface、Goal、Plan、Todo、Skill 和 Turn/Step 状态
+-> 对开放 Turn 生成普通 closer events
+-> append + fsync closers
+-> append session/end-seed，标记恢复前缀结束
+-> 构造 Agent
+```
+
+closer events 与 DeepSeek 保持一致：
+
+- 未记录开始的工具：`tool/result(error.code=TOOL_NOT_STARTED)`；
+- 已记录开始但结果缺失：`tool/result(error.code=TOOL_OUTCOME_UNKNOWN)`；
+- 开放 Step：`step/end`；
+- 开放 Turn：`turn/end(reason.kind=interrupted)`。
+
+这里没有 `session/repair` Event。中间 JSON 损坏、Header 不匹配、seq 不连续或未知必需 Event 必须
+显式失败，不能截断成一个看似正常的新 Session。恢复不会自动重跑 outcome unknown 的工具。
+
+### 5.8 压缩提交
+
+当前 `core.py` 只有在 `messages.clear()`/`messages.extend(new_msgs)` 时真正切换上下文。改造后应在
+该位置先持久化。模型摘要路径为：
+
+```text
+append compaction/start
+-> 生成现有 CompactionOutcome
+-> append compaction/summary
+-> append 带 replace surfaceOp 的 user/message
+-> append compaction/end
+-> flush + fsync
+-> 再修改 Agent.messages
+```
+
+无模型的 workflow checkpoint replacement 或现有 tool-result pruning 不伪造 summary，使用：
+
+```text
+append compaction/prune
+-> 紧接着 append 带 replace surfaceOp 的 Surface Event
+-> flush + fsync
+-> 再修改 Agent.messages
+```
+
+压缩失败且没有 replacement 时，模型摘要路径只追加带 error 的 `compaction/end`。现有
+`SummarizationEvent` 继续用于 Host 展示，不代替 Session Event。
+
+恢复只按已经提交的 replacement 重建 Surface：
+
+| 最后耐久位置 | 恢复结果 |
+| --- | --- |
+| `compaction/start` 之前 | 使用旧 Surface |
+| `compaction/start` 之后、replacement 之前 | 使用旧 Surface；已完成的 summary 只保留为审计记录 |
+| replacement 之后、`compaction/end` 之前 | 使用新 Surface |
+| 成功 `compaction/end` 之后 | 使用新 Surface |
+| 带 error 的 `compaction/end`，且没有 replacement | 使用旧 Surface |
+
+`compaction/end` 不是 Surface 提交点；replacement Event 才是。恢复不重新调用摘要模型，也不补造
+摘要或成功的 `compaction/end`。`session/end-seed` 使旧生命周期遗留的 unmatched start 不再阻止
+后续新压缩。旧消息 Event 永不从 JSONL 删除。
+
+### 5.9 Subagent 持久化
+
+当前 one-shot subagent 改为创建独立 child `session.jsonl`，但仍调用现有 `run_agent_loop()`：
+
+```text
+Parent log:
+  assistant/message
+  tool/call(sub_agent)
+  tool/result(meta.child_session_id = child id)
+
+Child log:
+  Header(parentSession, origin=subagent, delegationDepth)
+  turn/start
+  user/message
+  subagent/descriptor
+  ...普通模型和工具 Event...
+  turn/end
+```
+
+Child descriptor 只保存当前 one-shot 恢复和审计需要的字段，不复制 continuable composition：
+
+```json
+{"version":1,"mode":"one-shot","provider":"local","label":"分析持久化设计"}
+```
+
+父日志不复制 Child 的中间 Event。父 `tool/result` 使用现有结果 metadata/raw output 保存
+`child_session_id`，用于从委派结果打开 Child 日志。`SubAgentEvent` 继续只用于实时展示。
+
+Child 中断时按普通 Session 规则闭合自己的开放 Turn；父侧如果没有 durable `tool/result`，按普通
+`TOOL_OUTCOME_UNKNOWN` 处理，不从 Child 日志伪造一个成功结果，也不自动重新执行委派。
+
+首版不实现 fork history、continuable child、后台消息、mailbox 或父子跨文件事务。
+
+### 5.10 ACP 接入
+
+- ACP handle 仍是进程内临时 ID，不写入日志；
+- `session/new` 收到稳定 `_meta.session_id` 时，按该产品 Session ID 加载或创建日志；
+- 进程重启后 Host 先重新调用 `session/new`，Box-Agent 返回新的 ACP handle；
+- 已成功加载 JSONL 时不再应用 `session_continuation/v1`；
+- 只有找不到 JSONL 的旧 Session 才继续使用一次 continuation 迁移；
+- 不在首版增加新的 ACP response 字段、purge 方法或 Turn exactly-once 协议；
+- cancel 继续使用当前协作式取消，Core 退出时由 Session Log 记录正常或 interrupted Turn 终态。
+
+## 6. 最小代码改动范围
+
+### 6.1 新增
+
+| 文件 | 责任 |
+| --- | --- |
+| `box_agent/session_log.py` | Header/Event 校验、append、flush、load、tail repair、replay |
+| `tests/test_session_log.py` | JSONL、replay、checkpoint 和中断闭合测试 |
+| `tests/test_agent_session_persistence.py` | 主 Agent 检查点、状态恢复和压缩持久化测试 |
+
+如果单文件在实现后确实过大，再在不扩大外部 Interface 的前提下拆包；本文不预先创建多个空模块。
+
+### 6.2 修改
+
+| 文件 | 最小改动 |
+| --- | --- |
+| `box_agent/core.py` | 在模型、工具和实际压缩切换处 append/flush |
+| `box_agent/agent.py` | 记录 Turn/Step/Surface，并从 replay 恢复 messages、Goal 和 active Skill |
+| `box_agent/acp/__init__.py` | stable product Session ID 到 Session Log 的加载/创建 |
+| `box_agent/tools/plan_tool.py` | Plan 写成功后记录完整 `plan/write` |
+| `box_agent/tools/todo_tool.py` | Todo 写成功后记录完整 `todo/write` |
+| `box_agent/tools/sub_agent_tool.py` | 为当前 one-shot child 创建独立 Session Log |
+| `tests/test_core.py` | 语义检查点、压缩 replacement、中断工具测试 |
+| `tests/test_acp.py` | 重启后使用相同产品 Session ID 恢复 |
+| `tests/test_sub_agent_tool.py` | Child 独立日志和父结果 child ID |
+
+`session_trace.py`、`workflow_checkpoint_store.py`、Memory 和 ToolResultStorage 不改写为 Session Log
+实现，也不承担恢复事实来源。
+
+## 7. 实施顺序
+
+### 阶段 A：JSONL 和主 Agent 恢复
+
+1. 实现 Header/Event schema、连续 seq、append、flush 和 tail repair；
+2. 实现 Surface 和开放 Turn replay；
+3. 接入 user/assistant/tool/turn/step/request Event；
+4. 在模型请求和工具执行前加 flush gate；
+5. ACP 使用稳定产品 Session ID 加载；
+6. 完成进程重启恢复测试。
+
+### 阶段 B：Box-Agent 状态和压缩
+
+1. 接入 Goal、Plan、Todo、Skill Event；
+2. 把当前上下文切换改为 durable replacement 后再更新 messages；
+3. 验证压缩前 Event 可审计、恢复使用压缩后 Surface；
+4. 验证现有 workflow checkpoint、Memory、trace 和 ToolResultStorage 行为未被接管。
+
+### 阶段 C：当前 one-shot subagent
+
+1. 给 Child 创建独立日志和 lineage Header；
+2. 写入最小 one-shot descriptor；
+3. 父普通 tool result 保存 child Session ID；
+4. 验证父、子分别回放以及中断时不自动重跑。
+
+## 8. 必须通过的测试
+
+### JSONL
+
+- Header 只能是第一条；
+- seq 必须连续；
+- 完整 Event 全部回放；
+- 不完整最后一行可截断；
+- 中间损坏和未知必需 Event 显式失败；
+- flush/fsync 失败时模型和工具不继续执行；
+- 同一 Session 的第二个 writer 立即失败，owner 关闭或进程退出后可重新加载；
+- 未取得 writer 所有权时不能执行 torn tail 截断。
+
+### 中断恢复
+
+- 开放 Turn 追加 `turn/end(interrupted)`；
+- 开放 Step 先追加 `step/end`；
+- Assistant tool call 未 dispatch 得到 `TOOL_NOT_STARTED`；
+- 已 dispatch、结果未知得到 `TOOL_OUTCOME_UNKNOWN`；
+- 未知副作用工具不会自动重跑。
+
+### 压缩
+
+- replacement 提交前崩溃恢复旧 Surface；
+- replacement 提交后崩溃恢复新 Surface；
+- 被替换的原 Event 仍能审计；
+- tool call/result pairing 不被替换范围破坏。
+
+### Subagent
+
+- Parent 与 Child 使用不同 JSONL；
+- Child Header 的 `parentSession` 正确；
+- Child 日志包含自己的模型和工具 Event；
+- 父 tool result 能定位 Child Session；
+- Child 中断不导致父自动重跑委派；
+- `SubAgentEvent` 丢失不影响 Child replay。
+
+## 9. 验收标准
+
+1. Box-Agent 进程重启后，相同产品 Session ID 能从 `session.jsonl` 恢复已提交模型上下文。
+2. Goal、Plan、Todo、active Skill 和压缩后的 Surface 与崩溃前最后耐久状态一致。
+3. 可以从完整 Event Log 查看压缩前消息、模型输出、工具调用和工具结果。
+4. 工具副作用前的 `tool/call` 已持久化；缺失结果恢复为 outcome unknown，不盲目重跑。
+5. 当前 one-shot subagent 有独立日志，父结果可以定位 Child Session。
+6. 删除或关闭 `session_trace` 不影响恢复。
+7. 没有引入 SQLite、Snapshot、mailbox、hash chain 或新的 ACP 私有协议。
+8. 同一 Session 同时只有一个 writer；冲突不会修改或修复 `session.jsonl`。
+
+## 10. 源码位置
+
+DeepSeek Harness：
+
+- `packages/core/session/src/types.ts`：Header、Event、Surface vocabulary；
+- `packages/core/session/src/surface.ts`：Surface append/replace replay；
+- `packages/core/session/src/repair.ts`：`interruptedTurnClosers()`；
+- `packages/session/session-persistence-jsonl/src/index.ts`：JSONL append、fsync、tail repair；
+- `packages/session/session-checkpoint-policy/src/index.ts`：模型/工具/Step 检查点；
+- `packages/compaction/compaction/src/types.ts`：compaction Event；
+- `packages/compaction/compaction-basic/src/region.ts`：replacement 提交；
+- `packages/subagent/subagent/src/descriptor.ts`：descriptor；
+- `packages/subagent/subagent/src/child-agent.ts`：Child lineage；
+- `packages/subagent/subagent-in-process-driver/src/index.ts`：one-shot Child Session。
+
+Box-Agent：
+
+- `box_agent/agent.py`；
+- `box_agent/core.py`；
+- `box_agent/acp/__init__.py`；
+- `box_agent/events.py`；
+- `box_agent/tools/plan_tool.py`；
+- `box_agent/tools/todo_tool.py`；
+- `box_agent/tools/sub_agent_tool.py`；
+- `box_agent/session_trace.py`；
+- `box_agent/tool_result_storage.py`；
+- `box_agent/workflow_checkpoint_store.py`。

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -917,6 +917,32 @@ async def test_acp_restarts_with_same_product_session_from_jsonl(
         ("assistant", "done"),
     ]
     assert state.agent.session_log.events[-1]["type"] == "session/end-seed"
+
+    await restarted_agent.prompt(
+        SimpleNamespace(
+            sessionId=restarted.sessionId,
+            prompt=[{"text": "continue after restart"}],
+            field_meta={
+                "session_continuation": {
+                    "schema_version": "officev3-session-continuation/v1",
+                    "product_session_id": "stable-restart-session",
+                    "reason": "acp_epoch_recreated",
+                    "messages": [
+                        {"role": "user", "content": "stale migration seed"},
+                    ],
+                    "truncated": False,
+                }
+            },
+        )
+    )
+
+    assert [message.content for message in state.agent.messages].count(
+        "stale migration seed"
+    ) == 0
+    assert [(message.role, message.content) for message in state.agent.messages[-2:]] == [
+        ("user", "continue after restart"),
+        ("assistant", "done"),
+    ]
     state.agent.session_log.close()
 
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -882,6 +882,45 @@ class DoneLLM:
 
 
 @pytest.mark.asyncio
+async def test_acp_restarts_with_same_product_session_from_jsonl(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=2, workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    request = SimpleNamespace(
+        cwd=str(tmp_path),
+        field_meta={"session_id": "stable-restart-session"},
+    )
+    first_agent = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
+    first = await first_agent.newSession(request)
+    await first_agent.prompt(
+        SimpleNamespace(
+            sessionId=first.sessionId,
+            prompt=[{"text": "remember this"}],
+            field_meta={},
+        )
+    )
+    first_agent._sessions[first.sessionId].agent.session_log.close()
+
+    restarted_agent = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
+    restarted = await restarted_agent.newSession(request)
+    state = restarted_agent._sessions[restarted.sessionId]
+
+    assert restarted.sessionId != first.sessionId
+    assert [(message.role, message.content) for message in state.agent.messages[1:]] == [
+        ("user", "remember this"),
+        ("assistant", "done"),
+    ]
+    assert state.agent.session_log.events[-1]["type"] == "session/end-seed"
+    state.agent.session_log.close()
+
+
+@pytest.mark.asyncio
 async def test_prompt_clears_prompt_grants_once_before_attachment_processing(
     tmp_path, monkeypatch
 ):
@@ -1670,7 +1709,12 @@ async def test_acp_prompt_checks_for_mcp_auth_refresh(acp_agent, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_acp_seeds_negotiated_session_continuation_once(acp_agent):
+async def test_acp_seeds_negotiated_session_continuation_once(
+    acp_agent,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     agent, _ = acp_agent
     session = await agent.newSession(
         SimpleNamespace(
@@ -2218,7 +2262,11 @@ async def test_acp_emits_skills_usage_raw_output(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_acp_skill_invocations_are_idempotent_and_keep_context(tmp_path):
+async def test_acp_skill_invocations_are_idempotent_and_keep_context(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     skills_dir = tmp_path / "skills"
     skill_dir = skills_dir / "paid-skill"
     skill_dir.mkdir(parents=True)
@@ -2303,7 +2351,8 @@ async def test_acp_skill_invocations_are_idempotent_and_keep_context(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_acp_emits_turn_usage_for_tools_mcp_and_tokens(tmp_path):
+async def test_acp_emits_turn_usage_for_tools_mcp_and_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=3, workspace_dir=str(tmp_path)),
@@ -2363,7 +2412,8 @@ async def test_acp_emits_turn_usage_for_tools_mcp_and_tokens(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_acp_threads_session_turn_and_title_to_llm(tmp_path):
+async def test_acp_threads_session_turn_and_title_to_llm(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(
@@ -2886,7 +2936,8 @@ async def test_acp_injects_standard_box_agent_image_generation_policy(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_acp_uses_host_artifact_root_dir_for_output_mode(tmp_path):
+async def test_acp_uses_host_artifact_root_dir_for_output_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=1, workspace_dir=str(tmp_path)),
@@ -3742,6 +3793,7 @@ async def test_acp_external_skill_owner_survives_new_acp_session(
     tmp_path,
     monkeypatch,
 ):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setenv("BOX_AGENT_WORKFLOW_OWNER_DIR", str(tmp_path / "owners"))
     skills_dir = tmp_path / "skills"
     skill_dir = skills_dir / "ppt-master"

--- a/tests/test_agent_session_persistence.py
+++ b/tests/test_agent_session_persistence.py
@@ -1,0 +1,460 @@
+"""Agent integration tests for durable Session Log checkpoints."""
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from box_agent.agent import Agent
+from box_agent.events import DoneEvent
+from box_agent.hooks import BaseHook
+from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
+from box_agent.session_log import SessionLog, SessionLogDurabilityError
+from box_agent.tools.base import Tool, ToolResult
+from box_agent.tools.plan_tool import PlanReadTool, PlanStore, PlanWriteTool
+from box_agent.tools.todo_tool import TodoReadTool, TodoStore, TodoWriteTool
+
+
+def _read_durable_events(path: Path) -> list[dict]:
+    raw = path.read_bytes()
+    assert raw.endswith(b"\n")
+    return [json.loads(line) for line in raw.splitlines()[1:]]
+
+
+class _CheckpointInspectingLLM:
+    model = "test-model"
+    max_output_tokens = 1024
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.saw_durable_request = False
+
+    async def generate_stream(self, **_kwargs):
+        event_types = [event["type"] for event in _read_durable_events(self.path)]
+        self.saw_durable_request = event_types[:4] == [
+            "turn/start",
+            "user/message",
+            "step/start",
+            "request/header",
+        ]
+        yield StreamEvent(type="text", delta="durable answer")
+        yield StreamEvent(type="finish", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+async def test_agent_persists_request_before_provider_and_restores_messages(tmp_path):
+    session_id = "agent-session"
+    log = SessionLog.create(tmp_path / "sessions", session_id=session_id, cwd=tmp_path)
+    llm = _CheckpointInspectingLLM(log.path)
+    agent = Agent(
+        llm_client=llm,
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.add_user_message("persist me")
+
+    events = [event async for event in agent.run_events()]
+    log.close()
+
+    assert llm.saw_durable_request
+    assert any(isinstance(event, DoneEvent) for event in events)
+    restored = SessionLog.open(tmp_path / "sessions", session_id=session_id)
+    assert [(message.role, message.content) for message in restored.replay().messages] == [
+        ("user", "persist me"),
+        ("assistant", "durable answer"),
+    ]
+    assert [event["type"] for event in restored.events][-2:] == [
+        "step/end",
+        "turn/end",
+    ]
+    restored.close()
+
+
+class _ToolCallingLLM:
+    model = "test-model"
+    max_output_tokens = 1024
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate_stream(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            yield StreamEvent(
+                type="finish",
+                finish_reason="tool",
+                tool_calls=[
+                    ToolCall(
+                        id="durable-call",
+                        type="function",
+                        function=FunctionCall(
+                            name="side_effect",
+                            arguments={"value": "original"},
+                        ),
+                    )
+                ],
+            )
+            return
+        yield StreamEvent(type="text", delta="done")
+        yield StreamEvent(type="finish", finish_reason="stop")
+
+
+class _ArgumentHook(BaseHook):
+    async def on_tool_start(self, **_kwargs):
+        return {"value": "modified"}
+
+
+class _DurabilityInspectingTool(Tool):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.executed = False
+        self.saw_durable_call = False
+
+    @property
+    def name(self):
+        return "side_effect"
+
+    @property
+    def description(self):
+        return "Record one externally visible side effect."
+
+    @property
+    def parameters(self):
+        return {
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        }
+
+    async def execute(self, value: str):
+        calls = [
+            event
+            for event in _read_durable_events(self.path)
+            if event["type"] == "tool/call"
+        ]
+        self.saw_durable_call = bool(calls) and calls[-1]["data"] == {
+            "turn": 1,
+            "step": 1,
+            "callId": "durable-call",
+            "name": "side_effect",
+            "arguments": {"value": "modified"},
+        }
+        self.executed = True
+        return ToolResult(
+            success=True,
+            content=f"saved:{value}",
+            raw_output={"child_session_id": "child-session"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_side_effect_starts_only_after_exact_call_is_durable(tmp_path):
+    session_id = "tool-checkpoint"
+    root = tmp_path / "sessions"
+    log = SessionLog.create(root, session_id=session_id, cwd=tmp_path)
+    tool = _DurabilityInspectingTool(log.path)
+    agent = Agent(
+        llm_client=_ToolCallingLLM(),
+        system_prompt="system",
+        tools=[tool],
+        workspace_dir=str(tmp_path),
+        hooks=[_ArgumentHook()],
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.add_user_message("perform it")
+
+    events = [event async for event in agent.run_events()]
+    log.close()
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    assert tool.executed
+    assert tool.saw_durable_call
+    restored = SessionLog.open(root, session_id=session_id)
+    durable_result = next(
+        event
+        for event in restored.events
+        if event["type"] == "tool/result"
+    )
+    assert durable_result["data"]["result"]["rawOutput"] == {
+        "child_session_id": "child-session"
+    }
+    restored.close()
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_prevents_provider_call(tmp_path, monkeypatch):
+    log = SessionLog.create(
+        tmp_path / "sessions",
+        session_id="flush-failure",
+        cwd=tmp_path,
+    )
+    llm = _CheckpointInspectingLLM(log.path)
+    agent = Agent(
+        llm_client=llm,
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.add_user_message("must not reach provider")
+    monkeypatch.setattr(log, "flush", lambda: (_ for _ in ()).throw(OSError("disk")))
+
+    with pytest.raises(OSError, match="disk"):
+        _ = [event async for event in agent.run_events()]
+
+    assert not llm.saw_durable_request
+    log.close()
+
+
+class _SummaryCheckpointLLM:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.saw_start = False
+
+    async def generate(self, **_kwargs):
+        self.saw_start = (
+            _read_durable_events(self.path)[-1]["type"] == "compaction/start"
+        )
+        return LLMResponse(
+            content="<summary>durable compacted history</summary>",
+            finish_reason="stop",
+        )
+
+
+class _PostCompactionLLM:
+    model = "test-model"
+    max_output_tokens = 1024
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.saw_replacement = False
+
+    async def generate_stream(self, **_kwargs):
+        event_types = [event["type"] for event in _read_durable_events(self.path)]
+        self.saw_replacement = event_types[-2:] == [
+            "request/header",
+            "request/context",
+        ] and "compaction/end" in event_types
+        yield StreamEvent(type="text", delta="after compaction")
+        yield StreamEvent(type="finish", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+async def test_compaction_is_durable_before_live_context_switch(tmp_path):
+    session_id = "compaction-checkpoint"
+    root = tmp_path / "sessions"
+    log = SessionLog.create(root, session_id=session_id, cwd=tmp_path)
+    llm = _PostCompactionLLM(log.path)
+    summary_llm = _SummaryCheckpointLLM(log.path)
+    agent = Agent(
+        llm_client=llm,
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        token_limit=5_000,
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    for index in range(24):
+        role = "user" if index % 2 == 0 else "assistant"
+        agent.messages.append(Message(role=role, content=f"old-{index}:" + "x" * 2_000))
+    agent.add_user_message("latest request")
+    options = replace(agent.default_run_options(), summary_llm=summary_llm)
+
+    _ = [event async for event in agent.run_events(options=options)]
+
+    assert summary_llm.saw_start
+    assert llm.saw_replacement
+    assert any(
+        message.role == "user" and "durable compacted history" in str(message.content)
+        for message in log.replay().messages
+    )
+    assert any(
+        event["type"] == "user/message"
+        and str(event["data"].get("content", "")).startswith("old-0:")
+        for event in log.events
+    )
+    log.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_restores_goal_plan_and_todos_from_session_log(tmp_path):
+    root = tmp_path / "sessions"
+    log = SessionLog.create(root, session_id="domain-restore", cwd=tmp_path)
+    plan_store = PlanStore()
+    todo_store = TodoStore()
+    agent = Agent(
+        llm_client=_ToolCallingLLM(),
+        system_prompt="system",
+        tools=[
+            PlanWriteTool(plan_store),
+            PlanReadTool(plan_store),
+            TodoWriteTool(todo_store),
+            TodoReadTool(todo_store),
+        ],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.set_goal("persist state")
+    plan_result = await agent.tools["plan_write"].invoke(
+        {
+            "action": "set",
+            "title": "Durable plan",
+            "steps": [{"title": "Implement"}],
+        }
+    )
+    todo_result = await agent.tools["todo_write"].invoke(
+        {
+            "action": "set",
+            "todos": [
+                {
+                    "task": "Implement",
+                    "status": "in_progress",
+                    "priority": "high",
+                }
+            ],
+        }
+    )
+    assert plan_result.success and todo_result.success
+    log.close()
+
+    restored_log = SessionLog.open(root, session_id="domain-restore")
+    restored_plan_store = PlanStore()
+    restored_todo_store = TodoStore()
+    restored_agent = Agent(
+        llm_client=_ToolCallingLLM(),
+        system_prompt="system",
+        tools=[
+            PlanWriteTool(restored_plan_store),
+            PlanReadTool(restored_plan_store),
+            TodoWriteTool(restored_todo_store),
+            TodoReadTool(restored_todo_store),
+        ],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=restored_log,
+    )
+
+    assert restored_agent.goal is not None
+    assert restored_agent.goal.objective == "persist state"
+    assert restored_plan_store.get()["title"] == "Durable plan"
+    assert restored_todo_store.list()[0]["task"] == "Implement"
+    restored_log.close()
+
+
+class _PlanCallingLLM:
+    model = "test-model"
+    max_output_tokens = 1024
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate_stream(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            yield StreamEvent(
+                type="finish",
+                finish_reason="tool",
+                tool_calls=[
+                    ToolCall(
+                        id="plan-call",
+                        type="function",
+                        function=FunctionCall(
+                            name="plan_write",
+                            arguments={"action": "set", "title": "Must persist"},
+                        ),
+                    )
+                ],
+            )
+            return
+        yield StreamEvent(type="text", delta="must not run")
+        yield StreamEvent(type="finish", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+async def test_state_persistence_failure_aborts_before_next_provider_call(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "sessions"
+    log = SessionLog.create(root, session_id="state-flush-failure", cwd=tmp_path)
+    llm = _PlanCallingLLM()
+    store = PlanStore()
+    agent = Agent(
+        llm_client=llm,
+        system_prompt="system",
+        tools=[PlanWriteTool(store), PlanReadTool(store)],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.add_user_message("make a plan")
+    original_flush = log.flush
+    flush_count = 0
+
+    def fail_plan_flush():
+        nonlocal flush_count
+        flush_count += 1
+        if flush_count == 3:
+            log._failed = True
+            raise SessionLogDurabilityError("disk full")
+        original_flush()
+
+    monkeypatch.setattr(log, "flush", fail_plan_flush)
+
+    with pytest.raises(SessionLogDurabilityError, match="disk full"):
+        _ = [event async for event in agent.run_events()]
+
+    assert llm.calls == 1
+    log.close()
+
+
+def test_active_skill_metadata_restores_only_with_matching_content(tmp_path):
+    root = tmp_path / "sessions"
+    log = SessionLog.create(root, session_id="skill-restore", cwd=tmp_path)
+    agent = Agent(
+        llm_client=_ToolCallingLLM(),
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.activate_skill_instructions("review", "trusted skill prompt")
+    persisted = log.replay().skills
+    log.close()
+
+    assert persisted[0]["name"] == "review"
+    restored_log = SessionLog.open(root, session_id="skill-restore")
+    restored = Agent(
+        llm_client=_ToolCallingLLM(),
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=restored_log,
+    )
+    restored.restore_active_skill_instructions(
+        [
+            (
+                "review",
+                "trusted skill prompt",
+                persisted[0]["sha256"],
+                persisted[0]["loadOrder"],
+            )
+        ]
+    )
+
+    assert "trusted skill prompt" in restored.system_prompt
+    with pytest.raises(ValueError, match="content hash changed"):
+        restored.restore_active_skill_instructions(
+            [("review", "changed", persisted[0]["sha256"], 1)]
+        )
+    restored_log.close()

--- a/tests/test_follow_up_suggestions.py
+++ b/tests/test_follow_up_suggestions.py
@@ -197,7 +197,11 @@ async def test_acp_strips_model_metadata_across_activity_and_emits_suggestions(t
 
 
 @pytest.mark.asyncio
-async def test_acp_generates_suggestions_in_background_without_blocking_prompt(tmp_path) -> None:
+async def test_acp_generates_suggestions_in_background_without_blocking_prompt(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     conn = _RecordingConn()
     llm = _DedicatedFollowUpLLM()
     agent = BoxACPAgent(
@@ -263,7 +267,11 @@ async def test_acp_generates_suggestions_in_background_without_blocking_prompt(t
 
 
 @pytest.mark.asyncio
-async def test_acp_cancels_stale_background_suggestions_when_next_turn_starts(tmp_path) -> None:
+async def test_acp_cancels_stale_background_suggestions_when_next_turn_starts(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     conn = _RecordingConn()
     llm = _DedicatedFollowUpLLM()
     agent = BoxACPAgent(

--- a/tests/test_session_log.py
+++ b/tests/test_session_log.py
@@ -1,0 +1,456 @@
+"""Behavior tests for the durable append-only Session Log."""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from box_agent.schema import FunctionCall, Message, ToolCall
+from box_agent.session_log import (
+    SessionLog,
+    SessionLogCorrupted,
+    SessionLogInUseError,
+)
+
+
+def test_session_log_rejects_second_writer_until_owner_closes(tmp_path):
+    owner = SessionLog.create(tmp_path, session_id="single-writer", cwd=tmp_path)
+
+    with pytest.raises(SessionLogInUseError, match="already has an active writer"):
+        SessionLog.open(tmp_path, session_id="single-writer")
+
+    owner.close()
+    successor = SessionLog.open(tmp_path, session_id="single-writer")
+    successor.close()
+
+
+def test_session_log_writer_ownership_is_released_when_process_exits(tmp_path):
+    created = SessionLog.create(
+        tmp_path,
+        session_id="process-owner",
+        cwd=tmp_path,
+    )
+    created.close()
+    script = """
+import os
+import sys
+from box_agent.session_log import SessionLog
+
+log = SessionLog.open(sys.argv[1], session_id="process-owner")
+print("ready", flush=True)
+sys.stdin.readline()
+os._exit(0)
+"""
+    owner = subprocess.Popen(
+        [sys.executable, "-c", script, os.fspath(tmp_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert owner.stdout is not None
+        assert owner.stdout.readline() == "ready\n"
+        with pytest.raises(SessionLogInUseError):
+            SessionLog.open(tmp_path, session_id="process-owner")
+
+        assert owner.stdin is not None
+        owner.stdin.write("exit\n")
+        owner.stdin.flush()
+        assert owner.wait(timeout=30) == 0
+
+        successor = SessionLog.open(tmp_path, session_id="process-owner")
+        successor.close()
+    finally:
+        if owner.poll() is None:
+            owner.kill()
+            owner.wait(timeout=30)
+
+
+def test_session_log_does_not_repair_tail_without_writer_ownership(tmp_path):
+    owner = SessionLog.create(tmp_path, session_id="locked-tail", cwd=tmp_path)
+    owner.flush()
+    with owner.path.open("ab") as external_writer:
+        external_writer.write(b'{"type":"turn/start"')
+    torn_bytes = owner.path.read_bytes()
+
+    with pytest.raises(SessionLogInUseError):
+        SessionLog.open(tmp_path, session_id="locked-tail")
+
+    assert owner.path.read_bytes() == torn_bytes
+    owner.close()
+    successor = SessionLog.open(tmp_path, session_id="locked-tail")
+    successor.close()
+    assert owner.path.read_bytes().endswith(b"\n")
+
+
+def test_session_log_replays_a_durable_user_message(tmp_path):
+    log = SessionLog.create(
+        tmp_path,
+        session_id="product-session-1",
+        cwd=tmp_path,
+    )
+    log.append(
+        "user/message",
+        Message(role="user", content="keep this context").model_dump(
+            mode="json",
+            exclude_none=True,
+        ),
+        surface_op="append",
+    )
+    log.flush()
+    path = log.path
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="product-session-1")
+
+    assert path.name == "session.jsonl"
+    assert restored.header["id"] == "product-session-1"
+    assert restored.replay().messages == [
+        Message(role="user", content="keep this context")
+    ]
+    restored.close()
+
+
+def test_session_log_truncates_only_an_incomplete_final_record(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="crash-tail", cwd=tmp_path)
+    log.append(
+        "user/message",
+        Message(role="user", content="committed").model_dump(
+            mode="json",
+            exclude_none=True,
+        ),
+        surface_op="append",
+    )
+    log.flush()
+    path = log.path
+    log.close()
+    with path.open("ab") as handle:
+        handle.write(b'{"type":"assistant/message"')
+
+    restored = SessionLog.open(tmp_path, session_id="crash-tail")
+
+    assert restored.replay().messages == [Message(role="user", content="committed")]
+    restored.close()
+    assert path.read_bytes().endswith(b"\n")
+
+
+def test_session_log_rejects_corruption_before_the_final_record(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="middle-corrupt", cwd=tmp_path)
+    log.append(
+        "user/message",
+        Message(role="user", content="first").model_dump(mode="json"),
+        surface_op="append",
+    )
+    log.append(
+        "user/message",
+        Message(role="user", content="second").model_dump(mode="json"),
+        surface_op="append",
+    )
+    log.flush()
+    path = log.path
+    log.close()
+    lines = path.read_bytes().splitlines(keepends=True)
+    path.write_bytes(lines[0] + b"not-json\n" + lines[2])
+
+    for _ in range(2):
+        with pytest.raises(SessionLogCorrupted, match="record 1"):
+            SessionLog.open(tmp_path, session_id="middle-corrupt")
+
+
+def test_session_log_rejects_non_contiguous_seq_and_second_header(tmp_path):
+    seq_log = SessionLog.create(tmp_path, session_id="bad-seq", cwd=tmp_path)
+    seq_log.append("turn/start", {"turn": 1})
+    seq_log.flush()
+    seq_path = seq_log.path
+    seq_log.close()
+    records = seq_path.read_text(encoding="utf-8").splitlines()
+    event = json.loads(records[1])
+    event["seq"] = 4
+    records[1] = json.dumps(event)
+    seq_path.write_text("\n".join(records) + "\n", encoding="utf-8")
+
+    with pytest.raises(SessionLogCorrupted, match="non-contiguous seq"):
+        SessionLog.open(tmp_path, session_id="bad-seq")
+
+    header_log = SessionLog.create(tmp_path, session_id="second-header", cwd=tmp_path)
+    header_log.append("session", {"id": "second-header"})
+    header_log.flush()
+    header_log.close()
+
+    with pytest.raises(SessionLogCorrupted, match="unknown required event"):
+        SessionLog.open(tmp_path, session_id="second-header")
+
+
+def test_surface_replacement_restores_compacted_context_without_deleting_history(
+    tmp_path,
+):
+    log = SessionLog.create(tmp_path, session_id="compacted", cwd=tmp_path)
+    first = log.append(
+        "user/message",
+        Message(role="user", content="large request").model_dump(mode="json"),
+        surface_op="append",
+    )
+    second = log.append(
+        "assistant/message",
+        {
+            "turn": 1,
+            "step": 1,
+            "message": Message(role="assistant", content="large response").model_dump(
+                mode="json"
+            ),
+        },
+        surface_op="append",
+    )
+    log.append(
+        "user/message",
+        Message(role="user", content="summary checkpoint").model_dump(mode="json"),
+        surface_op={"op": "replace", "start": first["seq"], "end": second["seq"]},
+        source_event_seqs=[first["seq"], second["seq"]],
+    )
+    log.flush()
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="compacted")
+
+    assert restored.replay().messages == [
+        Message(role="user", content="summary checkpoint")
+    ]
+    assert [event["type"] for event in restored.events] == [
+        "user/message",
+        "assistant/message",
+        "user/message",
+    ]
+    restored.close()
+
+
+def test_compaction_replacement_commits_exact_new_surface_and_keeps_old_events(
+    tmp_path,
+):
+    log = SessionLog.create(tmp_path, session_id="exact-compaction", cwd=tmp_path)
+    old_messages = [
+        Message(role="user", content="large request"),
+        Message(role="assistant", content="large response"),
+    ]
+    log.append_unlogged_messages(old_messages, turn=1, step=1)
+    old_event_count = len(log.events)
+
+    new_messages = [
+        Message(role="user", content="summary"),
+        Message(role="user", content="recent request"),
+        Message(role="assistant", content="recent response"),
+    ]
+    replacement = log.replace_surface(
+        new_messages,
+        turn=1,
+        step=2,
+    )
+    log.flush()
+
+    assert log.replay().messages == new_messages
+    assert len(log.events) == old_event_count + len(new_messages)
+    assert replacement[0]["surfaceOp"] == {
+        "op": "replace",
+        "start": 0,
+        "end": 1,
+    }
+    assert replacement[0]["sourceEventSeqs"] == [0, 1]
+    log.close()
+
+
+def test_compaction_recovery_uses_replacement_as_commit_point(tmp_path):
+    before = SessionLog.create(tmp_path, session_id="before-replace", cwd=tmp_path)
+    before.append_unlogged_messages(
+        [Message(role="user", content="old surface")],
+        turn=1,
+        step=1,
+    )
+    before.append("compaction/start", {"turn": 1, "step": 2})
+    before.append(
+        "compaction/summary",
+        {"turn": 1, "step": 2, "message": {"role": "user", "content": "new"}},
+    )
+    before.flush()
+    before.close()
+
+    restored_before = SessionLog.open(tmp_path, session_id="before-replace")
+    assert restored_before.replay().messages == [
+        Message(role="user", content="old surface")
+    ]
+    restored_before.close()
+
+    after = SessionLog.create(tmp_path, session_id="after-replace", cwd=tmp_path)
+    after.append_unlogged_messages(
+        [Message(role="user", content="old surface")],
+        turn=1,
+        step=1,
+    )
+    after.append("compaction/start", {"turn": 1, "step": 2})
+    after.replace_surface(
+        [Message(role="user", content="new surface")],
+        turn=1,
+        step=2,
+    )
+    after.flush()
+    after.close()
+
+    restored_after = SessionLog.open(tmp_path, session_id="after-replace")
+    assert restored_after.replay().messages == [
+        Message(role="user", content="new surface")
+    ]
+    restored_after.close()
+
+
+def test_repair_closes_a_dispatched_tool_with_unknown_outcome(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="tool-crash", cwd=tmp_path)
+    log.append("turn/start", {"turn": 1})
+    log.append("step/start", {"turn": 1, "step": 1})
+    call = ToolCall(
+        id="call-unknown",
+        type="function",
+        function=FunctionCall(name="write_file", arguments={"path": "x"}),
+    )
+    log.append(
+        "assistant/message",
+        {
+            "turn": 1,
+            "step": 1,
+            "message": Message(
+                role="assistant",
+                content="",
+                tool_calls=[call],
+            ).model_dump(mode="json"),
+        },
+        surface_op="append",
+    )
+    call_event = log.append(
+        "tool/call",
+        {
+            "turn": 1,
+            "step": 1,
+            "callId": call.id,
+            "name": call.function.name,
+            "arguments": call.function.arguments,
+        },
+    )
+    log.flush()
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="tool-crash")
+    closers = restored.repair_interrupted_turn()
+    restored.flush()
+
+    assert [event["type"] for event in closers] == [
+        "tool/result",
+        "step/end",
+        "turn/end",
+    ]
+    assert closers[0]["data"]["error"]["code"] == "TOOL_OUTCOME_UNKNOWN"
+    assert closers[0]["sourceEventSeqs"] == [call_event["seq"]]
+    assert closers[-1]["data"]["reason"] == {"kind": "interrupted"}
+    assert restored.replay().messages[-1].tool_call_id == "call-unknown"
+    restored.close()
+
+
+def test_repair_marks_an_undispatched_assistant_call_not_started(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="tool-not-started", cwd=tmp_path)
+    log.append("turn/start", {"turn": 1})
+    log.append("step/start", {"turn": 1, "step": 1})
+    call = ToolCall(
+        id="call-not-started",
+        type="function",
+        function=FunctionCall(name="write_file", arguments={"path": "x"}),
+    )
+    log.append(
+        "assistant/message",
+        {
+            "turn": 1,
+            "step": 1,
+            "message": Message(
+                role="assistant",
+                content="",
+                tool_calls=[call],
+            ).model_dump(mode="json"),
+        },
+        surface_op="append",
+    )
+    log.flush()
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="tool-not-started")
+    closers = restored.repair_interrupted_turn()
+
+    assert closers[0]["data"]["error"]["code"] == "TOOL_NOT_STARTED"
+    assert "sourceEventSeqs" not in closers[0]
+    restored.close()
+
+
+def test_prepare_resume_closes_interrupted_prefix_before_end_seed(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="resume-boundary", cwd=tmp_path)
+    log.append("turn/start", {"turn": 1})
+    log.append("step/start", {"turn": 1, "step": 1})
+    log.flush()
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="resume-boundary")
+    appended = restored.prepare_resume()
+
+    assert [event["type"] for event in appended] == [
+        "step/end",
+        "turn/end",
+        "session/end-seed",
+    ]
+    assert appended[-2]["data"]["reason"] == {"kind": "interrupted"}
+    restored.close()
+
+
+def test_unknown_required_event_rejects_restore_but_ignorable_event_is_skipped(
+    tmp_path,
+):
+    required = SessionLog.create(tmp_path, session_id="future-required", cwd=tmp_path)
+    required.append("future/state-change", {"value": 1})
+    required.flush()
+    required.close()
+
+    with pytest.raises(SessionLogCorrupted, match="unknown required event"):
+        SessionLog.open(tmp_path, session_id="future-required")
+
+    ignorable = SessionLog.create(tmp_path, session_id="future-info", cwd=tmp_path)
+    ignorable.append("future/diagnostic", {"value": 1}, ignorable=True)
+    ignorable.flush()
+    ignorable.close()
+
+    restored = SessionLog.open(tmp_path, session_id="future-info")
+    assert restored.replay().messages == []
+    restored.close()
+
+
+def test_replay_restores_latest_box_agent_domain_state(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="domain-state", cwd=tmp_path)
+    log.append("goal/change", {"goal": {"objective": "ship", "status": "active"}})
+    log.append("plan/write", {"plan": {"title": "Implementation", "steps": []}})
+    log.append("todo/write", {"todos": [{"content": "test", "status": "pending"}]})
+    log.append(
+        "skill/change",
+        {
+            "skills": [
+                {"name": "pdfs", "sha256": "abc", "loadOrder": 1},
+            ]
+        },
+    )
+    log.append("goal/change", {"goal": None})
+    log.flush()
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="domain-state")
+    projection = restored.replay()
+
+    assert projection.goal is None
+    assert projection.plan == {"title": "Implementation", "steps": []}
+    assert projection.todos == [{"content": "test", "status": "pending"}]
+    assert projection.skills == [
+        {"name": "pdfs", "sha256": "abc", "loadOrder": 1}
+    ]
+    restored.close()

--- a/tests/test_session_trace.py
+++ b/tests/test_session_trace.py
@@ -463,7 +463,10 @@ async def test_core_records_tool_request_and_response_without_changing_events(tm
 
 
 @pytest.mark.asyncio
-async def test_acp_uses_upstream_session_id_without_changing_generated_acp_id(tmp_path, monkeypatch):
+async def test_acp_uses_upstream_session_id_without_changing_generated_acp_id(
+    tmp_path,
+    monkeypatch,
+):
     class DummyConn:
         async def sessionUpdate(self, payload):
             return None
@@ -477,6 +480,7 @@ async def test_acp_uses_upstream_session_id_without_changing_generated_acp_id(tm
                 usage=TokenUsage(prompt_tokens=4, completion_tokens=1, total_tokens=5),
             )
 
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setenv("BOX_AGENT_SESSION_TRACE_ENABLED", "1")
     monkeypatch.setenv("BOX_AGENT_SESSION_TRACE_DIR", str(tmp_path / "traces"))
     config = Config(

--- a/tests/test_sub_agent_tool.py
+++ b/tests/test_sub_agent_tool.py
@@ -15,6 +15,7 @@ from box_agent.events import DoneEvent, StopReason, SubAgentEvent, WebSearchEven
 from box_agent.context_resources import ResourceDescriptor
 from box_agent.schema import LLMResponse, Message, StreamEvent, TokenUsage
 from box_agent.agent import Agent
+from box_agent.session_log import SessionLog
 from box_agent.tools.base import Tool, ToolResult
 from box_agent.tools.file_tools import ReadTool, WriteTool
 from box_agent.tools.mcp_loader import MCPTool
@@ -330,6 +331,41 @@ async def test_basic_execution():
     result = await tool.execute(task="Analyze revenue data")
     assert result.success is True
     assert "revenue up 20%" in result.content
+
+
+async def test_one_shot_child_has_independent_replayable_session_log(tmp_path):
+    root = tmp_path / "sessions"
+    parent_log = SessionLog.create(
+        root,
+        session_id="parent-session",
+        cwd=tmp_path,
+    )
+    llm = _make_llm(text="child durable result")
+    tool = SubAgentTool(llm=llm, parent_tools={}, workspace_dir=str(tmp_path))
+    Agent(
+        llm_client=llm,
+        system_prompt="parent system",
+        tools=[tool],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=parent_log,
+    )
+
+    result = await tool.execute(task="Inspect isolated evidence", title="Evidence")
+
+    child_id = result.raw_output["child_session_id"]
+    child = SessionLog.open(root, session_id=child_id)
+    assert child.header["parentSession"] == "parent-session"
+    assert child.header["origin"] == "subagent"
+    assert child.header["delegationDepth"] == 1
+    assert any(event["type"] == "subagent/descriptor" for event in child.events)
+    assert [message.role for message in child.replay().messages] == [
+        "user",
+        "assistant",
+    ]
+    assert child.events[-1]["type"] == "turn/end"
+    child.close()
+    parent_log.close()
 
 
 async def test_forwarded_events_carry_short_title():


### PR DESCRIPTION
## Task

- Add an append-only JSONL Session Log for durable Agent context and audit replay.
- Restore messages, Goal, Plan, Todo and active Skills after process restart.
- Persist model/tool checkpoints, compaction replacement and one-shot subagent logs.
- Repair interrupted turns without automatically retrying unknown tool outcomes.
- Enforce single-writer ownership for each Session.

Out of scope: SQLite, snapshots, hash chains, multi-writer merging, background subagents and new ACP private protocols.

## Proof

- Persistence-focused suite: 471 passed.
- Full suite: 3179 passed, 61 skipped, 6 pre-existing unrelated failures.
- `py_compile`, `git diff --check` and whitespace checks passed.

## Risk

- Source-only validation; runtime was not built, installed or tested through a live Host.
- Windows locking path was not executed on a Windows runner.
- Writer locking is advisory and assumes writers use `SessionLog`.
- Rollback: revert commit `1cd14a1`.