### PR TITLE
fix(pptx): preserve source media and interaction contracts

### DIFF
--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -27,7 +27,6 @@ kernel persists across prompts within the same session.
 from __future__ import annotations
 
 import asyncio
-import base64
 import json as _json
 import logging
 import platform
@@ -923,30 +922,13 @@ class SessionState:
     mcp_fallback_tools: dict[str, Any] = field(default_factory=dict)
 
 
-_MAX_SOURCE_TEXT_ENV_CHARS = 120_000
 _CONTEXT_SUMMARY_MAX_OUTPUT_TOKENS = 4_096
 _TITLE_MAX_OUTPUT_TOKENS = 8_000
 
 
 def _bind_user_source_text(state: SessionState, user_request: str) -> None:
-    """Expose accumulated real user text to local provenance-aware tools.
-
-    The value is base64 encoded only to preserve arbitrary punctuation and
-    newlines across subprocess boundaries; it is not a secrecy mechanism.
-    """
-    request = user_request.strip()
-    if request:
-        state.source_text = (
-            f"{state.source_text.rstrip()}\n\n{request}"
-            if state.source_text.strip()
-            else request
-        )
-        if len(state.source_text) > _MAX_SOURCE_TEXT_ENV_CHARS:
-            state.source_text = state.source_text[-_MAX_SOURCE_TEXT_ENV_CHARS:]
-    encoded = base64.b64encode(state.source_text.encode("utf-8")).decode("ascii")
-    bash_tool = state.agent.tools.get("bash")
-    if bash_tool is not None and hasattr(bash_tool, "update_runtime_env"):
-        bash_tool.update_runtime_env({"BOX_AGENT_SOURCE_TEXT_B64": encoded})
+    """Bind one real ACP user turn through the shared Agent contract."""
+    state.source_text = state.agent.bind_user_source_text(user_request)
 
 
 class BoxACPAgent:

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -8,6 +8,7 @@ giving adapters one stable entry point for configuring and running a turn.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
@@ -64,6 +65,7 @@ from .session_continuation import ContinuationMessage
 
 _log = logging.getLogger(__name__)
 _ACTIVE_SKILL_TOKEN_BUDGET = 32_000
+_MAX_SOURCE_TEXT_ENV_CHARS = 120_000
 _DEFAULT_AGENT_CONFIG = AgentConfig()
 
 
@@ -586,6 +588,7 @@ class Agent:
         self._active_skill_hashes: dict[str, str] = {}
         self._active_skill_load_order: dict[str, int] = {}
         self._active_skill_sequence = 0
+        self._bound_user_source_text = ""
         for tool in self.tools.values():
             if hasattr(tool, "set_parent_system_prompt"):
                 tool.set_parent_system_prompt(system_prompt)
@@ -807,6 +810,33 @@ class Agent:
         if self.goal is not None and self.goal.status == "active":
             content = self._apply_goal_context(content)
         self.messages.append(Message(role="user", content=content))
+
+    def bind_user_source_text(self, user_request: str) -> str:
+        """Expose accumulated real user text to provenance-aware local tools.
+
+        CLI and ACP call this only at real user-turn boundaries. Internal
+        continuation prompts must not become source facts. Base64 preserves
+        punctuation and newlines across subprocess environments; it is not a
+        secrecy mechanism.
+        """
+        request = user_request.strip()
+        if request:
+            self._bound_user_source_text = (
+                f"{self._bound_user_source_text.rstrip()}\n\n{request}"
+                if self._bound_user_source_text.strip()
+                else request
+            )
+            if len(self._bound_user_source_text) > _MAX_SOURCE_TEXT_ENV_CHARS:
+                self._bound_user_source_text = self._bound_user_source_text[
+                    -_MAX_SOURCE_TEXT_ENV_CHARS:
+                ]
+        encoded = base64.b64encode(
+            self._bound_user_source_text.encode("utf-8")
+        ).decode("ascii")
+        bash_tool = self.tools.get("bash")
+        if bash_tool is not None and hasattr(bash_tool, "update_runtime_env"):
+            bash_tool.update_runtime_env({"BOX_AGENT_SOURCE_TEXT_B64": encoded})
+        return self._bound_user_source_text
 
     def seed_continuation_messages(
         self, messages: tuple[ContinuationMessage, ...]

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -2361,6 +2361,7 @@ async def run_agent(
         _apply_skill_filter(task)
         completion_gate = _build_cli_completion_gate(task)
         _apply_cli_auto_loaded_skills(completion_gate, task)
+        agent.bind_user_source_text(task)
         agent.add_user_message(task)
         if completion_gate is not None:
             patterns = ", ".join(completion_gate.required_changed_artifact_globs)
@@ -2713,6 +2714,7 @@ async def run_agent(
             _apply_skill_filter(user_input)
             preload_gate = _build_cli_completion_gate(user_input)
             _apply_cli_auto_loaded_skills(preload_gate, user_input)
+            agent.bind_user_source_text(user_input)
             agent.add_user_message(user_input)
 
             # Create cancellation event

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.9.7",
-  "generated_at": "2026-08-26T17:54:33Z",
+  "generated_at": "2026-08-26T17:54:37Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.9.7",
-  "generated_at": "2026-08-26T17:54:37Z",
+  "generated_at": "2026-08-26T17:36:00Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.9.7",
-  "generated_at": "2026-08-26T17:54:23Z",
+  "generated_at": "2026-08-26T17:54:29Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.9.7",
-  "generated_at": "2026-08-26T17:36:00Z",
+  "generated_at": "2026-08-26T17:54:23Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/_manifest.json
+++ b/box_agent/skills/_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "box_agent_version": "0.9.7",
-  "generated_at": "2026-08-26T17:54:29Z",
+  "generated_at": "2026-08-26T17:54:33Z",
   "skills": [
     {
       "name": "artifacts-builder",

--- a/box_agent/skills/document-skills/pptx/references/controlled-layouts.md
+++ b/box_agent/skills/document-skills/pptx/references/controlled-layouts.md
@@ -434,6 +434,23 @@ and tables should normally skip backgrounds or use only a faint low-detail
 texture. Prefer one dominant media treatment: a hero or a background, not both,
 unless the background is intentionally subordinate.
 
+## Interaction contract
+
+The controlled scaffold may add one deck-level `interaction_contract` when the
+bound request explicitly requires either `solar_orbit` or `spin_360`. The
+contract records a registered mode, one `target_slide_id`, and `required: true`;
+the runtime probe then verifies that the requested interaction initialized. A
+solar-orbit target renders exactly eight orbiting planets. A spin target renders
+one rotatable visual and uses the target slide's bound media when available.
+
+These interactions are an HTML-runtime capability. Playback supports pause/
+resume, and the spin visual also supports pointer dragging. During screenshot or
+PPTX export, editor chrome and interaction controls are hidden and animation is
+stopped, so the exported slide preserves a representative static state rather
+than executable motion or drag behavior. Never claim that the editable `.pptx`
+retains the HTML interaction; deliver the controlled HTML when the requested
+motion itself is required.
+
 ## Editor boundary
 
 The embedded editor supports plain-text edits, image replacement, adding a page

--- a/box_agent/skills/document-skills/pptx/references/image-assets.md
+++ b/box_agent/skills/document-skills/pptx/references/image-assets.md
@@ -46,6 +46,18 @@ Rules:
    `assets/source/`, hashes them, and records `decision: "use_existing"`.
    Reference that portable copied path from `deck.json`; never leave the final
    deck pointing at the user's original machine path.
+9. An explicit `--image-asset` binding always wins. When the bound user request
+   mentions local image files without explicit bindings, automatic binding is
+   conservative: first use an exact page hint next to the filename, then an
+   exact filename reference in the corresponding outline page. A filename tied
+   to an explicit 360-degree request binds to the registered spin-interaction
+   target. Otherwise, use stable source-file order only across outline pages
+   that explicitly request supplied/source media. Outline pages created by
+   deterministic splitting keep their original `source_outline_page`; a
+   filename in a narrowed bullet slice binds to that generated page. Never fill
+   an unrelated optional cover slot merely because it appears first. Ambiguous
+   files stay under `source_assets.unbound` in the image manifest and require an
+   explicit `--image-asset` binding.
 
 ## 2. Trigger rules
 

--- a/box_agent/skills/document-skills/pptx/runtime/interaction-runtime.css
+++ b/box_agent/skills/document-skills/pptx/runtime/interaction-runtime.css
@@ -1,0 +1,155 @@
+.deck-interaction {
+  position: absolute;
+  z-index: 8;
+  right: 76px;
+  top: 172px;
+  width: 760px;
+  height: 760px;
+  color: var(--deck-text);
+  pointer-events: auto;
+}
+
+.deck-interaction-toggle {
+  position: absolute;
+  z-index: 12;
+  right: 8px;
+  top: 8px;
+  border: 1px solid color-mix(in srgb, var(--deck-border) 72%, transparent);
+  border-radius: 999px;
+  padding: 9px 16px;
+  background: color-mix(in srgb, var(--deck-surface) 90%, transparent);
+  color: var(--deck-text);
+  font: 600 15px/1 var(--deck-label);
+  cursor: pointer;
+}
+
+.deck-solar-system {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 0;
+  height: 0;
+  transform: translate(-50%, -50%);
+}
+
+.deck-solar-sun {
+  position: absolute;
+  left: -58px;
+  top: -58px;
+  display: grid;
+  width: 116px;
+  height: 116px;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 28%, #fff8b0 0 8%, #ffc928 34%, #f36a16 72%, #a72b0e 100%);
+  box-shadow: 0 0 48px rgba(255, 175, 30, 0.72);
+  color: #5a1c08;
+  font: 800 18px/1 var(--deck-label);
+}
+
+.deck-planet-orbit {
+  --orbit-size: 180px;
+  --orbit-duration: 8s;
+  position: absolute;
+  left: calc(var(--orbit-size) / -2);
+  top: calc(var(--orbit-size) / -2);
+  width: var(--orbit-size);
+  height: var(--orbit-size);
+  border: 1px solid color-mix(in srgb, var(--deck-muted) 42%, transparent);
+  border-radius: 50%;
+  animation: deck-planet-orbit var(--orbit-duration) linear infinite;
+}
+
+.deck-planet {
+  --planet-size: 20px;
+  position: absolute;
+  left: 50%;
+  top: calc(var(--planet-size) / -2);
+  display: grid;
+  width: var(--planet-size);
+  height: var(--planet-size);
+  place-items: center;
+  border: 2px solid rgba(255, 255, 255, 0.66);
+  border-radius: 50%;
+  background: var(--planet-color, var(--deck-primary));
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.28);
+  color: var(--deck-inverse);
+  font: 700 11px/1 var(--deck-label);
+  transform: translateX(-50%);
+}
+
+.deck-interaction.is-paused .deck-planet-orbit {
+  animation-play-state: paused;
+}
+
+.deck-spin-stage {
+  position: absolute;
+  inset: 58px 20px 20px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--deck-border) 66%, transparent);
+  border-radius: var(--deck-radius-large);
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--deck-primary-soft) 52%, transparent), transparent 68%);
+  perspective: 1200px;
+  cursor: grab;
+  user-select: none;
+}
+
+.deck-spin-stage:active {
+  cursor: grabbing;
+}
+
+.deck-spin-stage img {
+  display: block;
+  width: min(92%, 660px);
+  height: min(88%, 620px);
+  object-fit: contain;
+  filter: drop-shadow(0 30px 38px rgba(0, 0, 0, 0.32));
+  transform-style: preserve-3d;
+  animation: deck-spin-360 11s linear infinite;
+}
+
+.deck-spin-placeholder {
+  display: grid;
+  width: 430px;
+  height: 430px;
+  place-items: center;
+  border: 2px solid color-mix(in srgb, var(--deck-primary) 72%, transparent);
+  color: var(--deck-primary);
+  font: 800 96px/1 var(--deck-display);
+  transform-style: preserve-3d;
+  animation: deck-spin-360 11s linear infinite;
+}
+
+.deck-spin-stage.is-user-controlled img,
+.deck-spin-stage.is-user-controlled .deck-spin-placeholder {
+  animation: none;
+  transform: rotateY(var(--deck-spin-angle, 0deg));
+}
+
+@keyframes deck-planet-orbit {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes deck-spin-360 {
+  from { transform: rotateY(0deg); }
+  to { transform: rotateY(360deg); }
+}
+
+.deck-export-mode .deck-interaction-toggle {
+  display: none;
+}
+
+.deck-export-mode .deck-planet-orbit,
+.deck-export-mode .deck-spin-stage img,
+.deck-export-mode .deck-spin-placeholder {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deck-planet-orbit,
+  .deck-spin-stage img,
+  .deck-spin-placeholder {
+    animation-play-state: paused;
+  }
+}

--- a/box_agent/skills/document-skills/pptx/runtime/interaction-runtime.js
+++ b/box_agent/skills/document-skills/pptx/runtime/interaction-runtime.js
@@ -1,0 +1,44 @@
+(function interactionRuntime(root) {
+  "use strict";
+
+  const interactions = Array.from(root.document.querySelectorAll("[data-deck-interaction-target]"));
+  interactions.forEach(container => {
+    const toggle = container.querySelector("[data-deck-interaction-toggle]");
+    if (toggle) {
+      toggle.addEventListener("click", () => {
+        const paused = container.classList.toggle("is-paused");
+        toggle.textContent = paused ? "继续运动" : "暂停运动";
+        toggle.setAttribute("aria-pressed", paused ? "true" : "false");
+      });
+    }
+
+    const spinStage = container.querySelector("[data-deck-spin-stage]");
+    if (spinStage) {
+      let dragging = false;
+      let previousX = 0;
+      let angle = 0;
+      spinStage.addEventListener("pointerdown", event => {
+        dragging = true;
+        previousX = event.clientX;
+        spinStage.classList.add("is-user-controlled");
+        spinStage.setPointerCapture(event.pointerId);
+      });
+      spinStage.addEventListener("pointermove", event => {
+        if (!dragging) return;
+        angle += (event.clientX - previousX) * 0.7;
+        previousX = event.clientX;
+        spinStage.style.setProperty("--deck-spin-angle", `${angle}deg`);
+      });
+      const stopDragging = event => {
+        dragging = false;
+        if (spinStage.hasPointerCapture(event.pointerId)) {
+          spinStage.releasePointerCapture(event.pointerId);
+        }
+      };
+      spinStage.addEventListener("pointerup", stopDragging);
+      spinStage.addEventListener("pointercancel", stopDragging);
+    }
+    container.dataset.interactionReady = "true";
+  });
+  root.__deckInteractionReady = Promise.resolve({ count: interactions.length });
+})(window);

--- a/box_agent/skills/document-skills/pptx/scripts/apply_deck_patch.js
+++ b/box_agent/skills/document-skills/pptx/scripts/apply_deck_patch.js
@@ -341,6 +341,19 @@ function normalizeValueToContract(value, contract, layoutId, fieldName, changes,
     );
     return compacted;
   }
