### PR TITLE
fix(llm): 尽量都使用流式传输，减少timeout风险

### DIFF
--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -44,6 +44,7 @@ from box_agent.agent import (
     should_continue_goal_autopilot,
 )
 from box_agent.config import AgentConfig, Config
+from box_agent.llm.buffered_stream import generate_buffered_stream
 from box_agent.completion import build_auto_completion_gate
 from box_agent.events import StopReason
 from box_agent.schema import LLMProvider, Message
@@ -1454,7 +1455,8 @@ def _doctor_config_status() -> tuple[dict[str, Any], Config | None]:
 
 async def _probe_llm_api(client: LLMClient):
     """Run one tool-free connectivity probe classified as an internal helper call."""
-    return await client.generate(
+    return await generate_buffered_stream(
+        client,
         messages=[Message(role="user", content="hi")],
         call_kind="utility",
     )

--- a/box_agent/core.py
+++ b/box_agent/core.py
@@ -74,6 +74,7 @@ from .events import (
 )
 from .hooks import HookManager
 from .logger import AgentLogger
+from .llm.buffered_stream import generate_buffered_stream
 from .llm.capabilities import image_input_support
 from .llm.debug_logging import reset_llm_debug_sink, set_llm_debug_sink
 from .model_history import is_model_history_placeholder
@@ -1499,7 +1500,8 @@ async def _create_summary(
 
     if not messages:
         return ""
-    response: LLMResponse = await llm.generate(
+    response: LLMResponse = await generate_buffered_stream(
+        llm,
         messages=[*messages, Message(role="user", content=_SUMMARY_REQUEST)],
         tools=None,
         thinking_enabled=False,

--- a/box_agent/llm/buffered_stream.py
+++ b/box_agent/llm/buffered_stream.py
@@ -1,0 +1,82 @@
+"""Collect provider streaming events into the legacy ``LLMResponse`` shape."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import AsyncIterator
+from typing import Any
+
+from ..schema import LLMResponse, StreamEvent
+
+
+async def _next_event(
+    iterator: AsyncIterator[StreamEvent],
+    idle_timeout: float | None,
+) -> StreamEvent:
+    if idle_timeout is None:
+        return await anext(iterator)
+    return await asyncio.wait_for(anext(iterator), timeout=idle_timeout)
+
+
+async def generate_buffered_stream(
+    llm: Any,
+    *,
+    messages: list[Any],
+    tools: list[Any] | None = None,
+    idle_timeout: float | None = None,
+    **kwargs: Any,
+) -> LLMResponse:
+    """Use streaming transport while returning one fully buffered response.
+
+    ``idle_timeout`` applies independently to each wait for provider activity,
+    so a healthy long-running response is not cancelled by a fixed total
+    runtime limit. Minimal test doubles and third-party clients that do not yet
+    expose ``generate_stream`` retain compatibility through ``generate``.
+    """
+    generate_stream = getattr(llm, "generate_stream", None)
+    if not inspect.isasyncgenfunction(generate_stream):
+        call = llm.generate(messages=messages, tools=tools, **kwargs)
+        if idle_timeout is None:
+            return await call
+        return await asyncio.wait_for(call, timeout=idle_timeout)
+
+    stream = generate_stream(messages=messages, tools=tools, **kwargs)
+    iterator = stream.__aiter__()
+    text_parts: list[str] = []
+    thinking_parts: list[str] = []
+    finish: StreamEvent | None = None
+
+    try:
+        while True:
+            try:
+                event = await _next_event(iterator, idle_timeout)
+            except StopAsyncIteration:
+                break
+            if event.type == "text" and event.delta:
+                text_parts.append(event.delta)
+            elif event.type == "thinking" and event.delta:
+                thinking_parts.append(event.delta)
+            elif event.type == "finish":
+                finish = event
+    finally:
+        close = getattr(iterator, "aclose", None)
+        if callable(close):
+            await close()
+
+    if finish is None:
+        raise RuntimeError("LLM stream ended without a finish event")
+
+    thinking = "".join(thinking_parts)
+    return LLMResponse(
+        content="".join(text_parts),
+        thinking=thinking or None,
+        tool_calls=finish.tool_calls,
+        finish_reason=finish.finish_reason or "stop",
+        usage=finish.usage,
+        provider_response_id=finish.provider_response_id,
+        truncated_tool_calls=finish.truncated_tool_calls,
+        raw_finish_reason=finish.raw_finish_reason,
+        stream_dropped_mid_tool=finish.stream_dropped_mid_tool,
+        oversized_tool_calls=finish.oversized_tool_calls,
+    )

--- a/box_agent/llm/lightweight.py
+++ b/box_agent/llm/lightweight.py
@@ -2,8 +2,8 @@
 
 Single-shot prompts (titles, summaries, rewrites) that must
 NOT spin up an Agent session, load tools/skills/MCP, touch memory, or write
-to conversation history. Wraps :func:`LLMClient.generate` with a hard
-timeout, no tools, no extended thinking, and a structured result.
+to conversation history. Buffers :func:`LLMClient.generate_stream` with an
+idle timeout, no tools, no extended thinking, and a structured result.
 
 The ACP ``llm/prompt`` extension method is a thin shell around this
 service — see :meth:`box_agent.acp.BoxACPAgent.extMethod`.
@@ -17,6 +17,7 @@ from time import perf_counter
 from typing import TYPE_CHECKING
 
 from ..schema import Message
+from .buffered_stream import generate_buffered_stream
 
 if TYPE_CHECKING:  # pragma: no cover - type-only import
     from .llm_wrapper import LLMClient
@@ -91,7 +92,7 @@ async def run_lightweight_prompt(
         session_id: Optional caller-owned session id for upstream trace grouping.
         turn_id: Optional caller-owned turn id for upstream trace grouping.
         title: Optional upstream trace title.
-        timeout: Hard wall-clock cap in seconds. Raised as
+        timeout: Maximum seconds without a stream event. Raised as
             :class:`LightweightTimeout` on expiry.
 
     Returns:
@@ -100,7 +101,7 @@ async def run_lightweight_prompt(
 
     Raises:
         LightweightInvalidArgs: ``prompt`` is empty or ``timeout`` is non-positive.
-        LightweightTimeout: The LLM call exceeded ``timeout`` seconds.
+        LightweightTimeout: The LLM stream was idle for ``timeout`` seconds.
         LightweightContentFiltered: The provider refused on moderation grounds.
         LightweightPromptError: Any other LLM-side failure.
     """
@@ -117,21 +118,20 @@ async def run_lightweight_prompt(
 
     started = perf_counter()
     try:
-        response = await asyncio.wait_for(
-            llm.generate(
-                messages=messages,
-                tools=None,
-                thinking_enabled=False,
-                session_id=session_id,
-                turn_id=turn_id,
-                title=title,
-                call_kind=call_kind,
-            ),
-            timeout=timeout,
+        response = await generate_buffered_stream(
+            llm,
+            messages=messages,
+            tools=None,
+            thinking_enabled=False,
+            session_id=session_id,
+            turn_id=turn_id,
+            title=title,
+            call_kind=call_kind,
+            idle_timeout=timeout,
         )
     except asyncio.TimeoutError as exc:
         raise LightweightTimeout(
-            f"lightweight prompt timed out after {timeout:.1f}s"
+            f"lightweight prompt was idle for {timeout:.1f}s"
         ) from exc
     except asyncio.CancelledError:
         raise

--- a/box_agent/mcp_servers/web_extract.py
+++ b/box_agent/mcp_servers/web_extract.py
@@ -15,6 +15,7 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
+from box_agent.llm.buffered_stream import generate_buffered_stream
 from box_agent.schema import Message
 from box_agent.tools.base import Tool, ToolResult
 
@@ -268,17 +269,16 @@ class WebExtractTool(Tool):
         ]
 
         try:
-            response = await asyncio.wait_for(
-                summary_llm.generate(
-                    messages=messages,
-                    tools=None,
-                    thinking_enabled=False,
-                    call_kind="utility",
-                ),
-                timeout=_SUMMARY_TIMEOUT_SECONDS,
+            response = await generate_buffered_stream(
+                summary_llm,
+                messages=messages,
+                tools=None,
+                thinking_enabled=False,
+                call_kind="utility",
+                idle_timeout=_SUMMARY_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
-            return None, f"Summarization timed out after {_SUMMARY_TIMEOUT_SECONDS:.0f}s"
+            return None, f"Summarization stream was idle for {_SUMMARY_TIMEOUT_SECONDS:.0f}s"
         except Exception as exc:  # pragma: no cover - provider errors vary
             return None, f"Summarization failed: {exc}"
 

--- a/box_agent/memory.py
+++ b/box_agent/memory.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Iterator
 
+from .llm.buffered_stream import generate_buffered_stream
 from .llm.model_routing import resolve_model_client
 
 if TYPE_CHECKING:
@@ -1223,7 +1224,8 @@ class MemoryManager:
                 task_tags=("summary", "analysis"),
                 required_ability_level=1,
             )
-            response = await memory_llm.generate(
+            response = await generate_buffered_stream(
+                memory_llm,
                 messages=[
                     Msg(role="system", content="You extract structured user information from raw notes."),
                     Msg(role="user", content=prompt),
@@ -1307,7 +1309,8 @@ class MemoryManager:
                 task_tags=("summary", "analysis"),
                 required_ability_level=1,
             )
-            response = await memory_llm.generate(
+            response = await generate_buffered_stream(
+                memory_llm,
                 messages=[
                     Msg(role="system", content=_CONTEXT_UPDATE_SYSTEM_PROMPT),
                     Msg(role="user", content=prompt),
@@ -1613,7 +1616,8 @@ class MemoryManager:
                 task_tags=("summary", "analysis"),
                 required_ability_level=1,
             )
-            response = await memory_llm.generate(
+            response = await generate_buffered_stream(
+                memory_llm,
                 messages=[
                     {"role": "system", "content": _PROMOTION_PLAN_SYSTEM_PROMPT},
                     {"role": "user", "content": user_prompt},
@@ -2405,7 +2409,8 @@ class MemoryExtractor:
             task_tags=("summary", "analysis"),
             required_ability_level=1,
         )
-        response = await memory_llm.generate(
+        response = await generate_buffered_stream(
+            memory_llm,
             messages=[
                 Msg(role="system", content=_EXTRACTION_SYSTEM_PROMPT),
                 Msg(role="user", content=prompt),

--- a/box_agent/memory_maintainer.py
+++ b/box_agent/memory_maintainer.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from time import monotonic
 from typing import TYPE_CHECKING
 
+from .llm.buffered_stream import generate_buffered_stream
 from .llm.model_routing import resolve_model_client
 
 from .memory import (
@@ -412,7 +413,8 @@ class MemoryMaintainer_Compact:  # placeholder so the file parses; will be inlin
                 task_tags=("summary",),
                 required_ability_level=1,
             )
-            response = await maintenance_llm.generate(
+            response = await generate_buffered_stream(
+                maintenance_llm,
                 messages=[
                     Msg(role="system", content=_COMPACT_SYSTEM_PROMPT),
                     Msg(role="user", content=user_prompt),
@@ -667,7 +669,8 @@ class MemoryMaintainer_Conflict:  # placeholder — bound onto MemoryMaintainer 
                     task_tags=("analysis", "reasoning"),
                     required_ability_level=2,
                 )
-                response = await maintenance_llm.generate(
+                response = await generate_buffered_stream(
+                    maintenance_llm,
                     messages=[
                         Msg(role="system", content=_CONFLICT_SYSTEM_PROMPT),
                         Msg(role="user", content=user_prompt),

--- a/box_agent/tools/image_inspection_tool.py
+++ b/box_agent/tools/image_inspection_tool.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from box_agent.llm.buffered_stream import generate_buffered_stream
 from box_agent.llm.capabilities import image_input_support
 from box_agent.schema import Message
 from box_agent.tools.base import Tool, ToolResult
@@ -204,14 +205,17 @@ class ImageInspectionTool(Tool):
             ),
         ]
         try:
-            response = await asyncio.wait_for(
-                self.llm.generate(messages=messages, tools=None, call_kind="utility"),
-                timeout=_IMAGE_INSPECTION_TIMEOUT,
+            response = await generate_buffered_stream(
+                self.llm,
+                messages=messages,
+                tools=None,
+                call_kind="utility",
+                idle_timeout=_IMAGE_INSPECTION_TIMEOUT,
             )
         except asyncio.TimeoutError:
             return self._error(
                 "IMAGE_REQUEST_FAILED",
-                f"image inspection timed out after {_IMAGE_INSPECTION_TIMEOUT:.0f}s",
+                f"image inspection stream was idle for {_IMAGE_INSPECTION_TIMEOUT:.0f}s",
             )
         except Exception as exc:  # pragma: no cover - provider exceptions vary
             if self._is_unsupported_image_input_error(str(exc)):

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -32,6 +32,7 @@ from ..events import (
     ThinkingEvent,
     WebSearchEvent,
 )
+from ..llm.buffered_stream import generate_buffered_stream
 from ..llm.model_routing import resolve_model_client
 from ..schema import Message
 from ..session_log import SessionLog
@@ -1157,27 +1158,27 @@ class SubAgentTool(EventEmittingTool):
             event=StepStart(step=1, max_steps=1),
         )
         try:
-            synthesis = llm.generate(
+            synthesis = generate_buffered_stream(
+                llm,
                 messages=messages,
                 tools=None,
                 thinking_enabled=False,
                 call_kind="subagent_step",
+                idle_timeout=(
+                    self._batch_synthesis_timeout_seconds
+                    if self._batch_synthesis_timeout_seconds > 0
+                    else None
+                ),
             )
-            if self._batch_synthesis_timeout_seconds > 0:
-                response = await asyncio.wait_for(
-                    synthesis,
-                    timeout=self._batch_synthesis_timeout_seconds,
-                )
-            else:
-                response = await synthesis
+            response = await synthesis
         except asyncio.TimeoutError:
             payload = {
                 **diagnostic,
                 "type": "sub_agent_delegation_error",
                 "code": "BATCH_SYNTHESIS_TIMEOUT",
                 "message": (
-                    "The batch synthesis model call exceeded the configured "
-                    f"{self._batch_synthesis_timeout_seconds:g} second runtime limit."
+                    "The batch synthesis model stream had no activity for the configured "
+                    f"{self._batch_synthesis_timeout_seconds:g} second idle limit."
                 ),
                 "retryable": True,
                 "timeout_seconds": self._batch_synthesis_timeout_seconds,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -25,7 +25,7 @@ async def test_agent_simple_task():
 
     # Load config
     config_path = Path("box_agent/config/config.yaml")
-    config = Config.from_yaml(config_path)
+    config = Config.from_yaml(config_path.resolve())
 
     # Create temp workspace
     with tempfile.TemporaryDirectory() as workspace_dir:
@@ -41,8 +41,11 @@ async def test_agent_simple_task():
         # Initialize LLM client
         llm_client = LLMClient(
             api_key=config.llm.api_key,
+            provider=config.llm.provider,
             api_base=config.llm.api_base,
             model=config.llm.model,
+            auth_file=config.llm.auth_file,
+            timeout=config.llm.timeout,
         )
 
         # Initialize tools
@@ -50,7 +53,7 @@ async def test_agent_simple_task():
             ReadTool(workspace_dir=workspace_dir),
             WriteTool(workspace_dir=workspace_dir),
             EditTool(workspace_dir=workspace_dir),
-            BashTool(),
+            BashTool(workspace_dir=workspace_dir),
         ]
 
         # Create agent
@@ -68,36 +71,15 @@ async def test_agent_simple_task():
 
         agent.add_user_message(task)
 
-        try:
-            result = await agent.run()
+        result = await agent.run()
 
-            print(f"\n{'=' * 80}")
-            print(f"Agent Result: {result}")
-            print("=" * 80)
+        print(f"\n{'=' * 80}")
+        print(f"Agent Result: {result}")
+        print("=" * 80)
 
-            # Check if file was created
-            test_file = Path(workspace_dir) / "test.txt"
-            if test_file.exists():
-                content = test_file.read_text()
-                print("\n✅ File created successfully!")
-                print(f"Content: {content}")
-
-                if "Hello from Agent!" in content:
-                    print("✅ Content is correct!")
-                    return True
-                else:
-                    print(f"⚠️  Content mismatch: {content}")
-                    return True  # Still count as success, agent did create the file
-            else:
-                print("⚠️  File was not created, but agent completed")
-                return True  # Agent might have completed differently
-
-        except Exception as e:
-            print(f"❌ Agent test failed: {e}")
-            import traceback
-
-            traceback.print_exc()
-            return False
+        test_file = Path(workspace_dir) / "test.txt"
+        assert test_file.exists(), "Agent should create test.txt"
+        assert "Hello from Agent!" in test_file.read_text()
 
 
 @pytest.mark.asyncio
@@ -107,7 +89,7 @@ async def test_agent_bash_task():
 
     # Load config
     config_path = Path("box_agent/config/config.yaml")
-    config = Config.from_yaml(config_path)
+    config = Config.from_yaml(config_path.resolve())
 
     # Create temp workspace
     with tempfile.TemporaryDirectory() as workspace_dir:
@@ -123,15 +105,18 @@ async def test_agent_bash_task():
         # Initialize LLM client
         llm_client = LLMClient(
             api_key=config.llm.api_key,
+            provider=config.llm.provider,
             api_base=config.llm.api_base,
             model=config.llm.model,
+            auth_file=config.llm.auth_file,
+            timeout=config.llm.timeout,
         )
 
         # Initialize tools
         tools = [
             ReadTool(workspace_dir=workspace_dir),
             WriteTool(workspace_dir=workspace_dir),
-            BashTool(),
+            BashTool(workspace_dir=workspace_dir),
         ]
 
         # Create agent
@@ -149,22 +134,13 @@ async def test_agent_bash_task():
 
         agent.add_user_message(task)
 
-        try:
-            result = await agent.run()
+        result = await agent.run()
 
-            print(f"\n{'=' * 80}")
-            print(f"Agent Result: {result}")
-            print("=" * 80)
+        print(f"\n{'=' * 80}")
+        print(f"Agent Result: {result}")
+        print("=" * 80)
 
-            print("\n✅ Bash task completed!")
-            return True
-
-        except Exception as e:
-            print(f"❌ Bash task failed: {e}")
-            import traceback
-
-            traceback.print_exc()
-            return False
+        assert result
 
 
 async def main():

--- a/tests/test_buffered_stream.py
+++ b/tests/test_buffered_stream.py
@@ -1,0 +1,107 @@
+"""Regression tests for buffered use of the streaming LLM transport."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from box_agent.llm.buffered_stream import generate_buffered_stream
+from box_agent.schema import LLMResponse, StreamEvent, TokenUsage
+
+
+class _StreamingLLM:
+    def __init__(self, events, *, delay: float = 0.0):
+        self.events = events
+        self.delay = delay
+        self.stream_calls = 0
+        self.generate_calls = 0
+
+    async def generate_stream(self, messages, tools=None, **kwargs):
+        self.stream_calls += 1
+        for event in self.events:
+            if self.delay:
+                await asyncio.sleep(self.delay)
+            yield event
+
+    async def generate(self, messages, tools=None, **kwargs):
+        self.generate_calls += 1
+        return LLMResponse(content="non-stream", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+async def test_buffered_stream_prefers_streaming_and_preserves_response_metadata():
+    usage = TokenUsage(prompt_tokens=4, completion_tokens=2, total_tokens=6)
+    llm = _StreamingLLM(
+        [
+            StreamEvent(type="thinking", delta="plan"),
+            StreamEvent(type="text", delta="hel"),
+            StreamEvent(type="activity"),
+            StreamEvent(type="text", delta="lo"),
+            StreamEvent(
+                type="finish",
+                finish_reason="stop",
+                usage=usage,
+                provider_response_id="response-1",
+            ),
+        ]
+    )
+
+    response = await generate_buffered_stream(llm, messages=[])
+
+    assert response.content == "hello"
+    assert response.thinking == "plan"
+    assert response.usage == usage
+    assert response.provider_response_id == "response-1"
+    assert llm.stream_calls == 1
+    assert llm.generate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_buffered_stream_idle_timeout_resets_after_each_event():
+    llm = _StreamingLLM(
+        [
+            StreamEvent(type="text", delta="a"),
+            StreamEvent(type="text", delta="b"),
+            StreamEvent(type="finish", finish_reason="stop"),
+        ],
+        delay=0.02,
+    )
+
+    response = await generate_buffered_stream(
+        llm,
+        messages=[],
+        idle_timeout=0.03,
+    )
+
+    assert response.content == "ab"
+
+
+@pytest.mark.asyncio
+async def test_buffered_stream_times_out_when_provider_goes_idle():
+    llm = _StreamingLLM(
+        [StreamEvent(type="finish", finish_reason="stop")],
+        delay=0.05,
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await generate_buffered_stream(llm, messages=[], idle_timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_buffered_stream_requires_finish_event():
+    llm = _StreamingLLM([StreamEvent(type="text", delta="partial")])
+
+    with pytest.raises(RuntimeError, match="without a finish event"):
+        await generate_buffered_stream(llm, messages=[])
+
+
+@pytest.mark.asyncio
+async def test_buffered_stream_falls_back_for_legacy_test_double():
+    class _LegacyLLM:
+        async def generate(self, messages, tools=None, **kwargs):
+            return LLMResponse(content="legacy", finish_reason="stop")
+
+    response = await generate_buffered_stream(_LegacyLLM(), messages=[])
+
+    assert response.content == "legacy"

--- a/tests/test_context_compaction_e2e.py
+++ b/tests/test_context_compaction_e2e.py
@@ -10,7 +10,7 @@ from box_agent.schema import LLMResponse, Message, StreamEvent
 
 
 class CompactionE2ELLM:
-    """Exercise one non-streaming summary call followed by a normal stream."""
+    """Exercise one buffered summary stream followed by a normal stream."""
 
     def __init__(self) -> None:
         self.summary_messages: list[Message] = []
@@ -33,6 +33,23 @@ class CompactionE2ELLM:
         )
 
     async def generate_stream(self, messages, tools=None, **_kwargs):
+        if _kwargs.get("call_kind") == "context_summary":
+            assert tools is None
+            self.summary_messages = list(messages)
+            yield StreamEvent(
+                type="text",
+                delta=(
+                    "<summary>"
+                    "1. Primary Request and Intent:\nContinue the compaction E2E.\n\n"
+                    "6. All User Messages:\n"
+                    "- old user request\n"
+                    "- latest user request\n\n"
+                    "8. Current Work:\nContext compaction is being verified."
+                    "</summary>"
+                ),
+            )
+            yield StreamEvent(type="finish", finish_reason="stop")
+            return
         self.normal_messages = list(messages)
         yield StreamEvent(type="text", delta="E2E resumed answer")
         yield StreamEvent(type="finish", finish_reason="stop")

--- a/tests/test_follow_up_suggestions.py
+++ b/tests/test_follow_up_suggestions.py
@@ -60,6 +60,15 @@ class _DedicatedFollowUpLLM:
         )
 
     async def generate_stream(self, messages, tools=None, **_):
+        if _.get("call_kind") == "utility":
+            self.generate_calls.append(_)
+            await self.release_suggestions.wait()
+            yield StreamEvent(
+                type="text",
+                delta='{"suggestions":["核对项目当前的 React 版本", "查看 React 19.2 的新增内容"]}',
+            )
+            yield StreamEvent(type="finish", finish_reason="stop")
+            return
         yield StreamEvent(type="text", delta="React 当前 npm 稳定最新版是 19.2.7。")
         yield StreamEvent(type="finish", finish_reason="stop")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,6 @@ from box_agent import LLMClient
 from box_agent.agent import Agent
 from box_agent.config import Config
 from box_agent.tools import BashTool, EditTool, ReadTool, WriteTool
-from box_agent.tools.mcp_loader import load_mcp_tools_async
 
 
 @pytest.mark.asyncio
@@ -29,7 +28,7 @@ async def test_basic_agent_usage():
     if not config_path.exists():
         pytest.skip("config.yaml not found")
 
-    config = Config.from_yaml(config_path)
+    config = Config.from_yaml(config_path.resolve())
 
     # Check API key
     if not config.llm.api_key or config.llm.api_key == "YOUR_API_KEY_HERE":
@@ -47,8 +46,11 @@ async def test_basic_agent_usage():
         # Initialize LLM client
         llm_client = LLMClient(
             api_key=config.llm.api_key,
+            provider=config.llm.provider,
             api_base=config.llm.api_base,
             model=config.llm.model,
+            auth_file=config.llm.auth_file,
+            timeout=config.llm.timeout,
         )
 
         # Initialize basic tools
@@ -56,23 +58,8 @@ async def test_basic_agent_usage():
             ReadTool(workspace_dir=workspace_dir),
             WriteTool(workspace_dir=workspace_dir),
             EditTool(workspace_dir=workspace_dir),
-            BashTool(),
+            BashTool(workspace_dir=workspace_dir),
         ]
-
-        # Load MCP tools (optional) - with timeout protection
-        try:
-            # MCP tools are disabled by default to prevent test hangs
-            # Enable specific MCP servers in mcp.json if needed
-            mcp_tools = await load_mcp_tools_async(
-                config_path="box_agent/config/mcp.json"
-            )
-            if mcp_tools:
-                print(f"✓ Loaded {len(mcp_tools)} MCP tools")
-                tools.extend(mcp_tools)
-            else:
-                print("⚠️  No MCP tools configured (mcp.json is empty)")
-        except Exception as e:
-            print(f"⚠️  MCP tools not loaded: {e}")
 
         # Create agent
         agent = Agent(

--- a/tests/test_lightweight_prompt.py
+++ b/tests/test_lightweight_prompt.py
@@ -14,7 +14,7 @@ from box_agent.llm.lightweight import (
     LightweightTimeout,
     run_lightweight_prompt,
 )
-from box_agent.schema import LLMResponse
+from box_agent.schema import LLMResponse, StreamEvent
 from box_agent.schema.schema import TokenUsage
 
 
@@ -69,6 +69,36 @@ class _FakeLLM:
             finish_reason="stop",
             usage=self._usage,
         )
+
+    async def generate_stream(
+        self,
+        messages,
+        tools=None,
+        *,
+        thinking_enabled: bool = False,
+        session_id: str = "",
+        turn_id: str = "",
+        title: str = "",
+        call_kind: str = "",
+    ):
+        self.calls.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "thinking_enabled": thinking_enabled,
+                "session_id": session_id,
+                "turn_id": turn_id,
+                "title": title,
+                "call_kind": call_kind,
+            }
+        )
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._raises is not None:
+            raise self._raises
+        if self._content:
+            yield StreamEvent(type="text", delta=self._content)
+        yield StreamEvent(type="finish", finish_reason="stop", usage=self._usage)
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from box_agent.config import Config
 from box_agent.llm import LLMClient
 from box_agent.schema import LLMProvider, Message
 
@@ -69,15 +70,16 @@ async def test_wrapper_openai_provider():
     print("\n=== Testing LLM Wrapper (OpenAI Provider) ===")
 
     # Load config
-    config_path = Path("box_agent/config/config.yaml")
-    with open(config_path, encoding="utf-8") as f:
-        config = yaml.safe_load(f)
+    config = Config.from_yaml(_CONFIG_PATH.resolve())
 
     # Create client with OpenAI provider
     client = LLMClient(
-        api_key=config["api_key"],
+        api_key=config.llm.api_key,
         provider=LLMProvider.OPENAI,
-        model=config.get("model"),
+        api_base=config.llm.api_base,
+        model=config.llm.model,
+        auth_file=config.llm.auth_file,
+        timeout=config.llm.timeout,
     )
 
     assert client.provider == LLMProvider.OPENAI
@@ -88,25 +90,15 @@ async def test_wrapper_openai_provider():
         Message(role="user", content="Say 'Hello, Box Agent!' and nothing else."),
     ]
 
-    try:
-        response = await client.generate(messages=messages)
+    response = await client.generate(messages=messages)
 
-        print(f"Response: {response.content}")
-        print(f"Finish reason: {response.finish_reason}")
+    print(f"Response: {response.content}")
+    print(f"Finish reason: {response.finish_reason}")
 
-        assert response.content, "Response content is empty"
-        assert "Hello" in response.content or "hello" in response.content, (
-            f"Response doesn't contain 'Hello': {response.content}"
-        )
-
-        print("✅ OpenAI provider test passed")
-        return True
-    except Exception as e:
-        print(f"❌ OpenAI provider test failed: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    assert response.content, "Response content is empty"
+    assert "Hello" in response.content or "hello" in response.content, (
+        f"Response doesn't contain 'Hello': {response.content}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -79,7 +79,7 @@ async def test_openai_simple_completion():
     # Create OpenAI client
     client = OpenAIClient(
         api_key=config["api_key"],
-        api_base="https://api.anthropic.com",
+        api_base=config.get("api_base"),
         model=config.get("model", "claude-sonnet-4-20250514"),
         retry_config=RetryConfig(enabled=True, max_retries=2),
     )
@@ -90,24 +90,14 @@ async def test_openai_simple_completion():
         Message(role="user", content="Say 'Hello from OpenAI!' and nothing else."),
     ]
 
-    try:
-        response = await client.generate(messages=messages)
+    response = await client.generate(messages=messages)
 
-        print(f"Response: {response.content}")
-        print(f"Thinking: {response.thinking}")
-        print(f"Finish reason: {response.finish_reason}")
+    print(f"Response: {response.content}")
+    print(f"Thinking: {response.thinking}")
+    print(f"Finish reason: {response.finish_reason}")
 
-        assert response.content, "Response content is empty"
-        assert "Hello" in response.content or "hello" in response.content
-
-        print("✅ OpenAI simple completion test passed")
-        return True
-    except Exception as e:
-        print(f"❌ OpenAI test failed: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    assert response.content, "Response content is empty"
+    assert "Hello" in response.content or "hello" in response.content
 
 
 @pytest.mark.asyncio
@@ -180,7 +170,7 @@ async def test_openai_tool_calling():
     # Create OpenAI client
     client = OpenAIClient(
         api_key=config["api_key"],
-        api_base="https://api.anthropic.com",
+        api_base=config.get("api_base"),
         model=config.get("model", "claude-sonnet-4-20250514"),
     )
 
@@ -207,27 +197,14 @@ async def test_openai_tool_calling():
         Message(role="user", content="What's the weather in New York?"),
     ]
 
-    try:
-        response = await client.generate(messages=messages, tools=tools)
+    response = await client.generate(messages=messages, tools=tools)
 
-        print(f"Response: {response.content}")
-        print(f"Thinking: {response.thinking}")
-        print(f"Tool calls: {response.tool_calls}")
+    print(f"Response: {response.content}")
+    print(f"Thinking: {response.thinking}")
+    print(f"Tool calls: {response.tool_calls}")
 
-        if response.tool_calls:
-            assert len(response.tool_calls) > 0
-            assert response.tool_calls[0].function.name == "get_weather"
-            print("✅ OpenAI tool calling test passed")
-        else:
-            print("⚠️  Warning: LLM didn't use tools, but request succeeded")
-
-        return True
-    except Exception as e:
-        print(f"❌ OpenAI tool calling test failed: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    assert response.tool_calls
+    assert response.tool_calls[0].function.name == "get_weather"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
+from box_agent.config import Config
 from box_agent.tools import mcp_loader
 from box_agent.tools.browser_runtime_scope import (
     BrowserRuntimeCoordinator,
@@ -41,6 +42,21 @@ from box_agent.tools.model_tool_context import (
 )
 from box_agent.tools.setup import merge_mcp_tools, register_mcp_tools
 from box_agent.tools.base import Tool, ToolResult
+
+
+_CONFIG_PATH = Path("box_agent/config/config.yaml")
+_MCP_CONFIG_PATH = Path("box_agent/config/mcp.json")
+
+
+async def _load_configured_mcp_tools():
+    """Load integration MCP tools with the configured rotating auth file."""
+    if not _CONFIG_PATH.exists():
+        pytest.skip("box_agent/config/config.yaml missing — integration test skipped")
+    config = Config.from_yaml(_CONFIG_PATH.resolve())
+    return await load_mcp_tools_async(
+        str(_MCP_CONFIG_PATH),
+        auth_file=config.llm.auth_file,
+    )
 
 
 def test_streamable_http_client_is_available():
@@ -1202,7 +1218,7 @@ async def test_mcp_tools_loading():
 
     try:
         # Load MCP tools
-        tools = await load_mcp_tools_async("box_agent/config/mcp.json")
+        tools = await _load_configured_mcp_tools()
 
         print(f"Loaded {len(tools)} MCP tools")
 
@@ -1230,7 +1246,7 @@ async def test_git_mcp_loading(mcp_config):
 
     try:
         # Load MCP tools
-        tools = await load_mcp_tools_async("box_agent/config/mcp.json")
+        tools = await _load_configured_mcp_tools()
 
         print("\n✅ Loaded successfully!")
         print("\n📊 Statistics:")
@@ -1262,7 +1278,7 @@ async def test_git_mcp_tool_availability():
     print("\n=== Testing Git MCP Tool Availability ===")
 
     try:
-        tools = await load_mcp_tools_async("box_agent/config/mcp.json")
+        tools = await _load_configured_mcp_tools()
 
         if not tools:
             pytest.skip("No MCP tools loaded")
@@ -1288,7 +1304,7 @@ async def test_mcp_tool_execution():
     print("\n=== Testing MCP Tool Execution ===")
 
     try:
-        tools = await load_mcp_tools_async("box_agent/config/mcp.json")
+        tools = await _load_configured_mcp_tools()
 
         if not tools:
             print("⚠️  No MCP tools loaded, skipping execution test")

--- a/tests/test_presentation_preflight.py
+++ b/tests/test_presentation_preflight.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from box_agent.acp import BoxACPAgent
-from box_agent.schema import LLMResponse
+from box_agent.schema import LLMResponse, StreamEvent
 from box_agent.workflows.presentation_preflight import (
     classify_presentation_request,
     build_presentation_preflight_result,
@@ -49,8 +49,39 @@ class _FakeLLM:
         )
         return LLMResponse(content=self.content, finish_reason="stop")
 
+    async def generate_stream(
+        self,
+        messages,
+        tools=None,
+        *,
+        thinking_enabled: bool = False,
+        session_id: str = "",
+        turn_id: str = "",
+        title: str = "",
+        call_kind: str = "",
+    ):
+        self.calls.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "session_id": session_id,
+                "turn_id": turn_id,
+                "title": title,
+                "call_kind": call_kind,
+            }
+        )
+        yield StreamEvent(type="text", delta=self.content)
+        yield StreamEvent(type="finish", finish_reason="stop")
+
 
 class _FailingLLM(_FakeLLM):
+    async def generate_stream(self, messages, tools=None, **kwargs):
+        self.calls.append(
+            {"messages": messages, "tools": tools, "call_kind": kwargs.get("call_kind", "")}
+        )
+        raise RuntimeError("provider unavailable")
+        yield
+
     async def generate(
         self,
         messages,
@@ -67,6 +98,14 @@ class _FailingLLM(_FakeLLM):
 
 
 class _SlowLLM(_FakeLLM):
+    async def generate_stream(self, messages, tools=None, **kwargs):
+        self.calls.append(
+            {"messages": messages, "tools": tools, "call_kind": kwargs.get("call_kind", "")}
+        )
+        await asyncio.sleep(0.05)
+        yield StreamEvent(type="text", delta=self.content)
+        yield StreamEvent(type="finish", finish_reason="stop")
+
     async def generate(
         self,
         messages,

--- a/tests/test_sub_agent_tool.py
+++ b/tests/test_sub_agent_tool.py
@@ -1337,8 +1337,23 @@ async def test_batch_files_reads_twenty_files_once_and_calls_generate_once(tmp_p
 
         async def generate_stream(self, messages, tools=None, **kwargs):
             self.stream_calls += 1
-            raise AssertionError("batch_files must not enter run_agent_loop")
-            yield
+            self.messages = messages
+            self.tools = tools
+            self.generate_kwargs = kwargs
+            encoding = tiktoken.get_encoding("cl100k_base")
+            prompt_tokens = sum(
+                len(encoding.encode(str(message.content))) for message in messages
+            )
+            yield StreamEvent(type="text", delta="ranked all 20 projects")
+            yield StreamEvent(
+                type="finish",
+                finish_reason="stop",
+                usage=TokenUsage(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=100,
+                    total_tokens=prompt_tokens + 100,
+                ),
+            )
 
     llm = BatchLLM()
     read_tool = CountingReadTool()
@@ -1359,8 +1374,8 @@ async def test_batch_files_reads_twenty_files_once_and_calls_generate_once(tmp_p
     assert result.content == "ranked all 20 projects"
     assert sorted(read_tool.calls) == sorted(paths)
     assert len(read_tool.calls) == 20
-    assert llm.generate_calls == 1
-    assert llm.stream_calls == 0
+    assert llm.generate_calls == 0
+    assert llm.stream_calls == 1
     assert llm.tools is None
     assert "session_id" not in llm.generate_kwargs
     assert llm.generate_kwargs["call_kind"] == "subagent_step"
@@ -1410,8 +1425,9 @@ async def test_batch_files_uses_parent_permission_negotiator_and_retries(tmp_pat
             return LLMResponse(content="inventory complete", finish_reason="stop")
 
         async def generate_stream(self, messages, tools=None, **kwargs):
-            raise AssertionError("batch_files must not enter run_agent_loop")
-            yield
+            assert "pdf" in messages[-1].content
+            yield StreamEvent(type="text", delta="inventory complete")
+            yield StreamEvent(type="finish", finish_reason="stop")
 
     read_tool = CountingReadTool()
     negotiator = FilesystemNegotiator(store)
@@ -1559,7 +1575,7 @@ async def test_batch_files_uses_configurable_synthesis_timeout():
     assert result.success is False
     assert result.raw_output["code"] == "BATCH_SYNTHESIS_TIMEOUT"
     assert result.raw_output["timeout_seconds"] == 0.01
-    assert "configured 0.01 second runtime limit" in result.raw_output["message"]
+    assert "configured 0.01 second idle limit" in result.raw_output["message"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## TPR

### Task（任务）

- **改动内容**：新增共享的流式缓冲适配器，并将需要一次性返回结果的内部 LLM 调用迁移到流式传输，包括上下文摘要、轻量提示、记忆提取与维护、网页提取摘要、图片检查、子 Agent 批量综合以及 CLI doctor 探针；对外仍返回原有的 `LLMResponse`。
- **改动原因**：固定的总时长超时会误杀仍在持续输出的健康请求。改为逐事件空闲超时后，只有流长时间无活动时才会超时。
- **影响入口**：共享 LLM helper、核心上下文压缩、记忆工作流、相关工具、子 Agent 综合、CLI doctor 及其回归测试。
- **不在范围内**：不修改 Provider wire 实现和公开的 `generate()` API；未验证真实 Anthropic API。

### Proof（验证）

- **执行的测试与检查**：
  - 聚焦真实集成测试：`9 passed, 1 skipped in 55.20s`，覆盖 OpenAI、Agent 和带认证的 MCP。
  - 排除 Anthropic API 的完整测试：`3218 passed, 3 skipped, 6 deselected in 346.46s`。
  - 额外补跑被同名过滤表达式误排除的 session 测试：`1 passed`。
  - `bash general_review/ci/preflight.sh`：源码编译通过；测试结果为 `3208 passed, 18 skipped, 1 deselected in 264.21s`；sdist 和 wheel 构建成功。
  - `git diff --check` 通过。
- **探针与构建产物**：
  - 使用配置中的动态 `auth_file` 成功加载并实际执行 search MCP 的 `web_search`。
  - 本地成功构建 `dist/box_agent-0.9.6.tar.gz` 和 `dist/box_agent-0.9.6-py3-none-any.whl`，产物未提交。
- **未执行项及原因**：
  - 按要求排除 5 个真实 Anthropic API 测试。
  - 未安装运行时、重启宿主或执行打包后 live task；本次验证止于源码测试与构建。

### Risk（风险）

- **兼容性**：没有异步生成器形式 `generate_stream()` 的旧客户端或测试替身会回退到 `generate()`；流结束元数据会复制到缓冲后的响应中。
- **打包与运行时影响**：已验证源码与 package build，未安装或重启运行时。
- **配置、密钥与迁移**：未提交配置、凭据、日志或 workspace 数据。集成测试现在使用配置中的 provider、API base、timeout 和 MCP auth file，不再默认假设 Anthropic。
- **回滚方式**：回退本 PR 的两个提交，即可恢复直接非流式调用和原有集成测试行为。
- **跨仓库后续**：暂未发现。

### 设计与架构影响

- **影响层与负责人**：LLM 能力层、核心上下文摘要调用点、记忆与工具能力层、集成测试；CLI 仍保持适配器职责。
- **契约、Schema 或协议影响**：没有公开 Schema 或宿主协议变更，现有调用方仍获得单个 `LLMResponse`。
- **文档更新**：无需更新设计索引；本次改动保留现有架构边界，仅调整内部传输方式。

### 目标分支一致性

- **基础分支与已检查 SHA**：`origin/main`，SHA 为 `e4167a98734ec2abf466510ad94f414dc2b17113`。
- **目标分支相关改动检查**：已检查 merge-base diff 和剩余的 `.generate()` 调用点；剩余调用均属于 Provider 实现、兼容包装器或明确的 legacy fallback。
- **Rebase 与历史修复风险**：分支从最新 `origin/main` 创建并再次执行 rebase；未引入 merge commit。

## Checklist（检查清单）

- [x] PR 只有一个清晰的行为或子系统范围。
- [x] 已从源码验证调用路径和归属，并在可用时使用 `.understand-anything` 作为导航索引。
- [x] 共享行为实现在共享逻辑中，没有在 CLI 与 ACP 重复实现。
- [x] 聚焦测试覆盖了改动行为。
- [x] 已针对核心、工具、MCP、记忆和 CLI 运行更广泛的测试。
- [x] 已评估文档影响；无需修改用户或贡献者文档。
- [x] 未修改内置 Skill。
- [x] 已说明 packaged runtime 的影响和验证边界。
- [x] 未包含本地配置、日志、workspace 文件或生成的图谱/cache。
- [x] 分支已 rebase 到最新基础分支 `main`，没有合并 `main`。
- [x] 已提供设计与目标分支一致性证据。
- [x] 当前 Head SHA 的 `teamwork/local-ci` 已通过。