### PR TITLE
fix（ui） ：去掉生成受控ppt页面的左右按钮，使导出按钮可见

### DIFF
--- a/box_agent/skills/document-skills/pptx/runtime/deck.css
+++ b/box_agent/skills/document-skills/pptx/runtime/deck.css
@@ -7813,12 +7813,6 @@ body.deck-thumbnails-visible .deck-thumbnails {
   background: #3D3D3D;
 }
 
-.deck-toolbar .toolbar-nav {
-  width: 44px;
-  padding: 0;
-  font-size: 20px;
-}
-
 .deck-toolbar .toolbar-icon {
   width: 44px;
   padding: 0;

--- a/box_agent/skills/document-skills/pptx/scripts/render_deck_html.js
+++ b/box_agent/skills/document-skills/pptx/scripts/render_deck_html.js
@@ -188,14 +188,12 @@ function renderThumbnailNavigation() {
 function renderToolbar() {
   return [
     '<nav class="deck-toolbar" aria-label="Deck editor">',
-    '  <button type="button" class="toolbar-nav" data-action="previous" aria-label="上一页" title="上一页">←</button>',
     '  <div class="toolbar-location" aria-live="polite" aria-atomic="true">',
     '    <span class="toolbar-current-label">当前页</span>',
     '    <strong class="toolbar-current-page" data-role="current-page">01</strong>',
     '    <span class="toolbar-total"><span class="toolbar-total-separator" aria-hidden="true">/</span><span class="toolbar-total-prefix"> 共 </span><span data-role="total-pages">01</span><span class="toolbar-total-suffix"> 页</span></span>',
     '    <span class="toolbar-current-title" data-role="current-title">未命名页面</span>',
     '  </div>',
-    '  <button type="button" class="toolbar-nav" data-action="next" aria-label="下一页" title="下一页">→</button>',
     '  <span class="toolbar-divider" aria-hidden="true"></span>',
     '  <button type="button" class="toolbar-edit" data-action="edit" aria-label="编辑" title="编辑内容" aria-pressed="false"><span class="toolbar-compact-symbol" aria-hidden="true">✎</span><span class="toolbar-action-label">编辑</span></button>',
     '  <div class="toolbar-popover" data-toolbar-menu="design">',

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -10628,6 +10628,10 @@ def test_example_validates_and_renders_deterministically(tmp_path: Path) -> None
     assert ">▶</button>" in html
     assert "▶ 播放" not in html
     assert 'data-action="export-pptx"' in html
+    assert 'class="toolbar-export"' in html
+    assert 'class="toolbar-nav"' not in html
+    assert 'data-action="previous"' not in html
+    assert 'data-action="next"' not in html
     assert 'data-role="thumbnail-list"' in html
     assert 'data-save-state="download"' in html
     assert 'id="deck-layout-picker"' in html


### PR DESCRIPTION
## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

### Design and architecture impact

- Affected layers and owners:
- Contract, schema, or protocol impact:
- Documentation updated:

### Target branch consistency

- Base branch and reviewed Head SHA:
- Relevant target-branch changes considered:
- Rebase, compatibility, or historical-fix risk:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [ ] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [ ] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` passed for the current Head SHA, or the missing status is explained.