+  if (
+    contract.type === "text"
+    && typeof value === "string"
+    && Number.isInteger(contract.maxChars)
+    && characterLength(value) > contract.maxChars
+  ) {
+    const compacted = fitCaption(value, contract.maxChars);
+    recordChange(
+      changes,
+      `${fieldPath}: compacted overlong text to ${contract.maxChars} characters`
+    );
+    return compacted;
+  }
   if (contract.type === "media") {
     const alt = layoutId === "project-case-study-v1"
       ? "AI 概念视觉，实际项目图待补充"

--- a/box_agent/skills/document-skills/pptx/scripts/deck_spec_core.js
+++ b/box_agent/skills/document-skills/pptx/scripts/deck_spec_core.js
@@ -744,6 +744,37 @@ function normalizeAndValidateSwimlaneProps(props, fieldPath, issues) {
   });
 }
 
+function validateAndNormalizeInteractionContract(value, slideIds, issues) {
+  if (value === undefined || value === null) return null;
+  if (!isPlainObject(value)) {
+    issues.push("interaction_contract: expected object");
+    return null;
+  }
+  const allowed = ["mode", "target_slide_id", "required"];
+  const unknown = Object.keys(value).filter(key => !allowed.includes(key));
+  if (unknown.length) {
+    issues.push(`interaction_contract: unknown field(s): ${unknown.join(", ")}`);
+  }
+  const mode = String(value.mode || "").trim();
+  const targetSlideId = String(value.target_slide_id || "").trim();
+  if (!["spin_360", "solar_orbit"].includes(mode)) {
+    issues.push("interaction_contract.mode: expected spin_360 or solar_orbit");
+  }
+  if (!slideIds.has(targetSlideId)) {
+    issues.push(
+      `interaction_contract.target_slide_id: unknown slide id ${JSON.stringify(targetSlideId)}`
+    );
+  }
+  if (value.required !== true) {
+    issues.push("interaction_contract.required: expected true");
+  }
+  return {
+    mode,
+    target_slide_id: targetSlideId,
+    required: value.required === true,
+  };
+}
+
 function validateAndNormalizeDeck(spec) {
   const issues = [];
   const warnings = [];
@@ -757,6 +788,7 @@ function validateAndNormalizeDeck(spec) {
     "theme_id",
     "design",
     "design_contract",
+    "interaction_contract",
     "truth_contract",
     "slides",
   ];
@@ -967,12 +999,21 @@ function validateAndNormalizeDeck(spec) {
     });
   }
 
+  const normalizedInteractionContract = validateAndNormalizeInteractionContract(
+    spec.interaction_contract,
+    new Set(normalizedSlides.map(slide => slide.id)),
+    issues
+  );
+
   const normalized = {
     schema_version: 1,
     title: typeof spec.title === "string" ? spec.title.trim() : "",
     theme_id: typeof spec.theme_id === "string" ? spec.theme_id : "",
     ...(normalizedDesign ? { design: normalizedDesign } : {}),
     ...(normalizedDesignContract ? { design_contract: normalizedDesignContract } : {}),
+    ...(normalizedInteractionContract
+      ? { interaction_contract: normalizedInteractionContract }
+      : {}),
     ...(normalizedTruthContract ? { truth_contract: normalizedTruthContract } : {}),
     slides: normalizedSlides,
   };

--- a/box_agent/skills/document-skills/pptx/scripts/deck_spec_core.js
+++ b/box_agent/skills/document-skills/pptx/scripts/deck_spec_core.js
@@ -4,6 +4,12 @@ const fs = require("fs");
 const path = require("path");
 
 const TRUTH_TEXT_MAX_CHARACTERS = 280;
