### PR TITLE
fix(mcp): 兼容模型侧工具名称限制

### DIFF
--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -5,6 +5,7 @@ import hashlib
 import inspect
 import json
 import os
+import re
 import sys
 import tempfile
 import time
@@ -68,9 +69,30 @@ from .mcp_tool_catalog import get_mcp_tool_catalog
 from .model_tool_context import current_model_tool_context
 
 
+_MODEL_TOOL_NAME_MAX_LENGTH = 64
+_INVALID_MODEL_TOOL_NAME_CHARACTER = re.compile(r"[^a-zA-Z0-9_-]")
+
+
 def _warn(msg: str) -> None:
     """Write diagnostic message to stderr (never stdout)."""
     sys.stderr.write(msg + "\n")
+
+
+def _public_mcp_tool_name(server_name: str, remote_name: str) -> str:
+    """Return a stable provider-safe name while preserving the MCP name separately."""
+    mapped_name = public_browser_tool_name(server_name, remote_name)
+    if (
+        len(mapped_name) <= _MODEL_TOOL_NAME_MAX_LENGTH
+        and not _INVALID_MODEL_TOOL_NAME_CHARACTER.search(mapped_name)
+    ):
+        return mapped_name
+
+    digest = hashlib.sha256(
+        f"{server_name}\0{remote_name}".encode("utf-8")
+    ).hexdigest()[:12]
+    safe_stem = _INVALID_MODEL_TOOL_NAME_CHARACTER.sub("_", mapped_name)
+    safe_stem = safe_stem[: _MODEL_TOOL_NAME_MAX_LENGTH - len(digest) - 2]
+    return f"{safe_stem}__{digest}"
 
 
 def _replace_server_catalog(connection: "MCPServerConnection") -> None:
@@ -611,7 +633,7 @@ class MCPServerConnection:
             execute_timeout = self._get_execute_timeout()
             for tool in tools_list.tools:
                 parameters = tool.inputSchema if hasattr(tool, "inputSchema") else {}
-                public_name = public_browser_tool_name(self.name, tool.name)
+                public_name = _public_mcp_tool_name(self.name, tool.name)
                 fixed_arguments = browser_tool_fixed_arguments(self.name, parameters)
                 parameters = public_browser_tool_parameters(parameters, fixed_arguments)
                 mcp_tool = MCPTool(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -26,6 +26,7 @@ from box_agent.tools.mcp_loader import (
     MCPTimeoutConfig,
     WEB_SEARCH_MCP_MAX_CONCURRENCY,
     _determine_connection_type,
+    _public_mcp_tool_name,
     cleanup_mcp_connections,
     get_mcp_timeout_config,
     load_mcp_tools_async,
@@ -46,6 +47,55 @@ from box_agent.tools.base import Tool, ToolResult
 def test_streamable_http_client_is_available():
     """The loader resolves the client exported by the installed MCP SDK."""
     assert callable(mcp_loader.streamable_http_client)
+
+
+def test_public_mcp_tool_name_sanitizes_provider_invalid_remote_name():
+    remote_name = "mcp-law-search-service.search_article"
+
+    public_name = _public_mcp_tool_name("pkulaw", remote_name)
+
+    assert public_name.startswith("mcp-law-search-service_search_article__")
+    assert len(public_name) <= 64
+    assert all(
+        character.isascii() and (character.isalnum() or character in "_-")
+        for character in public_name
+    )
+    assert public_name == _public_mcp_tool_name("pkulaw", remote_name)
+    assert _public_mcp_tool_name("pkulaw", "search_law") == "search_law"
+
+
+def test_public_mcp_tool_name_avoids_sanitized_name_collisions():
+    dotted = _public_mcp_tool_name("pkulaw", "law.search")
+    slashed = _public_mcp_tool_name("pkulaw", "law/search")
+
+    assert dotted != slashed
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_uses_public_name_for_model_and_remote_name_for_execution():
+    class FakeSession:
+        called_name = None
+
+        async def call_tool(self, name, arguments):
+            self.called_name = name
+            return SimpleNamespace(content=[], isError=False)
+
+    session = FakeSession()
+    remote_name = "mcp-law-search-service.search_article"
+    tool = MCPTool(
+        name=_public_mcp_tool_name("pkulaw", remote_name),
+        remote_name=remote_name,
+        description="search law",
+        parameters={"type": "object"},
+        session=session,
+        server_name="pkulaw",
+    )
+
+    result = await tool.execute(query="民法典")
+
+    assert result.success is True
+    assert "." not in tool.name
+    assert session.called_name == remote_name
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TPR

### Task

- What changed: 统一转换不符合模型限制的 MCP 工具名，同时保留原始名称用于实际调用。
- Why: 北大法宝工具名包含点号，回放调用历史时被模型网关以 400 拒绝。
- Affected entry points: Box-Agent MCP 工具加载与模型调用。
- Out of scope: 不修改 MCP 配置、认证、服务端及 Officev3。

### Proof

- Tests or checks run: 新增用例 3 passed。
- Logs, screenshots, probes, or manifests: 北大法宝工具调用成功，后续模型请求正常完成，未再出现 `input[*].name` 400。
- Not run, with reason: 未执行打包验证，本次仅修改 Box-Agent 源码。

### Risk

- Compatibility: 合法工具名保持不变；原始 MCP 名称仍用于远程调用。
- Packaging/runtime impact: 后续需要更新 Officev3 内置 Box-Agent runtime。
- Config, secrets, or migration: 无。
- Rollback: Revert `755cf42`。
- Cross-repository follow-up: Officev3 发版时更新 runtime。

### Target branch consistency

- Base branch and reviewed Head SHA: `main@f60267a` → `755cf42`
- Relevant target-branch changes considered: 已基于最新 `main`。
- Rebase, compatibility, or historical-fix risk: rebase 无冲突，未合并 `main`。

## Checklist

- [x] Scope is clear.
- [x] Focused tests passed.
- [x] No config, secrets, logs, or generated files included.
- [x] Rebased onto latest `main`.
- [ ] `teamwork/local-ci` pending PR creation.