### PR TITLE
fix(workflows): allow Windows image status sync

### DIFF
--- a/box_agent/workflows/controlled_presentation.py
+++ b/box_agent/workflows/controlled_presentation.py
@@ -157,7 +157,16 @@ _REPAIR_STAGES: Final[frozenset[str]] = frozenset(
 )
 _POLICY_REJECTION_STAGES: Final[frozenset[str]] = (
     _REPAIR_STAGES
-    | frozenset({"research", "outline", "scaffold", "apply_patch", "apply_redesign"})
+    | frozenset(
+        {
+            "research",
+            "outline",
+            "scaffold",
+            "image_status_sync",
+            "apply_patch",
+            "apply_redesign",
+        }
+    )
 )
 _REPEATED_EXECUTION_FAILURE_LIMIT: Final[int] = 2
 _REPEATED_POLICY_REJECTION_LIMIT: Final[int] = 3
@@ -444,18 +453,54 @@ def _image_status_error(
     stage: str | None,
     tool_name: str,
     arguments: dict[str, Any],
+    workspace_dir: str | None,
+    artifact_root_dir: str | Path | None,
 ) -> str | None:
     if stage != "image_status_sync":
         return None
     command = arguments.get("command")
+    if tool_name != "bash" or not isinstance(command, str):
+        return _IMAGE_STATUS_TOOL_ERROR
+    if "\n" in command or "\r" in command:
+        return _IMAGE_STATUS_TOOL_ERROR
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return _IMAGE_STATUS_TOOL_ERROR
+
+    artifact_root = artifact_scan_root(workspace_dir, artifact_root_dir)
+    if artifact_root is None:
+        return _IMAGE_STATUS_TOOL_ERROR
+    artifact_root = artifact_root.resolve(strict=False)
+
+    if len(tokens) >= 3 and tokens[0] == "cd" and tokens[2] == "&&":
+        supplied_root = Path(tokens[1].replace("\\", "/")).expanduser()
+        if supplied_root.resolve(strict=False) != artifact_root:
+            return _IMAGE_STATUS_TOOL_ERROR
+        tokens = tokens[3:]
+
+    if len(tokens) != 3:
+        return _IMAGE_STATUS_TOOL_ERROR
+    node_token, script_token, manifest_token = tokens
+    node_name = Path(node_token.replace("\\", "/")).name.casefold()
+    if node_name not in {"node", "node.exe"} and "BOX_AGENT_NODE" not in node_token:
+        return _IMAGE_STATUS_TOOL_ERROR
+
+    script_path = Path(script_token.replace("\\", "/")).expanduser()
     if (
-        tool_name == "bash"
-        and isinstance(command, str)
-        and "sync_image_manifest_status.js" in command
-        and "assets/generated/manifest.json" in command
+        not script_path.is_absolute()
+        or script_path.resolve(strict=False)
+        != _SYNC_IMAGE_STATUS_SCRIPT.resolve(strict=False)
     ):
-        return None
-    return _IMAGE_STATUS_TOOL_ERROR
+        return _IMAGE_STATUS_TOOL_ERROR
+
+    manifest_path = Path(manifest_token.replace("\\", "/")).expanduser()
+    if not manifest_path.is_absolute():
+        manifest_path = artifact_root / manifest_path
+    expected_manifest = artifact_root / "assets" / "generated" / "manifest.json"
+    if manifest_path.resolve(strict=False) != expected_manifest.resolve(strict=False):
+        return _IMAGE_STATUS_TOOL_ERROR
+    return None
 
 
 def _finalize_error(
@@ -3252,7 +3297,13 @@ class ControlledPresentationPolicy:
             )
         ):
             return _REDESIGN_REPAIR_TOOL_ERROR