+const OUTLINE_INTENT_TEXT_LIMITS = Object.freeze({
+  title: 120,
+  message: 500,
+  layout: 120,
+  visual: 300,
+});
 
 const {
   getLayout,
@@ -590,12 +596,12 @@ function validateAndNormalizeOutlineIntent(value, fieldPath, issues) {
     issues.push(`${fieldPath}: expected object`);
     return null;
   }
-  const contracts = {
-    title: { type: "text", maxChars: 120, required: true },
-    message: { type: "text", maxChars: 500, required: true },
-    layout: { type: "text", maxChars: 120, required: true },
-    visual: { type: "text", maxChars: 300, required: true },
-  };
+  const contracts = Object.fromEntries(
+    Object.entries(OUTLINE_INTENT_TEXT_LIMITS).map(([key, maxChars]) => [
+      key,
+      { type: "text", maxChars, required: true },
+    ])
+  );
   const unknown = Object.keys(value).filter(
     key => !Object.prototype.hasOwnProperty.call(contracts, key)
       && key !== "visual_item_contract"
@@ -1034,6 +1040,7 @@ function buildManifest() {
 module.exports = {
   DEFAULT_THEME_ID,
   MANIFEST_PATH,
+  OUTLINE_INTENT_TEXT_LIMITS,
   SKILL_ROOT,
   TRUTH_TEXT_MAX_CHARACTERS,
   buildManifest,

--- a/box_agent/skills/document-skills/pptx/scripts/design_contract_core.js
+++ b/box_agent/skills/document-skills/pptx/scripts/design_contract_core.js
@@ -260,7 +260,7 @@ function explicitCountContract(slide) {
       }
     }
   }
-  const match = visual.match(/(?:^|[^0-9一二三四五六七八九十])([0-9]{1,2}|[一二三四五六七八九十])\s*(?:条|个|项|类|张|段(?:式)?|象限|节点|阶段|主线|里程碑|卡片|标签|层|系统|行|列|章节|工位|分区|区域|序列|系列|指标|KPI|连接|连线)/u);
+  const match = visual.match(/(?:^|[^第0-9一二三四五六七八九十])([0-9]{1,2}|[一二三四五六七八九十])\s*(?:条|个|项|类|张|段(?:式)?|象限|节点|阶段|主线|里程碑|卡片|标签|层|系统|行|列|章节|工位|分区|区域|序列|系列|指标|KPI|连接|连线)/u);
   if (match) {
     const parsed = parseCount(match[1]);
     if (Number.isInteger(parsed) && parsed >= 2 && parsed <= 24) {
@@ -277,7 +277,10 @@ function explicitCountContract(slide) {
   const bullets = Array.isArray(slide && slide.bullets)
     ? slide.bullets.filter(item => String(item || "").trim())
     : [];
-  return ["pyramid", "numbered-actions"].includes(kind) && bullets.length >= 2
+  const declaredLayoutKind = visualKind({ layout: slide && slide.layout });
+  return ["pyramid", "numbered-actions"].includes(kind)
+    && declaredLayoutKind === kind
+    && bullets.length >= 2
     ? { count: bullets.length, dimension: kind === "pyramid" ? "items" : "actions" }
     : null;
 }

--- a/box_agent/skills/document-skills/pptx/scripts/design_contract_core.js
+++ b/box_agent/skills/document-skills/pptx/scripts/design_contract_core.js
@@ -231,6 +231,24 @@ function countDimension(value) {
   return matched ? matched[1] : "items";
 }
 
+function countUnitDimension(unit, localText) {
+  if (/(?:标签)/i.test(unit)) return "tags";
+  if (/(?:序列|系列)/i.test(unit)) return "series";
+  if (/(?:指标|KPI)/i.test(unit)) return "metrics";
+  if (/(?:节点)/i.test(unit)) return "nodes";
+  if (/(?:阶段|里程碑)/i.test(unit)) return "steps";
+  if (/(?:章节)/i.test(unit)) return "sections";
+  if (/(?:工位)/i.test(unit)) return "stations";
+  if (/(?:分区|区域)/i.test(unit)) return "zones";
+  if (/(?:连接|连线)/i.test(unit)) return "edges";
+  if (/(?:行)/i.test(unit)) return "rows";
+  if (/(?:列)/i.test(unit)) return "columns";
+  if (/(?:卡片)/i.test(unit)) return "cards";
+  if (/(?:类)/i.test(unit)) return "categories";
+  if (/(?:张)/i.test(unit) && /(?:卡片|cards?)/i.test(localText)) return "cards";
+  return null;
+}
+
 function explicitCountContract(slide) {
   const persisted = slide && slide.visual_item_contract;
   if (
@@ -260,12 +278,13 @@ function explicitCountContract(slide) {
       }
     }
   }
-  const match = visual.match(/(?:^|[^第0-9一二三四五六七八九十])([0-9]{1,2}|[一二三四五六七八九十])\s*(?:条|个|项|类|张|段(?:式)?|象限|节点|阶段|主线|里程碑|卡片|标签|层|系统|行|列|章节|工位|分区|区域|序列|系列|指标|KPI|连接|连线)/u);
+  const match = visual.match(/(?:^|[^第0-9一二三四五六七八九十])([0-9]{1,2}|[一二三四五六七八九十])\s*(条|个(?!月|季度|年度|年|百分点|工作日|自然日|小时|分钟|秒)|项|类|张|段(?:式)?|象限|节点|阶段|主线|里程碑|卡片|标签|层|系统|行|列|章节|工位|分区|区域|序列|系列|指标|KPI|连接|连线)/u);
   if (match) {
     const parsed = parseCount(match[1]);
     if (Number.isInteger(parsed) && parsed >= 2 && parsed <= 24) {
       const localText = visual.slice(match.index, match.index + match[0].length + 18);
-      const localDimension = countDimension(localText);
+      const localDimension = countUnitDimension(match[2], localText)
+        || countDimension(localText);
       return {
         count: parsed,
         dimension: localDimension === "items"

--- a/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
+++ b/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
@@ -912,20 +912,23 @@ function expandOutlineDrivenPlan(layoutIds, outlineBinding, interactionContract 
       capacity.maxItems,
       capacity.minItems
     );
-    if (!sizes || bullets.length !== requested.count) {
+    if (!sizes) {
       throw new Error(
         `Slide ${index + 1} requires controlled outline expansion for ${requested.count} ` +
-        `${requested.dimension} item(s), but deterministic splitting requires exactly ` +
-        `${requested.count} outline bullets and chunks within ${layoutId} capacity ` +
+        `${requested.dimension} item(s), but deterministic splitting requires chunks ` +
+        `within ${layoutId} capacity ` +
         `${capacity.minItems}-${capacity.maxItems}`
       );
     }
+    const bulletsMapItems = bullets.length === requested.count;
     let offset = 0;
     sizes.forEach((size, partIndex) => {
       const start = offset + 1;
       const end = offset + size;
       const authoringSlide = JSON.parse(JSON.stringify(outlineSlide));
-      authoringSlide.bullets = bullets.slice(offset, end);
+      authoringSlide.bullets = bulletsMapItems
+        ? bullets.slice(offset, end)
+        : bullets;
       authoringSlide.visual_item_contract = {
         dimension: requested.dimension,
         count: size,
@@ -1337,12 +1340,26 @@ function inferInteractionContract(sourceText, outlineSlides) {
   const targetPattern = mode === "solar_orbit"
     ? /(?:太阳系|八大行星|行星)/i
     : /(?:城堡|主视觉|立体|360)/i;
-  const targetIndex = Math.max(0, outlineSlides.findIndex(slide => targetPattern.test([
-    slide && slide.title,
-    slide && slide.message,
-    slide && slide.layout,
-    slide && slide.visual,
-  ].filter(Boolean).join("\n"))));
+  const rankedTargets = outlineSlides.map((slide, index) => {
+    const content = [
+      slide && slide.title,
+      slide && slide.message,
+      slide && slide.layout,
+      slide && slide.visual,
+    ].filter(Boolean).join("\n");
+    let score = targetPattern.test(content) ? 1 : -100;
+    if (mode === "solar_orbit") {
+      const requested = expectedVisualItemContract(slide);
+      if (requested && requested.count === 8) score += 8;
+      if (/(?:八张|8\s*张).{0,12}(?:行星|卡片)/i.test(content)) score += 3;
+      if (/(?:封面|cover)/i.test(String(slide && slide.layout || ""))) score -= 6;
+    }
+    return { index, score };
+  });
+  const targetIndex = rankedTargets.reduce(
+    (best, candidate) => candidate.score > best.score ? candidate : best,
+    { index: 0, score: -101 },
+  ).index;
   return {
     mode,
     target_slide_id: `slide-${String(targetIndex + 1).padStart(2, "0")}`,

--- a/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
+++ b/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
@@ -50,6 +50,8 @@ const AUTO_COVER_TECH_VISUAL_RE = /(?:代码窗口|代码片段|协作节点|节
 const AUTO_GENERATIVE_VISUAL_MEDIUM_RE = /(?:主视觉|缩略图|实景|照片|插画|卡通(?:形象|插画|插图)?|儿童插画|儿童插图|概念图|效果图|界面|截图|样机|地图|地理分布|空间分布|场景|实物|特写|肖像|包装视觉|hero\s+image|thumbnail|photo|illustration|cartoon(?:\s+illustration)?|concept\s+art|interface|screenshot|mockup|map|geographic\s+distribution|scene|product\s+shot|object\s+study|close[- ]?up|portrait|packaging\s+visual)/i;
 const AUTO_PRIMARY_BITMAP_VISUAL_RE = /(?:主视觉|缩略图|实景|照片|插画|卡通(?:形象|插画|插图)?|儿童插画|儿童插图|概念图|效果图|样机|地图|场景|实物|特写|肖像|包装视觉|hero\s+image|thumbnail|photo|illustration|cartoon(?:\s+illustration)?|concept\s+art|mockup|map|scene|product\s+shot|object\s+study|close[- ]?up|portrait|packaging\s+visual)/i;
 const AUTO_DATA_VISUAL_RE = /(?:图表|表格|数据看板|KPI|指标|chart|table|dashboard|metrics?)/i;
+const AUTO_SOLAR_ORBIT_RE = /(?:(?:太阳系|八大行星)[\s\S]{0,100}(?:转起来|公转|旋转|转动)|(?:转起来|公转|旋转|转动)[\s\S]{0,100}(?:太阳系|八大行星))/i;
+const AUTO_SPIN_360_RE = /(?:360\s*(?:度|°|degrees?)?[^。；;!?！？\n]{0,24}(?:转|旋转|转动)|(?:转|旋转|转动)[^。；;!?！？\n]{0,24}360\s*(?:度|°|degrees?)?)/i;
 const AUTO_COVER_IMAGE_OPTOUT_RE = /(?:不要|无需|不需要|不得|禁止|不)(?:生成|使用|添加)?(?:图片|生图|视觉图)|(?:纯文字|仅文字)|\b(?:no\s+(?:generated\s+)?images?|without\s+images?|text[- ]only)\b/i;
 const AUTO_SLIDE_LOCAL_IMAGE_OPTOUT_RE = /(?:第?\s*\d{1,2}\s*页|(?:页面|slide)\s*[:：#-]?\s*\d{1,2}|封面|首页|cover)[^。；;!?！？\n]{0,48}(?:纯文字|仅文字|无图片|不要图片|不使用图片|text[- ]only|without\s+images?)|(?:纯文字|仅文字|无图片|不要图片|不使用图片|text[- ]only|without\s+images?)[^。；;!?！？\n]{0,48}(?:封面|首页|cover)/i;
 const STRUCTURED_NEXT_STEPS_MATRIX_RE = /(?:表格|矩阵|table|matrix)|(?:(?:执行)?角色|负责人|责任人|owners?|assignees?|responsibilit(?:y|ies))[^\n。；;]{0,48}(?:姓名|成员|人员|names?|members?)/i;
@@ -515,7 +517,18 @@ function alignScaffoldVisualCardinality(layoutId, props, outlineSlide) {
     || (Number.isInteger(contract.maxItems) && expected > contract.maxItems)
   ) return;
   if (collection.length > expected) collection.splice(expected);
-  const seed = collection.length ? collection[collection.length - 1] : null;
+  const collectionName = String(field).split(".").filter(Boolean).pop();
+  const itemDefault = layout
+    && layout.editor
+    && layout.editor.controls
+    && layout.editor.controls.collections
+    && collectionName
+    && layout.editor.controls.collections[collectionName]
+    ? layout.editor.controls.collections[collectionName].itemDefault
+    : null;
+  const seed = collection.length
+    ? collection[collection.length - 1]
+    : itemDefault;
   while (collection.length < expected) {
     const item = seed === null ? "待填充" : JSON.parse(JSON.stringify(seed));
     const ordinal = collection.length + 1;
@@ -1189,10 +1202,128 @@ function prepareExistingImageAssets(specs, orderedLayouts, deckFile, force = fal
       slide: spec.slide,
       slot: spec.slot,
       outputPath,
+      sourceName: path.basename(sourcePath),
       hash: createHash("sha256").update(fs.readFileSync(destination)).digest("hex"),
     });
   });
   return prepared;
+}
+
+function isPathInside(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+}
+
+function mentionedSourceImageFiles(sourceText, deckFile) {
+  const artifactRoot = path.resolve(
+    String(process.env.BOX_AGENT_OUTPUT_DIR || path.dirname(deckFile)).trim()
+      || path.dirname(deckFile)
+  );
+  const allowedRoots = [artifactRoot];
+  if (path.basename(artifactRoot).toLowerCase() === "output") {
+    allowedRoots.push(path.dirname(artifactRoot));
+  }
+  const mentioned = [];
+  const pattern = /(?:^|[\s"'`（(：:,，、])((?:\/|\.\.?[\\/])?[^\s"'`<>|：:,，、；;（）()]+?\.(?:png|jpe?g|webp))(?=$|[\s"'`<>|，。；;、）)])/giu;
+  for (const match of String(sourceText || "").matchAll(pattern)) {
+    const token = match[1];
+    const candidates = path.isAbsolute(token)
+      ? [path.resolve(token)]
+      : [
+        path.resolve(process.cwd(), token),
+        ...allowedRoots.map(root => path.resolve(root, token)),
+      ];
+    const resolved = candidates.find(candidate => (
+      allowedRoots.some(root => isPathInside(candidate, root))
+      && isNonEmptyFile(candidate)
+    ));
+    if (resolved && !mentioned.includes(resolved)) mentioned.push(resolved);
+  }
+  return mentioned;
+}
+
+function automaticImageAssetSpecs(
+  sourceFiles,
+  explicitSpecs,
+  orderedLayouts,
+  outlineSlides,
+) {
+  const explicitSlides = new Set(explicitSpecs.map(spec => spec.slide));
+  const explicitSources = new Set(explicitSpecs.map(spec => path.resolve(spec.sourcePath)));
+  const candidates = orderedLayouts.flatMap((layout, index) => {
+    if (explicitSlides.has(index + 1)) return [];
+    const slots = layout && layout.mediaSlots && Array.isArray(layout.mediaSlots.slots)
+      ? layout.mediaSlots.slots
+      : [];
+    const slot = slots.find(item => (
+      item
+      && Array.isArray(item.strategies)
+      && item.strategies.includes("use_existing")
+    ));
+    return slot
+      ? [{ slide: index + 1, slot: slot.id }]
+      : [];
+  });
+  const remaining = sourceFiles.filter(file => !explicitSources.has(path.resolve(file)));
+  const specs = remaining.slice(0, candidates.length).map((sourcePath, index) => ({
+    ...candidates[index],
+    sourcePath,
+  }));
+  return {
+    specs,
+    unbound: remaining.slice(candidates.length),
+  };
+}
+
+function setNestedValue(root, fieldPath, value) {
+  const parts = String(fieldPath || "").split(".").filter(Boolean);
+  let current = root;
+  parts.slice(0, -1).forEach(part => {
+    if (!current[part] || typeof current[part] !== "object") current[part] = {};
+    current = current[part];
+  });
+  if (parts.length) current[parts[parts.length - 1]] = value;
+}
+
+function bindPreparedImageAssets(skeleton, prepared, orderedLayouts, outlineSlides) {
+  prepared.forEach(asset => {
+    const layout = orderedLayouts[asset.slide - 1];
+    const slide = skeleton.slides[asset.slide - 1];
+    if (!layout || !slide) return;
+    const slot = layout.mediaSlots.slots.find(item => item && item.id === asset.slot);
+    const propPath = asset.slot === "background" ? "background" : slot && slot.propPath;
+    if (!propPath) return;
+    const outlineSlide = outlineSlides[asset.slide - 1] || {};
+    setNestedValue(slide.props, propPath, {
+      src: asset.outputPath,
+      alt: String(outlineSlide.visual || outlineSlide.title || asset.sourceName).trim(),
+      origin: "uploaded",
+    });
+  });
+}
+
+function inferInteractionContract(sourceText, outlineSlides) {
+  const text = String(sourceText || "");
+  const mode = AUTO_SOLAR_ORBIT_RE.test(text)
+    ? "solar_orbit"
+    : AUTO_SPIN_360_RE.test(text)
+      ? "spin_360"
+      : null;
+  if (!mode) return null;
+  const targetPattern = mode === "solar_orbit"
+    ? /(?:太阳系|八大行星|行星)/i
+    : /(?:城堡|主视觉|立体|360)/i;
+  const targetIndex = Math.max(0, outlineSlides.findIndex(slide => targetPattern.test([
+    slide && slide.title,
+    slide && slide.message,
+    slide && slide.layout,
+    slide && slide.visual,
+  ].filter(Boolean).join("\n"))));
+  return {
+    mode,
+    target_slide_id: `slide-${String(targetIndex + 1).padStart(2, "0")}`,
+    required: true,
+  };
 }
 
 function isNonEmptyFile(filePath) {
@@ -1459,6 +1590,10 @@ function main() {
       ? splitDefaultRuntimeSourceFacts(runtimeBinding.source_text)
       : opts.sourceFacts
   );
+  const interactionContract = inferInteractionContract(
+    runtimeBinding.source_text,
+    authoringSlides,
+  );
   const skeleton = orderedLayouts.length
     ? {
       schema_version: 1,
@@ -1466,6 +1601,7 @@ function main() {
       theme_id: theme.id,
       design,
       ...(designContract ? { design_contract: designContract } : {}),
+      ...(interactionContract ? { interaction_contract: interactionContract } : {}),
       truth_contract: {
         mode: opts.truthMode,
         source_facts: sourceFactNormalization.facts,
@@ -1513,6 +1649,8 @@ function main() {
   let deckFile = null;
   let contractReport = null;
   let imageManifest = null;
+  let automaticallyBoundSourceAssets = [];
+  let unboundMentionedSourceAssets = [];
   if (opts.out) {
     if (!skeleton) {
       throw new Error("--out requires at least one ordered LAYOUT_ID");
@@ -1541,12 +1679,35 @@ function main() {
         "keep one deck/manifest pair in the canonical output root"
       );
     }
-    const existingImageAssets = prepareExistingImageAssets(
+    const mentionedSourceAssets = opts.noImages
+      ? []
+      : mentionedSourceImageFiles(runtimeBinding.source_text, deckFile);
+    const automaticAssets = automaticImageAssetSpecs(
+      mentionedSourceAssets,
       opts.imageAssets,
+      orderedLayouts,
+      authoringSlides,
+    );
+    automaticallyBoundSourceAssets = automaticAssets.specs;
+    unboundMentionedSourceAssets = automaticAssets.unbound;
+    const existingImageAssets = prepareExistingImageAssets(
+      [...opts.imageAssets, ...automaticallyBoundSourceAssets],
       orderedLayouts,
       deckFile,
       opts.force,
     );
+    bindPreparedImageAssets(
+      skeleton,
+      existingImageAssets,
+      orderedLayouts,
+      authoringSlides,
+    );
+    const boundValidation = validateAndNormalizeDeck(skeleton);
+    if (!boundValidation.ok) {
+      throw new Error(
+        `Generated skeleton with source media is invalid:\n${boundValidation.issues.join("\n")}`
+      );
+    }
     fs.mkdirSync(path.dirname(deckFile), { recursive: true });
     fs.writeFileSync(deckFile, `${JSON.stringify(skeleton, null, 2)}\n`, "utf8");
 
@@ -1569,6 +1730,15 @@ function main() {
       schema_version: 1,
       mode: opts.imageMode,
       generation_forbidden: generationForbidden,
+      source_assets: {
+        mentioned: mentionedSourceAssets.map(sourcePath => path.basename(sourcePath)),
+        automatically_bound: automaticallyBoundSourceAssets.map(spec => ({
+          slide: spec.slide,
+          slot: spec.slot,
+          source: path.basename(spec.sourcePath),
+        })),
+        unbound: unboundMentionedSourceAssets.map(sourcePath => path.basename(sourcePath)),
+      },
       deck: {
         title: skeleton.title,
         theme_id: skeleton.theme_id,
@@ -1665,6 +1835,13 @@ function main() {
       required_field_normalizations: requiredFieldNormalizations,
       required_field_relaxations: requiredFieldRelaxations,
       warnings: [
+        ...(unboundMentionedSourceAssets.length
+          ? [
+            "User-mentioned source images were not bound because the validated outline " +
+            `contains too few compatible source-media pages: ${unboundMentionedSourceAssets
+              .map(sourcePath => path.basename(sourcePath)).join(", ")}`,
+          ]
+          : []),
         ...requiredFieldRelaxations.map(item => (
           `Slide ${item.slide} ignored decorative --require-field ${item.field} because ` +
           `${item.effective_layout_id} does not expose it and the outline does not ` +
@@ -1682,6 +1859,14 @@ function main() {
           evidence_import_count: outlineBinding.importedResearchFacts.length,
         }
         : null,
+      source_assets: {
+        automatically_bound: automaticallyBoundSourceAssets.map(spec => ({
+          slide: spec.slide,
+          slot: spec.slot,
+          source: path.basename(spec.sourcePath),
+        })),
+        unbound: unboundMentionedSourceAssets.map(sourcePath => path.basename(sourcePath)),
+      },
     };
     fs.mkdirSync(path.dirname(contractReport), { recursive: true });
     fs.writeFileSync(contractReport, `${JSON.stringify(reportPayload, null, 2)}\n`, "utf8");

--- a/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
+++ b/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
@@ -680,12 +680,17 @@ function readOutlineBinding(outlineInput, expectedSlideCount = null) {
 function normalizeOutlineDrivenLayoutIds(
   layoutIds,
   outlineBinding,
-  layoutPolicy = {}
+  layoutPolicy = {},
+  interactionContract = null
 ) {
   const normalizations = [];
   if (!outlineBinding) return { layoutIds: layoutIds.slice(), normalizations };
   const effective = layoutIds.map((layoutId, index) => {
     const slide = outlineBinding.slides[index];
+    const interactionOwnsCardinality = interactionContract
+      && interactionContract.mode === "solar_orbit"
+      && interactionContract.target_slide_id
+        === `slide-${String(index + 1).padStart(2, "0")}`;
     const outlineText = [
       slide && slide.title,
       slide && slide.message,
@@ -709,6 +714,8 @@ function normalizeOutlineDrivenLayoutIds(
     const timelineMaxItems = visualCollectionLimit("timeline-horizontal-v1", slide);
     const cardsMaxItems = visualCollectionLimit("cards-grid-v1", slide);
     if (
+      !interactionOwnsCardinality
+      &&
       layoutId === "timeline-horizontal-v1"
       && Number.isInteger(timelineMaxItems)
       && Number.isInteger(cardsMaxItems)
@@ -728,6 +735,8 @@ function normalizeOutlineDrivenLayoutIds(
     }
     const selectedMaxItems = visualCollectionLimit(layoutId, slide);
     if (
+      !interactionOwnsCardinality
+      &&
       layoutId === "statement-focus-v1"
       && Number.isInteger(selectedMaxItems)
       && explicitVisualItemCount > selectedMaxItems
@@ -745,6 +754,8 @@ function normalizeOutlineDrivenLayoutIds(
       return "cards-grid-v1";
     }
     if (
+      !interactionOwnsCardinality
+      &&
       layoutId === "closing-next-steps-v1"
       && explicitVisualItemCount > 4
       && explicitVisualItemCount <= 6
@@ -793,6 +804,14 @@ function normalizeOutlineDrivenLayoutIds(
   });
   const capacityChecked = effective.map((layoutId, index) => {
     const slide = outlineBinding.slides[index];
+    if (
+      interactionContract
+      && interactionContract.mode === "solar_orbit"
+      && interactionContract.target_slide_id
+        === `slide-${String(index + 1).padStart(2, "0")}`
+    ) {
+      return layoutId;
+    }
     const requested = expectedVisualItemContract(slide);
     const expected = requested && requested.count;
     const selectedCapacity = visualCollectionCapacity(layoutId, slide);
@@ -860,17 +879,22 @@ function balancedChunkSizes(total, maximum, minimum) {
   return sizes.every(size => size >= minimum && size <= maximum) ? sizes : null;
 }
 
-function expandOutlineDrivenPlan(layoutIds, outlineBinding) {
+function expandOutlineDrivenPlan(layoutIds, outlineBinding, interactionContract = null) {
   if (!outlineBinding) {
     return layoutIds.map((layoutId, index) => ({ layoutId, outlineSlide: null, index }));
   }
   const plan = [];
   layoutIds.forEach((layoutId, index) => {
     const outlineSlide = outlineBinding.slides[index];
+    const interactionOwnsCardinality = interactionContract
+      && interactionContract.mode === "solar_orbit"
+      && interactionContract.target_slide_id
+        === `slide-${String(index + 1).padStart(2, "0")}`;
     const requested = expectedVisualItemContract(outlineSlide);
     const capacity = visualCollectionCapacity(layoutId, outlineSlide);
     if (
-      !requested
+      interactionOwnsCardinality
+      || !requested
       || !capacity
       || (
         requested.count >= capacity.minItems
@@ -1434,6 +1458,11 @@ function main() {
   const outlineBinding = opts.outline
     ? readOutlineBinding(opts.outline, opts.layoutIds.length || null)
     : null;
+  const runtimeBinding = runtimeSourceBinding();
+  const outlineInteractionContract = inferInteractionContract(
+    runtimeBinding.source_text,
+    outlineBinding ? outlineBinding.slides : [],
+  );
   const assumptions = [...new Set(
     opts.assumptions.map(value => value.trim()).filter(Boolean)
   )];
@@ -1460,11 +1489,13 @@ function main() {
   const layoutResolution = normalizeOutlineDrivenLayoutIds(
     opts.layoutIds,
     outlineBinding,
-    layoutPolicy
+    layoutPolicy,
+    outlineInteractionContract,
   );
   const authoringPlan = expandOutlineDrivenPlan(
     layoutResolution.layoutIds,
-    outlineBinding
+    outlineBinding,
+    outlineInteractionContract,
   );
   const effectiveLayoutIds = authoringPlan.map(entry => {
     const layoutId = entry.layoutId;
@@ -1486,7 +1517,6 @@ function main() {
     outlineBinding ? { ...outlineBinding, slides: authoringSlides } : null,
     layoutPolicy
   );
-  const runtimeBinding = runtimeSourceBinding();
   const designContext = {
     title: opts.title,
     source_facts: opts.sourceFacts,

--- a/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
+++ b/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
@@ -1269,11 +1269,125 @@ function mentionedSourceImageFiles(sourceText, deckFile) {
   return mentioned;
 }
 
+function normalizedSourceReference(value) {
+  return String(value || "").replace(/\\/g, "/").toLowerCase();
+}
+
+function outlineSlideMediaText(slide) {
+  if (!slide || typeof slide !== "object") return "";
+  return [
+    slide.title,
+    slide.message,
+    slide.visual,
+    slide.notes,
+    ...(Array.isArray(slide.bullets) ? slide.bullets : []),
+  ].filter(Boolean).join("\n");
+}
+
+function outlineMentionsSourceFile(slide, sourcePath) {
+  const slideText = normalizedSourceReference(outlineSlideMediaText(slide));
+  const sourceName = normalizedSourceReference(path.basename(sourcePath));
+  return Boolean(sourceName && slideText.includes(sourceName));
+}
+
+function outlineRequestsSourceMedia(slide) {
+  const slideText = outlineSlideMediaText(slide);
+  return [
+    /(?:用户|客户|附件|本地|现有|已有|原始|真实|上传|提供|给定|标注)[^\n。；;]{0,12}(?:图片|照片|截图|图像|剧照|概念图|手写信|邮件)/iu,
+    /(?:图片|照片|截图|图像|剧照|概念图|手写信|邮件)[^\n。；;]{0,12}(?:素材|附件|原图|标注|上传|提供)/iu,
+    /(?:source|provided|uploaded|attached|existing|local|original|annotated)[\s_-]*(?:image|photo|screenshot|still|media)/iu,
+  ].some(pattern => pattern.test(slideText));
+}
+
+function sourcePageHint(sourceText, sourcePath) {
+  const normalizedText = normalizedSourceReference(sourceText);
+  const sourceName = normalizedSourceReference(path.basename(sourcePath));
+  if (!sourceName) return null;
+  const hints = new Set();
+  let offset = 0;
+  while (offset < normalizedText.length) {
+    const matchIndex = normalizedText.indexOf(sourceName, offset);
+    if (matchIndex < 0) break;
+    const segmentStart = Math.max(
+      normalizedText.lastIndexOf("\n", matchIndex),
+      normalizedText.lastIndexOf("。", matchIndex),
+      normalizedText.lastIndexOf("；", matchIndex),
+      normalizedText.lastIndexOf(";", matchIndex)
+    ) + 1;
+    const followingBoundaries = ["\n", "。", "；", ";"]
+      .map(separator => normalizedText.indexOf(separator, matchIndex + sourceName.length))
+      .filter(index => index >= 0);
+    const segmentEnd = followingBoundaries.length
+      ? Math.min(...followingBoundaries)
+      : normalizedText.length;
+    const segment = normalizedText.slice(segmentStart, segmentEnd);
+    const sourceStart = matchIndex - segmentStart;
+    const sourceEnd = sourceStart + sourceName.length;
+    const markers = [];
+    for (const pattern of [
+      /第\s*(\d{1,3})\s*页/giu,
+      /(?:slide|page)\s*#?\s*(\d{1,3})\b/giu,
+      /\b(\d{1,3})(?:st|nd|rd|th)\s+(?:slide|page)\b/giu,
+    ]) {
+      for (const match of segment.matchAll(pattern)) {
+        const markerStart = match.index;
+        const markerEnd = markerStart + match[0].length;
+        markers.push({
+          page: Number(match[1]),
+          side: markerEnd <= sourceStart
+            ? "before"
+            : markerStart >= sourceEnd
+              ? "after"
+              : "overlap",
+          distance: markerEnd <= sourceStart
+            ? sourceStart - markerEnd
+            : markerStart >= sourceEnd
+              ? markerStart - sourceEnd
+              : 0,
+        });
+      }
+    }
+    if (markers.length) {
+      const precedingMarkers = markers.filter(marker => marker.side === "before");
+      const relevantMarkers = precedingMarkers.length ? precedingMarkers : markers;
+      const closestDistance = Math.min(
+        ...relevantMarkers.map(marker => marker.distance)
+      );
+      const closestPages = new Set(
+        relevantMarkers
+          .filter(marker => marker.distance === closestDistance)
+          .map(marker => marker.page)
+      );
+      if (closestPages.size === 1) hints.add([...closestPages][0]);
+    }
+    offset = matchIndex + sourceName.length;
+  }
+  return hints.size === 1 ? [...hints][0] : null;
+}
+
+function sourceRequestsSpinInteraction(sourceText, sourcePath) {
+  const normalizedText = normalizedSourceReference(sourceText);
+  const sourceName = normalizedSourceReference(path.basename(sourcePath));
+  if (!sourceName) return false;
+  const matchIndex = normalizedText.indexOf(sourceName);
+  if (matchIndex < 0) return false;
+  const context = normalizedText.slice(
+    Math.max(0, matchIndex - 48),
+    Math.min(normalizedText.length, matchIndex + sourceName.length + 48)
+  );
+  return [
+    /(?:360\s*(?:度|°)?|三百六十度)[^\n。；;]{0,18}(?:转|旋转|拖拽|立体)/iu,
+    /(?:转|旋转|拖拽)[^\n。；;]{0,18}(?:360\s*(?:度|°)?|三百六十度)/iu,
+  ].some(pattern => pattern.test(context));
+}
+
 function automaticImageAssetSpecs(
   sourceFiles,
   explicitSpecs,
   orderedLayouts,
   outlineSlides,
+  sourceText,
+  interactionContract,
 ) {
   const explicitSlides = new Set(explicitSpecs.map(spec => spec.slide));
   const explicitSources = new Set(explicitSpecs.map(spec => path.resolve(spec.sourcePath)));
@@ -1287,18 +1401,72 @@ function automaticImageAssetSpecs(
       && Array.isArray(item.strategies)
       && item.strategies.includes("use_existing")
     ));
+    const outlineSlide = outlineSlides[index] || {};
     return slot
-      ? [{ slide: index + 1, slot: slot.id }]
+      ? [{
+        slide: index + 1,
+        slot: slot.id,
+        outlineSlide,
+        sourceOutlinePage: Number(outlineSlide.page) || index + 1,
+      }]
       : [];
   });
   const remaining = sourceFiles.filter(file => !explicitSources.has(path.resolve(file)));
-  const specs = remaining.slice(0, candidates.length).map((sourcePath, index) => ({
-    ...candidates[index],
-    sourcePath,
-  }));
+  const available = [...candidates];
+  const specs = [];
+  const unbound = [];
+  remaining.forEach(sourcePath => {
+    const pageHint = sourcePageHint(sourceText, sourcePath);
+    const directMatches = available.filter(candidate => (
+      outlineMentionsSourceFile(candidate.outlineSlide, sourcePath)
+    ));
+    const pageMatches = pageHint == null
+      ? []
+      : available.filter(candidate => candidate.sourceOutlinePage === pageHint);
+    const interactionTarget = interactionContract
+      && interactionContract.mode === "spin_360"
+      && sourceRequestsSpinInteraction(sourceText, sourcePath)
+      ? available.find(candidate => (
+        `slide-${String(candidate.slide).padStart(2, "0")}`
+          === interactionContract.target_slide_id
+      ))
+      : null;
+    let selected = null;
+    let reason = null;
+    if (pageHint != null) {
+      selected = directMatches.find(candidate => candidate.sourceOutlinePage === pageHint)
+        || pageMatches.find(candidate => outlineRequestsSourceMedia(candidate.outlineSlide))
+        || pageMatches[0]
+        || null;
+      reason = selected ? "source_page_hint" : null;
+    } else if (directMatches.length) {
+      selected = directMatches[0];
+      reason = "outline_file_reference";
+    } else if (interactionTarget) {
+      selected = interactionTarget;
+      reason = "source_interaction_request";
+    } else {
+      selected = available.find(candidate => outlineRequestsSourceMedia(
+        candidate.outlineSlide
+      )) || null;
+      reason = selected ? "outline_source_media_intent" : null;
+    }
+    if (!selected) {
+      unbound.push(sourcePath);
+      return;
+    }
+    specs.push({
+      slide: selected.slide,
+      slot: selected.slot,
+      sourceOutlinePage: selected.sourceOutlinePage,
+      bindingReason: reason,
+      sourcePath,
+    });
+    available.splice(available.indexOf(selected), 1);
+  });
   return {
     specs,
-    unbound: remaining.slice(candidates.length),
+    unbound,
   };
 }
 
@@ -1739,6 +1907,8 @@ function main() {
       opts.imageAssets,
       orderedLayouts,
       authoringSlides,
+      runtimeBinding.source_text,
+      interactionContract,
     );
     automaticallyBoundSourceAssets = automaticAssets.specs;
     unboundMentionedSourceAssets = automaticAssets.unbound;
@@ -1788,6 +1958,8 @@ function main() {
           slide: spec.slide,
           slot: spec.slot,
           source: path.basename(spec.sourcePath),
+          source_outline_page: spec.sourceOutlinePage,
+          reason: spec.bindingReason,
         })),
         unbound: unboundMentionedSourceAssets.map(sourcePath => path.basename(sourcePath)),
       },
@@ -1916,6 +2088,8 @@ function main() {
           slide: spec.slide,
           slot: spec.slot,
           source: path.basename(spec.sourcePath),
+          source_outline_page: spec.sourceOutlinePage,
+          reason: spec.bindingReason,
         })),
         unbound: unboundMentionedSourceAssets.map(sourcePath => path.basename(sourcePath)),
       },

--- a/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
+++ b/box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js
@@ -1353,6 +1353,11 @@ function inferInteractionContract(sourceText, outlineSlides) {
       if (requested && requested.count === 8) score += 8;
       if (/(?:八张|8\s*张).{0,12}(?:行星|卡片)/i.test(content)) score += 3;
       if (/(?:封面|cover)/i.test(String(slide && slide.layout || ""))) score -= 6;
+    } else {
+      if (/(?:360\s*(?:°|度)?|全景旋转|可拖拽旋转)/i.test(content)) score += 6;
+      if (/(?:立体|三维|3d|模型)/i.test(content)) score += 3;
+      if (/(?:城堡|主体|主视觉)/i.test(content)) score += 2;
+      if (/(?:封面|cover)/i.test(String(slide && slide.layout || ""))) score -= 6;
     }
     return { index, score };
   });

--- a/box_agent/skills/document-skills/pptx/scripts/outline_layout_contract.js
+++ b/box_agent/skills/document-skills/pptx/scripts/outline_layout_contract.js
@@ -312,6 +312,14 @@ function analyzeOutlineLayoutIntent(
       "outline explicitly marks this page as a typography-led cover"
     );
   }
+  if (MEDIA_RE.test(visual)) {
+    return semanticRule(
+      "source-media",
+      "image-hero-split-v1",
+      ["image-hero-split-v1", "project-case-study-v1"],
+      "outline explicitly asks for a photograph, screenshot, or other primary media asset"
+    );
+  }
   if (FACTORY_PROCESS_RE.test(all)) {
     return semanticRule(
       "factory-process-line",
@@ -367,8 +375,8 @@ function analyzeOutlineLayoutIntent(
     return semanticRule(
       "timeline",
       "timeline-horizontal-v1",
-      ["timeline-horizontal-v1"],
-      "outline asks for ordered milestones on a time or roadmap axis"
+      ["timeline-horizontal-v1", "cards-grid-v1"],
+      "outline asks for ordered milestones; a controlled timeline or numbered cards can preserve the sequence"
     );
   }
   if (PROCESS_RE.test(visual)) {

--- a/box_agent/skills/document-skills/pptx/scripts/probe_deck_runtime.js
+++ b/box_agent/skills/document-skills/pptx/scripts/probe_deck_runtime.js
@@ -199,6 +199,7 @@ async function readEditorState(page, viewport) {
     const toolbar = document.querySelector(".deck-toolbar");
     const statement = document.querySelector(".statement-poster");
     const diagram = document.querySelector("#deck-root > .slide [data-pptx-diagram]");
+    const interactionRoot = document.querySelector("[data-deck-interaction-target]");
     const diagrams = Array.from(document.querySelectorAll("#deck-root > .slide [data-pptx-diagram]")).map(root => {
       let spec = {};
       try {
@@ -320,6 +321,21 @@ async function readEditorState(page, viewport) {
         nodes: diagram.querySelectorAll("[data-diagram-node-id]").length,
         edges: diagram.querySelectorAll("[data-diagram-edge-id]").length,
       } : null,
+      interaction: {
+        requiredMode: document.body.getAttribute("data-deck-interaction-mode"),
+        mode: interactionRoot
+          ? interactionRoot.getAttribute("data-deck-interaction-target")
+          : null,
+        ready: interactionRoot
+          ? interactionRoot.getAttribute("data-interaction-ready") === "true"
+          : false,
+        planetCount: interactionRoot
+          ? interactionRoot.querySelectorAll(".deck-planet").length
+          : 0,
+        spinVisualCount: interactionRoot
+          ? interactionRoot.querySelectorAll(".deck-spin-stage img, .deck-spin-placeholder").length
+          : 0,
+      },
       diagrams,
     };
   }, viewport);
@@ -388,6 +404,9 @@ async function main() {
     await page.evaluate(async () => {
       if (window.__deckDiagramReady && typeof window.__deckDiagramReady.then === "function") {
         await window.__deckDiagramReady;
+      }
+      if (window.__deckInteractionReady && typeof window.__deckInteractionReady.then === "function") {
+        await window.__deckInteractionReady;
       }
     });
     await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
@@ -465,6 +484,26 @@ async function main() {
       editor.diagram.nodes < 2
     )) {
       issues.push("Technical diagram runtime did not produce one ready inline SVG graph");
+    }
+    if (editor.interaction.requiredMode && (
+      !editor.interaction.ready
+      || editor.interaction.mode !== editor.interaction.requiredMode
+    )) {
+      issues.push("Required deck interaction runtime did not initialize");
+    }
+    if (
+      editor.interaction.requiredMode === "solar_orbit"
+      && editor.interaction.planetCount !== 8
+    ) {
+      issues.push(
+        `Solar interaction rendered ${editor.interaction.planetCount} planets instead of 8`
+      );
+    }
+    if (
+      editor.interaction.requiredMode === "spin_360"
+      && editor.interaction.spinVisualCount !== 1
+    ) {
+      issues.push("360 interaction does not contain exactly one rotatable visual");
     }
     (editor.diagrams || []).forEach((diagram, index) => {
       if (diagram.nodes !== diagram.specNodes || diagram.uniqueNodeIds !== diagram.nodes) {

--- a/box_agent/skills/document-skills/pptx/scripts/render_deck_html.js
+++ b/box_agent/skills/document-skills/pptx/scripts/render_deck_html.js
@@ -227,6 +227,60 @@ function renderToolbar() {
   ].join("\n");
 }
 
+function slideMedia(slide) {
+  const props = slide && slide.props && typeof slide.props === "object"
+    ? slide.props
+    : {};
+  return [props.hero, props.image, props.media, slide && slide.background]
+    .find(value => value && typeof value === "object" && typeof value.src === "string")
+    || null;
+}
+
+function renderSolarOrbitInteraction() {
+  const planets = [
+    ["水", 150, 12, 7, "#9b9b97"],
+    ["金", 220, 19, 10, "#d89a45"],
+    ["地", 290, 20, 13, "#3c82d4"],
+    ["火", 360, 16, 16, "#b6492f"],
+    ["木", 440, 38, 21, "#c88f61"],
+    ["土", 520, 34, 27, "#d3b66e"],
+    ["天", 600, 26, 33, "#66bfd0"],
+    ["海", 680, 25, 40, "#376ad2"],
+  ];
+  return [
+    '<div class="deck-interaction deck-interaction-solar" data-deck-decoration="interaction" data-deck-interaction-target="solar_orbit" aria-label="可暂停的八大行星公转示意">',
+    '  <button type="button" class="deck-interaction-toggle" data-deck-interaction-toggle aria-pressed="false">暂停运动</button>',
+    '  <div class="deck-solar-system">',
+    '    <div class="deck-solar-sun">太阳</div>',
+    ...planets.map(([label, orbit, size, duration, color]) => (
+      `    <div class="deck-planet-orbit" style="--orbit-size:${orbit}px;--orbit-duration:${duration}s">` +
+      `<span class="deck-planet" style="--planet-size:${size}px;--planet-color:${color}" title="${label}">${label}</span></div>`
+    )),
+    "  </div>",
+    "</div>",
+  ].join("\n");
+}
+
+function renderSpinInteraction(slide) {
+  const media = slideMedia(slide);
+  const visual = media
+    ? `<img src="${escapeHtml(media.src)}" alt="${escapeHtml(media.alt || "360 度主视觉")}" draggable="false" />`
+    : '<div class="deck-spin-placeholder" aria-label="360 度主视觉占位">360°</div>';
+  return [
+    '<div class="deck-interaction deck-interaction-spin" data-deck-decoration="interaction" data-deck-interaction-target="spin_360" aria-label="可拖拽的 360 度主视觉">',
+    '  <button type="button" class="deck-interaction-toggle" data-deck-interaction-toggle aria-pressed="false">暂停运动</button>',
+    `  <div class="deck-spin-stage" data-deck-spin-stage>${visual}</div>`,
+    "</div>",
+  ].join("\n");
+}
+
+function renderInteraction(contract, slide) {
+  if (!contract || slide.id !== contract.target_slide_id) return "";
+  return contract.mode === "solar_orbit"
+    ? renderSolarOrbitInteraction()
+    : renderSpinInteraction(slide);
+}
+
 function renderDocument(deck, theme) {
   const runtimeCss = fs.readFileSync(path.join(SKILL_ROOT, "runtime", "deck.css"), "utf8");
   const compositionCss = fs.readFileSync(
@@ -234,6 +288,12 @@ function renderDocument(deck, theme) {
     "utf8"
   );
   const editorJs = fs.readFileSync(path.join(SKILL_ROOT, "runtime", "deck-editor.js"), "utf8");
+  const interactionCss = deck.interaction_contract
+    ? fs.readFileSync(path.join(SKILL_ROOT, "runtime", "interaction-runtime.css"), "utf8")
+    : "";
+  const interactionJs = deck.interaction_contract
+    ? fs.readFileSync(path.join(SKILL_ROOT, "runtime", "interaction-runtime.js"), "utf8")
+    : "";
   const layoutRegistryJs = fs.readFileSync(
     path.join(SKILL_ROOT, "layouts", "registry.js"),
     "utf8"
@@ -243,7 +303,11 @@ function renderDocument(deck, theme) {
   const slideHtml = deck.slides.map((slide, index) => {
     const layout = getLayout(slide.layout_id);
     if (!layout) throw new Error(`Unknown layout during render: ${slide.layout_id}`);
-    return layout.render(slide, index, design);
+    const rendered = layout.render(slide, index, design);
+    const interaction = renderInteraction(deck.interaction_contract, slide);
+    return interaction
+      ? rendered.replace(/<\/section>\s*$/, `${interaction}\n</section>`)
+      : rendered;
   }).join("\n\n");
   const hasCharts = slideHtml.includes("data-pptx-chart");
   const chartScripts = hasCharts
@@ -299,10 +363,11 @@ function renderDocument(deck, theme) {
     "  <style>",
     runtimeCss,
     compositionCss,
+    interactionCss,
     themeVariables(theme, deck.design_contract),
     "  </style>",
     "</head>",
-    `<body data-deck-schema-version="1" data-deck-theme="${escapeHtml(visualDnaId)}" data-deck-theme-id="${escapeHtml(theme.id)}" data-deck-composition="${escapeHtml(design.family)}" data-deck-composition-variant="${escapeHtml(design.variant)}" data-deck-design-seed="${escapeHtml(design.seed)}"${paletteAccentUsage}${themeStyleAttributes(theme)}>`,
+    `<body data-deck-schema-version="1" data-deck-theme="${escapeHtml(visualDnaId)}" data-deck-theme-id="${escapeHtml(theme.id)}" data-deck-composition="${escapeHtml(design.family)}" data-deck-composition-variant="${escapeHtml(design.variant)}" data-deck-design-seed="${escapeHtml(design.seed)}"${deck.interaction_contract ? ` data-deck-interaction-mode="${escapeHtml(deck.interaction_contract.mode)}"` : ""}${paletteAccentUsage}${themeStyleAttributes(theme)}>`,
     '  <main id="deck-root">',
     slideHtml,
     "  </main>",
@@ -319,6 +384,13 @@ function renderDocument(deck, theme) {
     "  </script>",
     ...chartScripts,
     ...diagramScripts,
+    ...(interactionJs
+      ? [
+        '  <script data-deck-runtime="interaction-runtime">',
+        safeInlineScript(interactionJs),
+        "  </script>",
+      ]
+      : []),
     "  <script>",
     editorJs,
     "  </script>",

--- a/box_agent/skills/document-skills/pptx/scripts/validate_outline.js
+++ b/box_agent/skills/document-skills/pptx/scripts/validate_outline.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const {
+  OUTLINE_INTENT_TEXT_LIMITS,
   TRUTH_TEXT_MAX_CHARACTERS,
   resolveArtifactPath,
   runtimeSourceBinding,
@@ -455,6 +456,13 @@ function validate(outline, opts) {
 
     for (const field of ["title", "message", "layout", "visual"]) {
       if (!text(slide[field])) issues.push(`${label}: missing ${field}`);
+      const length = wordLikeLength(slide[field]);
+      const maxChars = OUTLINE_INTENT_TEXT_LIMITS[field];
+      if (length > maxChars) {
+        issues.push(
+          `${label}: ${field} has ${length} characters; maximum is ${maxChars}`
+        );
+      }
     }
 
     if (!Array.isArray(slide.bullets)) {

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -307,6 +307,7 @@ def test_interactive_cli_passes_explicit_skill_gate_to_agent(
         ),
     )
     run_options: list[dict[str, object]] = []
+    bound_source_texts: list[str] = []
 
     async def fake_initialize_base_tools(*args, **kwargs):
         return [GetSkillTool(skill_loader)], skill_loader, None, None
@@ -314,6 +315,10 @@ def test_interactive_cli_passes_explicit_skill_gate_to_agent(
     async def fake_run(self, *args, **kwargs):
         run_options.append(kwargs)
         return "done"
+
+    def fake_bind_user_source_text(self, text: str):
+        bound_source_texts.append(text)
+        return text
 
     monkeypatch.setattr(
         cli.Config,
@@ -333,6 +338,7 @@ def test_interactive_cli_passes_explicit_skill_gate_to_agent(
     monkeypatch.setattr(cli, "add_workspace_tools", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "PromptSession", _ExplicitSkillPromptSession)
     monkeypatch.setattr(cli.Agent, "run", fake_run)
+    monkeypatch.setattr(cli.Agent, "bind_user_source_text", fake_bind_user_source_text)
     _ExplicitSkillPromptSession.prompt_count = 0
 
     exit_code = asyncio.run(
@@ -346,6 +352,7 @@ def test_interactive_cli_passes_explicit_skill_gate_to_agent(
 
     assert exit_code == 0
     assert len(run_options) == 1
+    assert bound_source_texts == ["请用 /report-skill 生成报告"]
     gate = run_options[0]["completion_gate"]
     assert gate.workflow_checkpoint_kind == "external_skill"
     assert gate.workflow_options["skill_name"] == "report-skill"
@@ -564,6 +571,13 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
     async def fake_initialize_base_tools(*args, **kwargs):
         return [GetSkillTool(skill_loader)], skill_loader, None, None
 
+    bound_source_texts: list[str] = []
+    original_bind_user_source_text = cli.Agent.bind_user_source_text
+
+    def capture_bind_user_source_text(self, text: str):
+        bound_source_texts.append(text)
+        return original_bind_user_source_text(self, text)
+
     monkeypatch.setattr(cli.Config, "get_default_config_path", staticmethod(lambda: config_path))
     monkeypatch.setattr(cli.Config, "from_yaml", staticmethod(lambda _path: config))
     monkeypatch.setattr(
@@ -574,6 +588,7 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
     monkeypatch.setattr(cli, "LLMClient", _PreloadedSkillThenGetSkillLLM)
     monkeypatch.setattr(cli, "initialize_base_tools", fake_initialize_base_tools)
     monkeypatch.setattr(cli, "add_workspace_tools", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.Agent, "bind_user_source_text", capture_bind_user_source_text)
     _CaptureStreamLLM.instances.clear()
 
     exit_code = asyncio.run(
@@ -587,6 +602,7 @@ def test_cli_task_preloads_pptx_even_when_filter_drops_it(tmp_path: Path, monkey
     )
 
     assert exit_code == 0
+    assert bound_source_texts == [prompt]
     first_system_prompt = _CaptureStreamLLM.instances[0].system_prompts[0]
     assert "## Auto-Loaded Skill Instructions" in first_system_prompt
     assert "# Skill: pptx" in first_system_prompt

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -6001,6 +6001,212 @@ def test_scaffold_auto_binds_user_mentioned_source_images_to_media_pages(
     assert validated.returncode == 0, validated.stdout + validated.stderr
 
 
+def test_scaffold_binds_source_image_to_explicit_outline_page_hint(
+    tmp_path: Path,
+) -> None:
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    source = inputs / "castle.png"
+    source.write_bytes(
+        base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+            "/x8AAusB9Wl2YvQAAAAASUVORK5CYII="
+        )
+    )
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(outline_path, page_count=3, source_mode="user_provided")
+    outline["slides"][0].update(
+        {"layout": "cover", "visual": "极简文字封面"}
+    )
+    outline["slides"][2].update(
+        {"layout": "feature", "visual": "右侧保留视觉区域"}
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT，第 3 页使用 inputs/castle.png。".encode("utf-8")
+    ).decode("ascii")
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "cover-hero-v1",
+        "cards-grid-v1",
+        "image-hero-split-v1",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert deck["slides"][2]["props"]["image"]["src"] == (
+        "assets/source/slide-03-image.png"
+    )
+    manifest = json.loads(
+        (output / "assets" / "generated" / "manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["source_assets"]["automatically_bound"] == [
+        {
+            "slide": 3,
+            "slot": "image",
+            "source": "castle.png",
+            "source_outline_page": 3,
+            "reason": "source_page_hint",
+        }
+    ]
+
+
+def test_scaffold_matches_source_images_to_outline_file_references(
+    tmp_path: Path,
+) -> None:
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    image_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/x8AAusB9Wl2YvQAAAAASUVORK5CYII="
+    )
+    (inputs / "first.png").write_bytes(image_bytes)
+    (inputs / "second.jpg").write_bytes(image_bytes)
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(outline_path, page_count=2, source_mode="user_provided")
+    outline["slides"][0].update(
+        {"layout": "case", "visual": "使用 inputs/second.jpg 作为案例原图"}
+    )
+    outline["slides"][1].update(
+        {"layout": "case", "visual": "使用 inputs/first.png 作为案例原图"}
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        (
+            "请制作一份PPT。素材文件：inputs/first.png、"
+            "inputs/second.jpg。"
+        ).encode("utf-8")
+    ).decode("ascii")
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "image-hero-split-v1",
+        "image-hero-split-v1",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert [slide["props"]["image"]["src"] for slide in deck["slides"]] == [
+        "assets/source/slide-01-image.jpg",
+        "assets/source/slide-02-image.png",
+    ]
+
+
+def test_scaffold_uses_nearest_page_hint_for_each_source_file(
+    tmp_path: Path,
+) -> None:
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    image_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/x8AAusB9Wl2YvQAAAAASUVORK5CYII="
+    )
+    (inputs / "first.png").write_bytes(image_bytes)
+    (inputs / "second.jpg").write_bytes(image_bytes)
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(outline_path, page_count=2, source_mode="user_provided")
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        (
+            "请制作一份PPT，第 2 页用 inputs/second.jpg，"
+            "第 1 页用 inputs/first.png。"
+        ).encode("utf-8")
+    ).decode("ascii")
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "image-hero-split-v1",
+        "image-hero-split-v1",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert [slide["props"]["image"]["src"] for slide in deck["slides"]] == [
+        "assets/source/slide-01-image.png",
+        "assets/source/slide-02-image.jpg",
+    ]
+
+
+def test_scaffold_leaves_ambiguous_source_image_unbound(
+    tmp_path: Path,
+) -> None:
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    source = inputs / "reference.png"
+    source.write_bytes(
+        base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+            "/x8AAusB9Wl2YvQAAAAASUVORK5CYII="
+        )
+    )
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(outline_path, page_count=1, source_mode="user_provided")
+    outline["slides"][0].update(
+        {"layout": "cover", "visual": "仅用大标题和留白构成封面"}
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT。参考文件：inputs/reference.png。".encode("utf-8")
+    ).decode("ascii")
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "cover-hero-v1",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    manifest = json.loads(
+        (output / "assets" / "generated" / "manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["source_assets"]["automatically_bound"] == []
+    assert manifest["source_assets"]["unbound"] == ["reference.png"]
+
+
 def test_scaffold_and_runtime_preserve_explicit_solar_orbit_interaction(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -4142,6 +4142,72 @@ def test_bound_deck_rejects_visual_cardinality_and_missing_persisted_intent(
     assert "outline visual explicitly requests 3 visual item(s), got 4" in result.stdout
 
 
+def test_scaffold_does_not_treat_third_planet_as_three_visual_rows(
+    tmp_path: Path,
+) -> None:
+    outline_path = tmp_path / "outline.json"
+    outline = _write_outline(outline_path, page_count=1, source_mode="user_provided")
+    outline["slides"][0].update(
+        {
+            "title": "厄拉科斯：第三行星",
+            "message": "用尺度与地貌解释这颗沙漠星球。",
+            "bullets": ["岩石盆地", "沙海", "风暴"],
+            "layout": "statement",
+            "visual": "宽画幅满版：石质巨墙围合的盆地，沙脊层叠如海浪。",
+        }
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    deck_path = tmp_path / "deck.json"
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "statement-focus-v1",
+        "--outline",
+        str(outline_path),
+        "--out",
+        str(deck_path),
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads(deck_path.read_text(encoding="utf-8"))
+    assert deck["slides"][0]["props"]["proofs"] == []
+    assert deck["slides"][0]["outline_intent"].get("visual_item_contract") is None
+
+
+def test_scaffold_uses_typed_default_for_empty_explicit_proof_collection(
+    tmp_path: Path,
+) -> None:
+    outline_path = tmp_path / "outline.json"
+    outline = _write_outline(outline_path, page_count=1, source_mode="user_provided")
+    outline["slides"][0].update(
+        {
+            "title": "核心判断",
+            "message": "用三项证明支撑结论。",
+            "bullets": [],
+            "layout": "statement",
+            "visual": "一句结论，下方放三项证明。",
+        }
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    deck_path = tmp_path / "deck.json"
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "statement-focus-v1",
+        "--outline",
+        str(outline_path),
+        "--out",
+        str(deck_path),
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads(deck_path.read_text(encoding="utf-8"))
+    assert deck["slides"][0]["props"]["proofs"] == [
+        {"value": "新证明点", "label": f"视觉项 {index}"}
+        for index in range(1, 4)
+    ]
+
+
 def test_bound_deck_rejects_unchanged_scaffold_content(tmp_path: Path) -> None:
     outline_path = tmp_path / "outline.json"
     _write_outline(outline_path, page_count=1)
@@ -4984,7 +5050,7 @@ def test_scaffold_normalizes_six_step_timeline_to_numbered_cards(
             ],
             "layout": "横向流程图",
             "visual": (
-                "六节点横向流程图，依次呈现明确问题、收集信息、拆分问题、"
+                "六节点横向时间轴/流程图，依次呈现明确问题、收集信息、拆分问题、"
                 "分类归纳、提炼结论、组织表达。"
             ),
         }
@@ -5726,16 +5792,20 @@ def test_scaffold_copies_and_validates_user_supplied_image_asset(
     copied = deck_path.parent / cover["output_path"]
     assert copied.read_bytes() == source.read_bytes()
 
-    unbound = _run(
+    deck = json.loads(deck_path.read_text(encoding="utf-8"))
+    assert deck["slides"][0]["props"]["hero"] == {
+        "src": cover["output_path"],
+        "alt": "client-ui.png",
+        "origin": "uploaded",
+    }
+    bound = _run(
         "validate_image_manifest.js",
         str(manifest_path),
         "--deck",
         str(deck_path),
     )
-    assert unbound.returncode == 1
-    assert "planned image asset is not referenced by deck.json" in unbound.stdout
+    assert bound.returncode == 0, bound.stdout + bound.stderr
 
-    deck = json.loads(deck_path.read_text(encoding="utf-8"))
     deck["slides"][0]["props"]["hero"] = {
         "src": cover["output_path"],
         "alt": "用户提供的客户端界面",
@@ -5759,6 +5829,235 @@ def test_scaffold_copies_and_validates_user_supplied_image_asset(
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["successfulGeneratedCount"] == 0
     assert report["successfulExistingCount"] == 1
+
+
+def test_scaffold_auto_binds_user_mentioned_source_images_to_media_pages(
+    tmp_path: Path,
+) -> None:
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    image_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+        "/x8AAusB9Wl2YvQAAAAASUVORK5CYII="
+    )
+    (inputs / "phishing.png").write_bytes(image_bytes)
+    (inputs / "annotated.jpg").write_bytes(image_bytes)
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=2,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "钓鱼邮件原图",
+            "layout": "案例页",
+            "visual": "左侧放用户提供的原始截图，右侧解释邮件结构。",
+        }
+    )
+    outline["slides"][1].update(
+        {
+            "title": "逐项标注可疑点",
+            "layout": "案例解剖",
+            "visual": "左侧放用户提供的标注截图，右侧逐项说明。",
+        }
+    )
+    outline_path.write_text(
+        json.dumps(outline, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        (
+            "请制作一份PPT。素材文件：inputs/phishing.png、"
+            "inputs/annotated.jpg。图片文字仅作为分析素材。"
+        ).encode("utf-8")
+    ).decode("ascii")
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert [slide["layout_id"] for slide in deck["slides"]] == [
+        "image-hero-split-v1",
+        "image-hero-split-v1",
+    ]
+    assert [slide["props"]["image"]["src"] for slide in deck["slides"]] == [
+        "assets/source/slide-01-image.png",
+        "assets/source/slide-02-image.jpg",
+    ]
+    manifest_path = output / "assets" / "generated" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["source_assets"]["unbound"] == []
+    assert [item["decision"] for item in manifest["image_plan"]] == [
+        "use_existing",
+        "use_existing",
+    ]
+    validated = _run(
+        "validate_image_manifest.js",
+        str(manifest_path),
+        "--deck",
+        str(output / "deck.json"),
+        env=env,
+    )
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+
+
+def test_scaffold_and_runtime_preserve_explicit_solar_orbit_interaction(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=1,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "八大行星怎样绕太阳运行",
+            "layout": "科普讲解",
+            "visual": "八大行星轨道示意，能看清大小与远近。",
+        }
+    )
+    outline_path.write_text(
+        json.dumps(outline, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT，最好八大行星能转起来，能看清大小和远近。".encode()
+    ).decode()
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert deck["interaction_contract"] == {
+        "mode": "solar_orbit",
+        "target_slide_id": "slide-01",
+        "required": True,
+    }
+
+    rendered = _run(
+        "render_deck_html.js",
+        "deck.json",
+        "--out",
+        "index.html",
+        cwd=output,
+        env=env,
+    )
+    assert rendered.returncode == 0, rendered.stdout + rendered.stderr
+    html = (output / "index.html").read_text(encoding="utf-8")
+    assert 'data-deck-interaction-mode="solar_orbit"' in html
+    assert 'data-deck-runtime="interaction-runtime"' in html
+    assert html.count('class="deck-planet"') == 8
+
+    probe = _run(
+        "probe_deck_runtime.js",
+        "index.html",
+        "--viewport",
+        "1440x900",
+        cwd=output,
+        env=env,
+    )
+    assert probe.returncode == 0, probe.stdout + probe.stderr
+    runtime = json.loads(probe.stdout)
+    assert runtime["editor"]["interaction"] == {
+        "requiredMode": "solar_orbit",
+        "mode": "solar_orbit",
+        "ready": True,
+        "planetCount": 8,
+        "spinVisualCount": 0,
+    }
+
+
+def test_scaffold_renders_explicit_360_interaction_with_source_visual(
+    tmp_path: Path,
+) -> None:
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    (inputs / "castle.png").write_bytes(
+        base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+            "/x8AAusB9Wl2YvQAAAAASUVORK5CYII="
+        )
+    )
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=1,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "云境天穹",
+            "layout": "视觉封面",
+            "visual": "空中城堡主视觉，动漫游戏风格。",
+        }
+    )
+    outline_path.write_text(
+        json.dumps(outline, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT，把 inputs/castle.png 做成能 360 度转的立体效果。".encode()
+    ).decode()
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert deck["interaction_contract"] == {
+        "mode": "spin_360",
+        "target_slide_id": "slide-01",
+        "required": True,
+    }
+    rendered = _run(
+        "render_deck_html.js",
+        "deck.json",
+        "--out",
+        "index.html",
+        cwd=output,
+        env=env,
+    )
+    assert rendered.returncode == 0, rendered.stdout + rendered.stderr
+    html = (output / "index.html").read_text(encoding="utf-8")
+    assert 'data-deck-interaction-mode="spin_360"' in html
+    assert 'data-deck-interaction-target="spin_360"' in html
+    assert 'src="assets/source/slide-01-hero.png"' in html
+    assert "data-deck-spin-stage" in html
 
 
 def test_deck_contract_normalizes_observed_model_layout_aliases(

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -3840,6 +3840,18 @@ def test_outline_rejects_conflicting_agenda_counts_across_fields(tmp_path: Path)
     assert "conflicting agenda item counts 7, 8" in validated.stdout
 
 
+def test_outline_rejects_text_that_would_fail_scaffold_contract(tmp_path: Path) -> None:
+    outline_path = tmp_path / "outline.json"
+    outline = _write_outline(outline_path, page_count=1, source_mode="user_provided")
+    outline["slides"][0]["visual"] = "超" * 301
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+
+    validated = _run("validate_outline.js", str(outline_path))
+
+    assert validated.returncode == 1
+    assert "slide-01: visual has 301 characters; maximum is 300" in validated.stdout
+
+
 @pytest.mark.parametrize(
     ("title", "visual", "bullets", "layout_id", "field", "count"),
     [
@@ -6254,6 +6266,56 @@ def test_scaffold_renders_explicit_360_interaction_with_source_visual(
     assert "data-deck-spin-stage" in html
 
 
+def test_spin_interaction_targets_explicit_360_content_page(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=3,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "云境天穹：空中城堡",
+            "layout": "cover-hero-v1",
+            "visual": "梦幻空中城堡主视觉封面",
+        }
+    )
+    outline["slides"][2].update(
+        {
+            "title": "360° 立体空中城堡",
+            "message": "拖拽查看城堡的完整三维结构。",
+            "layout": "image-hero-split-v1",
+            "visual": "可拖拽旋转的 3D 城堡模型",
+        }
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT，把空中城堡做成能 360 度转的立体效果。".encode()
+    ).decode()
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert deck["interaction_contract"] == {
+        "mode": "spin_360",
+        "target_slide_id": "slide-03",
+        "required": True,
+    }
+
+
 def test_deck_contract_normalizes_observed_model_layout_aliases(
     tmp_path: Path,
 ) -> None:
@@ -8116,6 +8178,37 @@ def test_batch_patch_compacts_overlong_optional_source_caption(
     payload = json.loads(result.stdout)
     assert (
         "slides.slide-01.props.source: compacted optional source caption to 100 characters"
+        in payload["normalization_changes"]
+    )
+
+
+def test_batch_patch_compacts_overlong_nested_text(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "cards-grid-v1",
+        "--out",
+        str(deck_path),
+    )
+    assert scaffold.returncode == 0, scaffold.stderr
+    body = "Part One 与 Part Two 的画幅和镜头系统形成鲜明对照；" + "压迫感" * 30
+    patch_path = tmp_path / "deck.patch.json"
+    patch_path.write_text(
+        json.dumps(
+            {"slides": {"slide-01": {"props": {"items": [{"body": body}]}}}},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run("apply_deck_patch.js", str(deck_path), str(patch_path))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    deck = json.loads(deck_path.read_text(encoding="utf-8"))
+    assert len(deck["slides"][0]["props"]["items"][0]["body"]) <= 100
+    payload = json.loads(result.stdout)
+    assert (
+        "slides.slide-01.props.items.0.body: compacted overlong text to 100 characters"
         in payload["normalization_changes"]
     )
 

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -3981,6 +3981,81 @@ def test_scaffold_splits_overflow_for_typed_collection_layouts(
     assert slides[-1]["source_outline_item_range"]["end"] == item_count
 
 
+def test_scaffold_splits_visual_count_when_bullets_are_page_summary(tmp_path: Path) -> None:
+    outline_path = tmp_path / "outline.json"
+    outline = _write_outline(outline_path, page_count=1, source_mode="user_provided")
+    outline["slides"][0].update(
+        {
+            "title": "八大行星，一颗都不能少",
+            "message": "用一页建立八大行星的完整认知。",
+            "bullets": ["认识名称", "区分类型", "观察顺序"],
+            "layout": "cards-grid-v1",
+            "visual": "八张行星卡片，每张标注名称与石头或气体类型。",
+        }
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    deck_path = tmp_path / "deck.json"
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        str(outline_path),
+        "--out",
+        str(deck_path),
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    slides = json.loads(deck_path.read_text(encoding="utf-8"))["slides"]
+    assert [len(slide["props"]["items"]) for slide in slides] == [4, 4]
+    assert [slide["source_outline_item_range"] for slide in slides] == [
+        {"start": 1, "end": 4, "total": 8, "part": 1, "parts": 2},
+        {"start": 5, "end": 8, "total": 8, "part": 2, "parts": 2},
+    ]
+
+
+@pytest.mark.parametrize(
+    "visual",
+    [
+        "12个月销量折线图 + 增速柱状叠加",
+        "近 24 个月销量折线/柱状组合图，含同比标签",
+    ],
+)
+def test_scaffold_does_not_treat_time_window_as_visual_item_count(
+    tmp_path: Path,
+    visual: str,
+) -> None:
+    outline_path = tmp_path / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=1,
+        source_mode="public_authoritative_research",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "月度销量走势",
+            "message": "暂无可验证公开数据",
+            "bullets": ["暂无可验证公开数据"],
+            "layout": "chart-data-v1",
+            "visual": visual,
+        }
+    )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    deck_path = tmp_path / "deck.json"
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        str(outline_path),
+        "--out",
+        str(deck_path),
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    slides = json.loads(deck_path.read_text(encoding="utf-8"))["slides"]
+    assert len(slides) == 1
+    assert "source_outline_item_range" not in slides[0]
+
+
 def test_scaffold_and_patch_support_six_column_nine_row_gantt(
     tmp_path: Path,
 ) -> None:
@@ -6056,6 +6131,59 @@ def test_solar_interaction_owns_eight_planet_cardinality_without_outline_split(
     assert (output / "index.html").read_text(encoding="utf-8").count(
         'class="deck-planet"'
     ) == 8
+
+
+def test_solar_interaction_targets_the_explicit_eight_planet_page(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=3,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "一起出发去太阳系",
+            "layout": "cover-hero-v1",
+            "visual": "太阳系星空封面",
+        }
+    )
+    for page in (1, 2):
+        outline["slides"][page].update(
+            {
+                "title": "八大行星" if page == 1 else "课堂小测试",
+                "message": "认识八大行星的名称、大小与远近。",
+                "bullets": ["认识名称", "比较大小", "观察远近"],
+                "layout": "cards-grid-v1",
+                "visual": "八张行星卡片，每张标注名称。",
+            }
+        )
+    outline_path.write_text(json.dumps(outline, ensure_ascii=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT，八大行星能转起来并看清大小和远近。".encode()
+    ).decode()
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert deck["interaction_contract"] == {
+        "mode": "solar_orbit",
+        "target_slide_id": "slide-02",
+        "required": True,
+    }
+    assert [slide["source_outline_page"] for slide in deck["slides"]] == [1, 2, 3, 3]
 
 
 def test_scaffold_renders_explicit_360_interaction_with_source_visual(

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -5992,6 +5992,72 @@ def test_scaffold_and_runtime_preserve_explicit_solar_orbit_interaction(
     }
 
 
+def test_solar_interaction_owns_eight_planet_cardinality_without_outline_split(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    outline_path = output / "outline.json"
+    outline = _write_outline(
+        outline_path,
+        page_count=1,
+        source_mode="user_provided",
+    )
+    outline["slides"][0].update(
+        {
+            "title": "太阳系有八位行星朋友",
+            "message": "观察八大行星的大小和离太阳远近。",
+            "layout": "行星卡片",
+            "visual": "八个可爱行星徽章按顺序排列成两排。",
+            "bullets": ["记住顺序", "比较大小", "观察距离"],
+        }
+    )
+    outline_path.write_text(
+        json.dumps(outline, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["BOX_AGENT_OUTPUT_DIR"] = str(output)
+    env["BOX_AGENT_SOURCE_TEXT_B64"] = base64.b64encode(
+        "请制作一份PPT，八大行星能转起来、能看清谁大谁小和离太阳远近。".encode()
+    ).decode()
+
+    scaffold = _run(
+        "inspect_deck_contract.js",
+        "cards-grid-v1",
+        "--outline",
+        "outline.json",
+        "--out",
+        "deck.json",
+        cwd=output,
+        env=env,
+    )
+
+    assert scaffold.returncode == 0, scaffold.stdout + scaffold.stderr
+    deck = json.loads((output / "deck.json").read_text(encoding="utf-8"))
+    assert len(deck["slides"]) == 1
+    assert deck["slides"][0]["layout_id"] == "cards-grid-v1"
+    assert "source_outline_item_range" not in deck["slides"][0]
+    assert deck["interaction_contract"] == {
+        "mode": "solar_orbit",
+        "target_slide_id": "slide-01",
+        "required": True,
+    }
+
+    rendered = _run(
+        "render_deck_html.js",
+        "deck.json",
+        "--out",
+        "index.html",
+        cwd=output,
+        env=env,
+    )
+    assert rendered.returncode == 0, rendered.stdout + rendered.stderr
+    assert (output / "index.html").read_text(encoding="utf-8").count(
+        'class="deck-planet"'
+    ) == 8
+
+
 def test_scaffold_renders_explicit_360_interaction_with_source_visual(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_session_integration.py
+++ b/tests/test_session_integration.py
@@ -2,6 +2,7 @@
 Session integration tests - Testing multi-turn conversations and session management
 """
 
+import base64
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -77,6 +78,27 @@ def test_multi_turn_conversation(mock_llm_client, temp_workspace):
     assert len(user_messages) == 2
     assert user_messages[0].content == "Hello"
     assert user_messages[1].content == "Help me create a file"
+
+
+def test_user_source_binding_accumulates_and_updates_bash_env(
+    mock_llm_client,
+    temp_workspace,
+):
+    bash = BashTool(workspace_dir=temp_workspace)
+    agent = Agent(
+        llm_client=mock_llm_client,
+        system_prompt="System",
+        tools=[bash],
+        workspace_dir=temp_workspace,
+    )
+
+    assert agent.bind_user_source_text("原始事实 A") == "原始事实 A"
+    assert agent.bind_user_source_text("补充事实 B") == "原始事实 A\n\n补充事实 B"
+
+    source_text = base64.b64decode(
+        bash._subprocess_env["BOX_AGENT_SOURCE_TEXT_B64"]
+    ).decode("utf-8")
+    assert source_text == "原始事实 A\n\n补充事实 B"
 
 
 def test_session_history_management(mock_llm_client, temp_workspace):


### PR DESCRIPTION
## TPR

### Task

- What changed: The controlled PPTX Skill now preserves user-mentioned source images, represents requested `solar_orbit` and `spin_360` interactions as an optional deck contract, renders and probes those interactions, binds original user text consistently across CLI and ACP, and recovers bounded visual-cardinality and text-contract mismatches.
- Why: Source media and interaction requirements could be lost between the real user turn, deck scaffolding, and HTML rendering. Existing deterministic cardinality handling could also misread time or ordinal expressions and fail late when layout or text limits disagreed.
- Affected entry points: Shared `Agent` source binding, thin CLI/ACP user-turn adapters, controlled PPTX scaffold/validation/patch/render/runtime-probe scripts, and the built-in Skill manifest.
- Out of scope: Prompt routing and mode detection; research/evidence workflows; model/provider parameters and retries; malformed model JSON recovery; permission/security policy; image-provider behavior; native 3D asset generation; OfficeV3 installation or live-host validation.

### Proof

- Tests or checks run:
  - `git diff --check upstream/main...HEAD` — passed.
  - `uv run pytest tests/test_pptx_controlled_deck.py tests/test_cli_runtime.py tests/test_session_integration.py tests/test_acp.py -q` — 481 passed in 221.40s.
  - `bash general_review/ci/preflight.sh` — passed: compile succeeded; 3,216 passed, 19 skipped, 1 deselected in 317.33s; source and wheel distributions built successfully.
- Logs, screenshots, probes, or manifests:
  - `uv run python scripts/generate_skills_manifest.py` regenerated 36 built-in Skill entries; the only resulting diff was the expected `generated_at` timestamp, confirming the committed Skill hashes and entries are current.
  - Runtime regression coverage verifies interaction initialization, exactly eight rendered planets, exactly one rotatable visual, source-image binding, cardinality recovery, target-slide selection, and bounded text repair.
- Not run, with reason:
  - No packaged runtime installation, host restart, or fresh OfficeV3 live task was performed; validation stops at source tests and successful package build.
  - No manual visual QA screenshot/contact sheet was produced in this PR validation pass; rendering behavior is covered by controlled-deck and runtime-probe tests.

### Risk

- Compatibility: `interaction_contract` is optional and additive. Existing decks without it retain their current schema and rendering behavior. CLI and ACP call the same shared source-binding method; no ACP protocol field changes.
- Packaging/runtime impact: The source and wheel build passed, but the built runtime was not installed or probed in OfficeV3. HTML interactions require JavaScript and do not remain interactive in static PDF or ordinary PPTX exports.
- Config, secrets, or migration: No configuration, secret, or migration changes. `BOX_AGENT_SOURCE_TEXT_B64` is transport encoding, not encryption; retained source text is capped at 120,000 characters.
- Rollback: Revert the four commits in reverse order. Decks without the optional interaction contract are unaffected.
- Cross-repository follow-up: OfficeV3 attachment flows still need exact attachment paths preserved in source context; that host/media concern is intentionally isolated from this PR. A live OfficeV3 rebuild/install/restart/probe remains follow-up work.

### Design and architecture impact

- Affected layers and owners: Shared source binding lives on `Agent`; CLI and ACP only bind real user turns. Presentation-specific inference, schema validation, rendering, and runtime probing remain in the PPTX Skill.
- Contract, schema, or protocol impact: Adds an optional deck-level `interaction_contract` with `mode`, `target_slide_id`, and `required`. Supported modes are `solar_orbit` and `spin_360`. No public CLI or ACP protocol changes.
- Documentation updated: No standalone user documentation change. The behavior and limits are encoded in the controlled-deck contract, runtime implementation, and direct regression tests.

### Target branch consistency

- Base branch and reviewed Head SHA: `upstream/main` at `e4167a98734ec2abf466510ad94f414dc2b17113`; reviewed head `d994e82decbd27fca09cf2bc61e197bb498c765b`.
- Relevant target-branch changes considered: A final `git fetch upstream main` confirmed the branch is four commits ahead and zero commits behind; its merge base equals the current `upstream/main`.
- Rebase, compatibility, or historical-fix risk: The branch was built independently from the current base and does not merge `main`. It refines the existing PPTX cardinality contract rather than replacing it.

## Commit details

### 1. `cc8f696` — `fix(pptx): preserve source media and requested interactions`

Previously:

- Image paths mentioned by the user could be ignored and replaced with generated placeholders.
- Requests such as “八大行星转起来” or “城堡可以 360 度旋转” could remain prose in the outline while the rendered deck stayed static.

Now:

- Explicit PNG/JPG/JPEG/WebP paths are discovered from the bound original user text.
- Source images are copied into `assets/source/`, hashed, and bound to compatible `use_existing` media slots. Unused images are reported under `source_assets.unbound`.
- A validated optional `interaction_contract` supports `solar_orbit` and `spin_360`.
- The HTML renderer conditionally adds the interaction CSS/JavaScript runtime.
- Runtime QA checks initialization, eight rendered planets, and one rotatable visual.

Limitations:

- `spin_360` rotates one flat image around its Y-axis; it is not a generated multi-angle 3D model.
- Interactions are HTML runtime behavior and do not survive static PDF or ordinary PPTX export.

Main files:

- `box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js`
- `box_agent/skills/document-skills/pptx/scripts/deck_spec_core.js`
- `box_agent/skills/document-skills/pptx/scripts/render_deck_html.js`
- `box_agent/skills/document-skills/pptx/scripts/probe_deck_runtime.js`
- `box_agent/skills/document-skills/pptx/runtime/interaction-runtime.css`
- `box_agent/skills/document-skills/pptx/runtime/interaction-runtime.js`

### 2. `3667201` — `fix(pptx): bind source interaction contracts`

Previously:

- PPTX scripts read provenance and interaction requirements from `BOX_AGENT_SOURCE_TEXT_B64`.
- ACP populated equivalent source context independently, while CLI/TUI did not consistently expose real user turns to the Skill scripts.

Now:

- `Agent.bind_user_source_text()` owns the shared behavior.
- Real user turns accumulate across the session, internal continuation prompts are excluded, and retained text is capped at 120,000 characters.
- The shared method Base64-encodes the exact text and updates the Bash tool runtime environment.
- CLI and ACP are thin callers of the same method.
- The interaction contract owns the eight-planet cardinality on its target page, preventing unnecessary outline splitting.

Main files:

- `box_agent/agent.py`
- `box_agent/cli.py`
- `box_agent/acp/__init__.py`
- `box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js`

### 3. `967e2de` — `fix(pptx): recover visual cardinality conflicts`

The original PPTX Skill already parsed expressions such as “八张卡片” and compared the requested count with layout capacity. This commit makes that existing deterministic contract less error-prone.

Previously:

- Broad count matching could interpret time or ordinal expressions as visual-item counts.
- Nearby words could produce an ambiguous dimension instead of using the matched unit.
- Oversized visual collections could only be split when the outline contained exactly one bullet per requested item.
- A generic cover could be selected instead of the detailed interaction page.

Now:

- Ordinal and time expressions are excluded from visual-cardinality matching.
- The matched unit determines dimensions such as cards, rows, columns, nodes, metrics, stages, or zones.
- Oversized collections are split deterministically even when bullets summarize the page rather than map one-to-one to visual items.
- Eight animated planets are treated as the interaction’s own cardinality rather than eight layout cards.
- Target-slide scoring prefers the explicit eight-planet content page over a cover.

Main files:

- `box_agent/skills/document-skills/pptx/scripts/design_contract_core.js`
- `box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js`

### 4. `d994e82` — `fix(pptx): recover bounded deck contract mismatches`

Previously:

- An outline could pass validation and then fail while scaffolding `deck.json` because outline and deck validators enforced limits at different stages.
- A valid batch patch could fail the entire mutation when nested text exceeded a field’s declared maximum.
- A generic castle cover could win over an explicit draggable 360-degree content page.

Now:

- Outline and deck validation share limits for title (120), message (500), layout (120), and visual (300).
- Overlong outlines fail early with a precise field error.
- Batch patching deterministically compacts overlong text to the field contract and records the normalization.
- `spin_360` target scoring prefers explicit 360-degree, draggable, 3D/model content and penalizes covers.

Main files:

- `box_agent/skills/document-skills/pptx/scripts/validate_outline.js`
- `box_agent/skills/document-skills/pptx/scripts/deck_spec_core.js`
- `box_agent/skills/document-skills/pptx/scripts/apply_deck_patch.js`
- `box_agent/skills/document-skills/pptx/scripts/inspect_deck_contract.js`

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [x] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior, or the missing coverage is explained.
- [x] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes. No standalone documentation change is included; this is disclosed above.
- [x] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [x] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [x] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [x] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [x] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` is pending because the PR has not yet been opened; the repository preflight passed locally on the reviewed Head SHA.
