### PR TITLE
fix(llm): omit unsupported disabled reasoning effort

### DIFF
--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -42,7 +42,6 @@ _DEFAULT_SENSENOVA_MODEL_PREFIXES = ("sensenova-", "sn-sensenova-")
 _SENSENOVA_MODEL_PREFIXES_ENV = "BOX_AGENT_SENSENOVA_MODEL_PREFIXES"
 _SENSENOVA_PREFIX_BOUNDARIES = frozenset("-_/:.")
 _GLM_5_3_MODEL_MARKERS = ("glm-5-3", "glm-5.3")
-_GEMINI_NO_DISABLE_MARKERS = ("gemini-2.5-pro", "gemini-3.1-pro")
 _SENSENOVA_PSEUDO_TOOL_CALL_RE = re.compile(
     r"<tool_call>\s*<function=([A-Za-z_][\w.-]*)>\s*(.*?)\s*</function>\s*</tool_call>",
     re.DOTALL,
@@ -116,17 +115,8 @@ def _apply_thinking_params(
     if "qwen" in normalized_model:
         params["extra_body"] = {"enable_thinking": thinking_enabled}
         return
-    if "gemini" in normalized_model:
-        if thinking_enabled:
-            params["reasoning_effort"] = _DEEP_THINK_REASONING_EFFORT
-        elif not any(marker in normalized_model for marker in _GEMINI_NO_DISABLE_MARKERS):
-            params["reasoning_effort"] = "none"
-        return
     if thinking_enabled:
         params["reasoning_effort"] = _DEEP_THINK_REASONING_EFFORT
-        return
-    if _is_sensenova_model(model):
-        params["reasoning_effort"] = "none"
 
 
 def _tool_parameter_types(

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -124,9 +124,9 @@ async def test_openai_request_sends_high_reasoning_effort_when_enabled(monkeypat
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("thinking_enabled", "expected_effort"),
-    [(True, "high"), (False, "none")],
+    [(True, "high"), (False, None)],
 )
-async def test_sensenova_request_sends_top_level_reasoning_effort(
+async def test_sensenova_request_only_sends_reasoning_effort_when_enabled(
     thinking_enabled,
     expected_effort,
     monkeypatch,
@@ -155,7 +155,10 @@ async def test_sensenova_request_sends_top_level_reasoning_effort(
     )
 
     assert "extra_body" not in captured
-    assert captured["reasoning_effort"] == expected_effort
+    if expected_effort is None:
+        assert "reasoning_effort" not in captured
+    else:
+        assert captured["reasoning_effort"] == expected_effort
 
 
 @pytest.mark.asyncio
@@ -193,7 +196,7 @@ async def test_openai_request_no_extra_body_by_default(monkeypatch):
     [
         ("gpt-5", True, None, "high"),
         ("custom-chat-model", False, None, None),
-        ("SenseNova-Flash-Lite-test", False, None, "none"),
+        ("SenseNova-Flash-Lite-test", False, None, None),
         ("SenseNova-Flash-Lite-test", True, None, "high"),
         ("SN-SenseNova-6-8-Flash-Lite", True, None, "high"),
         (
@@ -210,7 +213,7 @@ async def test_openai_request_no_extra_body_by_default(monkeypatch):
         ),
         ("QWEN3-235B", True, {"enable_thinking": True}, None),
         ("vendor/qwen3-coder", False, {"enable_thinking": False}, None),
-        ("Gemini-2.5-Flash", False, None, "none"),
+        ("Gemini-2.5-Flash", False, None, None),
         ("Gemini-2.5-Pro", False, None, None),
         ("GEMINI-3.1-PRO-preview", False, None, None),
         ("gemini-3-flash", True, None, "high"),
@@ -620,9 +623,9 @@ async def test_generic_openai_stream_does_not_execute_tool_markup_from_thinking(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("thinking_enabled", "expected_effort"),
-    [(True, "high"), (False, "none")],
+    [(True, "high"), (False, None)],
 )
-async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
+async def test_sensenova_sdk_only_sends_reasoning_effort_when_enabled(
     thinking_enabled,
     expected_effort,
 ):
@@ -678,7 +681,10 @@ async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
 
     assert "extra_body" not in captured
     assert "chat_template_kwargs" not in captured
-    assert captured["reasoning_effort"] == expected_effort
+    if expected_effort is None:
+        assert "reasoning_effort" not in captured
+    else:
+        assert captured["reasoning_effort"] == expected_effort
 
 
 @pytest.mark.asyncio
@@ -692,7 +698,7 @@ async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
         ("raccoon-405a1c", True, {"reasoning_effort": "high"}),
         ("raccoon-405a1c", False, {}),
         ("sn-sensenova-6-8-flash-lite", True, {"reasoning_effort": "high"}),
-        ("sn-sensenova-6-8-flash-lite", False, {"reasoning_effort": "none"}),
+        ("sn-sensenova-6-8-flash-lite", False, {}),
         ("sn-glm-5-2", True, {"reasoning_effort": "high"}),
         ("sn-glm-5-2", False, {}),
         ("sn-glm-5-3", True, {"reasoning_effort": "high"}),
@@ -712,7 +718,7 @@ async def test_sensenova_sdk_sends_reasoning_effort_in_wire_body(
         ("QWEN3-235B", True, {"enable_thinking": True}),
         ("vendor/qwen3-coder", False, {"enable_thinking": False}),
         ("Gemini-2.5-Flash", True, {"reasoning_effort": "high"}),
-        ("Gemini-2.5-Flash", False, {"reasoning_effort": "none"}),
+        ("Gemini-2.5-Flash", False, {}),
         ("gemini-2.5-pro-preview", False, {}),
         ("GEMINI-3.1-PRO", False, {}),
         (


### PR DESCRIPTION
## TPR

### Task

- What changed: omit unsupported disabled `reasoning_effort` values for SenseNova and Gemini; retain explicit provider controls, including GLM 5.3 `low`/`high` semantics.
- Why: SenseNova rejects `reasoning_effort=none` with HTTP 422. Disabled generic reasoning should be expressed by omitting the optional field; GLM 5.3 remains an explicit exception because that model requires reasoning and supports `low`/`high`.
- Affected entry points: OpenAI-compatible streaming and non-streaming requests, including `web_extract` LLM summaries.
- Out of scope: existing Qwen, DeepSeek, Doubao, and GLM 5.3 provider-specific thinking controls; web extraction schema changes; runtime deployment.

### Proof

- Tests or checks run: `uv run --python 3.12 pytest tests/test_thinking.py tests/test_web_extract.py tests/test_mcp.py tests/test_sub_agent_tool.py -q --tb=short` (`219 passed, 3 skipped`).
- Logs, screenshots, probes, or manifests: `bash general_review/ci/preflight.sh` (`3005 passed, 17 skipped, 1 deselected`; sdist and wheel built successfully). Wire-body tests assert the field is absent when disabled.
- Not run, with reason: no live provider or officev3 task was run because this PR validates source behavior and does not deploy a runtime.

### Risk

- Compatibility: providers now use their default behavior when generic `reasoning_effort` is disabled; explicit enable behavior is unchanged. Existing Qwen/DeepSeek/Doubao controls and GLM 5.3 `low`/`high` semantics are unchanged.
- Packaging/runtime impact: source and packages build successfully; no runtime was installed, restarted, or live-probed.
- Config, secrets, or migration: none.
- Rollback: revert this commit to restore explicit disabled values.
- Cross-repository follow-up: rebuild/reinstall the consuming officev3 runtime before live verification.

### Design and architecture impact

- Affected layers and owners: provider wire translation in `box_agent/llm/openai_client.py` only.
- Contract, schema, or protocol impact: no public schema change; unsupported optional wire fields are omitted.
- Documentation updated: not required for this compatibility fix.

### Target branch consistency

- Base branch and reviewed Head SHA: `origin/main` at `7fc40296d80a6b9bc9a44349211470a08334999e`; change commit `091cf262efce973a3dde4945589fc8229e766048`.
- Relevant target-branch changes considered: PR #80 originally omitted disabled thinking parameters; `d4efd210` introduced `reasoning_effort=none`; `248a2cc` and `a881c92` added and refined the GLM 5.3 `low`/`high` exception, which this PR preserves.
- Rebase, compatibility, or historical-fix risk: branch rebased onto the latest fetched `origin/main`; conflicts were resolved by preserving the newer GLM 5.3 mapping; no merge commit.

## Checklist

- [x] This PR has one clear behavior or subsystem scope.
- [x] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [x] Shared behavior is implemented in shared provider logic, not duplicated across CLI and ACP.
- [x] Focused tests cover the changed behavior.
- [x] The full local preflight suite and package build passed.
- [x] Documentation impact was assessed; no user-facing documentation change is needed.
- [x] No built-in skills changed.
- [x] Packaged runtime status is stated above.
- [x] No local config, logs, workspace files, or generated graph/cache files are included.
- [x] This branch is based on the latest fetched base `main`; `main` was not merged.
- [x] Design and target-branch consistency evidence is included above.
- [x] `teamwork/local-ci` equivalent preflight passed for the committed source state.