-        image_status_error = _image_status_error(self.stage, tool_name, arguments)
+        image_status_error = _image_status_error(
+            self.stage,
+            tool_name,
+            arguments,
+            self.workspace_dir,
+            self.artifact_root_dir,
+        )
         if image_status_error is not None:
             return image_status_error
         apply_patch_error = _apply_patch_error(

--- a/tests/test_completion_gate.py
+++ b/tests/test_completion_gate.py
@@ -81,6 +81,7 @@ APPLY_PATCH_SCRIPT = FINALIZER_SCRIPT.parent / "apply_deck_patch.js"
 APPLY_REDESIGN_SCRIPT = FINALIZER_SCRIPT.parent / "apply_deck_redesign.js"
 VALIDATE_OUTLINE_SCRIPT = FINALIZER_SCRIPT.parent / "validate_outline.js"
 REBASE_IMAGE_POLICY_SCRIPT = FINALIZER_SCRIPT.parent / "rebase_image_policy.js"
+SYNC_IMAGE_STATUS_SCRIPT = FINALIZER_SCRIPT.parent / "sync_image_manifest_status.js"
 
 
 def _write_valid_research_report(
@@ -6003,6 +6004,88 @@ async def test_controlled_image_status_sync_blocks_manual_manifest_edit(tmp_path
     assert "CONTROLLED_PRESENTATION_IMAGE_STATUS_SYNC_REQUIRED" in (
         blocked.error or ""
     )
+
+
+def test_controlled_image_status_sync_allows_windows_separator_command(tmp_path):
+    output = tmp_path / "output"
+    manifest = output / "assets" / "generated" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"image_plan":[]}', encoding="utf-8")
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=output,
+        research_mode="content_ready",
+        stage="image_status_sync",
+    )
+
+    def windows_path(path: Path) -> str:
+        return str(path).replace("/", "\\")
+
+    command = (
+        f"cd {shlex.quote(windows_path(output))} && node "
+        f"{shlex.quote(windows_path(SYNC_IMAGE_STATUS_SCRIPT))} "
+        f"{shlex.quote(windows_path(manifest))}"
+    )
+
+    assert policy.tool_call_error(
+        "bash",
+        {"command": command},
+        verified_evidence_urls=set(),
+    ) is None
+    assert policy.tool_call_error(
+        "bash",
+        {"command": f"{command} && echo bypass"},
+        verified_evidence_urls=set(),
+    ) is not None
+
+
+def test_controlled_image_status_sync_allows_its_deterministic_action(tmp_path):
+    output = tmp_path / "output"
+    manifest = output / "assets" / "generated" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"image_plan":[]}', encoding="utf-8")
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=output,
+        research_mode="content_ready",
+        stage="image_status_sync",
+    )
+
+    action = policy.next_deterministic_action()
+
+    assert action is not None
+    assert action.capability == "controlled_presentation.image_status_sync"
+    assert policy.tool_call_error(
+        action.tool_name,
+        action.arguments,
+        verified_evidence_urls=set(),
+    ) is None
+
+
+def test_controlled_image_status_policy_rejections_trip_repair_fuse(tmp_path):
+    policy = ControlledPresentationPolicy(
+        workspace_dir=str(tmp_path),
+        artifact_root_dir=tmp_path / "output",
+        research_mode="content_ready",
+        stage="image_status_sync",
+    )
+
+    for decision_id in range(1, 4):
+        policy.begin_tool_decision(decision_id)
+        blocked = policy.tool_call_error(
+            "read_file",
+            {"path": "assets/generated/manifest.json"},
+            verified_evidence_urls=set(),
+        )
+        assert blocked is not None
+        policy.record_tool_result(
+            "read_file",
+            {"path": "assets/generated/manifest.json"},
+            ToolResult(success=False, error=blocked),
+            executed=False,
+        )
+
+    assert policy.repair_stalled is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TPR

### Task

- What changed:
- Why:
- Affected entry points:
- Out of scope:

### Proof

- Tests or checks run:
- Logs, screenshots, probes, or manifests:
- Not run, with reason:

### Risk

- Compatibility:
- Packaging/runtime impact:
- Config, secrets, or migration:
- Rollback:
- Cross-repository follow-up:

### Design and architecture impact

- Affected layers and owners:
- Contract, schema, or protocol impact:
- Documentation updated:

### Target branch consistency

- Base branch and reviewed Head SHA:
- Relevant target-branch changes considered:
- Rebase, compatibility, or historical-fix risk:

## Checklist

- [ ] This PR has one clear behavior or subsystem scope.
- [ ] Code path and ownership were verified from source; `.understand-anything` was used as an index when available.
- [ ] Shared behavior is implemented in shared core logic, not duplicated across CLI and ACP.
- [ ] Focused tests cover the changed behavior, or the missing coverage is explained.
- [ ] Broader tests were run for shared core, tools, MCP, memory, CLI, ACP, skills, or packaging changes.
- [ ] Documentation was updated for user-facing or contributor-facing changes.
- [ ] Built-in skill changes regenerated `box_agent/skills/_manifest.json`.
- [ ] Packaged runtime impact is stated, including whether rebuild/install/probe was done.
- [ ] No local config, logs, workspace files, or generated `.understand-anything` graph/cache files are included.
- [ ] This branch was rebased onto the latest base `main` before this PR was opened or updated; `main` was not merged into the feature branch.
- [ ] Design and target-branch consistency evidence is included above.
- [ ] `teamwork/local-ci` passed for the current Head SHA, or the missing status is explained.
