### PR TITLE
feat(packaging): 优化 Windows ACP 精简构建策略

### DIFF
--- a/docs/PRODUCTION_GUIDE.md
+++ b/docs/PRODUCTION_GUIDE.md
@@ -135,6 +135,15 @@ collection, and runtime-manifest helpers as the generic builder. This keeps the
 `web_extract` dispatch and `mcp_servers` declaration identical for
 `bin/box-agent-acp.exe`; do not add Windows-only copies of those contracts.
 
+The Windows-specific `scripts/build_win_runtime.py` defaults to a slim ACP build;
+`--bundled-python-sandbox` produces the full Python/Node/PortableGit bundle.
+`--exe-only` updates only `bin/`, the manifest, and version: it does not install
+stable runtimes. Its selected profile must match the existing manifests in both
+the output directory and any `--install-to` target. Full-bundle incremental builds
+still need `--bundled-python-sandbox`. A profile mismatch, missing manifest, or
+unknown profile is rejected before any build changes. To switch profiles, omit
+`--exe-only` and run a clean build, preferably in a separate output directory.
+
 #### Key Constraints
 
 | Channel | Content | Rule |

--- a/docs/PRODUCTION_GUIDE_CN.md
+++ b/docs/PRODUCTION_GUIDE_CN.md
@@ -96,6 +96,13 @@ Windows 专用构建器复用通用构建器的 PyInstaller hidden-import、coll
 runtime manifest helper，确保 `bin/box-agent-acp.exe` 的 `web_extract`
 dispatch 与 `mcp_servers` 声明一致；不要再维护 Windows 独立副本。
 
+Windows 专用脚本 `scripts/build_win_runtime.py` 默认构建精简 ACP；
+`--bundled-python-sandbox` 构建内含 Python/Node/PortableGit 的完整包。
+`--exe-only` 只更新 `bin/`、manifest 和版本，不安装三件套，因此所选模式必须与
+输出目录及 `--install-to` 目标的已有 manifest 一致。完整包增量重建仍需加
+`--bundled-python-sandbox`。跨模式、清单缺失或模式无法确定时会在任何构建修改前
+报错；需要切换模式时去掉 `--exe-only`，执行一次完整构建，建议使用独立输出目录。
+
 #### 从源码构建
 
 ```bash

--- a/scripts/build_win_runtime.py
+++ b/scripts/build_win_runtime.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
-"""Windows-only BoxAgent runtime builder with two stages.
+"""Windows-only BoxAgent runtime builder; ACP-only by default.
 
 Stages:
     bin/              ← PyInstaller-frozen BoxAgent (changes when source changes)
-    runtime/          ← PortableGit (bash) + python-build-standalone (python)
-    runtimes/         ← Node
+    runtime/          ← PortableGit + Python (only --bundled-python-sandbox)
+    runtimes/         ← Node (only --bundled-python-sandbox)
 
 `--exe-only` rebuilds **bin/ only**, leaving runtime/ and runtimes/ untouched.
 Use this when you change BoxAgent Python source but don't touch bash/node/python.
 
 Usage:
-    # Full build (PyInstaller + bash + python + node + tar.gz)
+    # Slim ACP build; analysis kernel and stable runtimes are provided by the host
     python scripts/build_win_runtime.py --version 0.8.40
+
+    # Legacy full bundle (PyInstaller + bash + python + node + tar.gz)
+    python scripts/build_win_runtime.py --version 0.8.40 --bundled-python-sandbox
 
     # Rebuild only the BoxAgent exe; keep existing runtime/ and runtimes/
     python scripts/build_win_runtime.py --version 0.8.40 --exe-only
@@ -136,26 +139,28 @@ def _rmtree_with_retry(
             time.sleep(delay_seconds * (attempt + 1))
 
 
-def _windows_pyinstaller_hidden_imports() -> list[str]:
+def _windows_pyinstaller_hidden_imports(*, external_python_sandbox: bool = True) -> list[str]:
     """Return the shared runtime hidden imports for the Windows build."""
     from scripts import build_runtime
 
     return build_runtime.pyinstaller_hidden_imports(
-        external_python_sandbox=False,
+        external_python_sandbox=external_python_sandbox,
     )
 
 
-def _windows_pyinstaller_collect_args() -> list[str]:
+def _windows_pyinstaller_collect_args(*, external_python_sandbox: bool = True) -> list[str]:
     """Return the shared runtime collect args for the Windows build."""
     from scripts import build_runtime
 
     return build_runtime.pyinstaller_collect_args(
-        external_python_sandbox=False,
+        external_python_sandbox=external_python_sandbox,
     )
 
 
-def _run_pyinstaller(bin_dir: Path) -> None:
+def _run_pyinstaller(bin_dir: Path, *, external_python_sandbox: bool = True) -> None:
     """Run PyInstaller and copy the output into ``bin_dir``."""
+    from scripts import build_runtime
+
     work_dir = bin_dir.parent.parent / "pyinstaller_work"
     dist_dir = bin_dir.parent.parent / "pyinstaller_out"
     spec_dir = bin_dir.parent.parent
@@ -175,11 +180,18 @@ def _run_pyinstaller(bin_dir: Path) -> None:
         if Path(src).exists():
             datas_args.extend(["--add-data", f"{src}{os.pathsep}{dst}"])
 
-    hidden_imports = _windows_pyinstaller_hidden_imports()
+    hidden_imports = _windows_pyinstaller_hidden_imports(
+        external_python_sandbox=external_python_sandbox
+    )
     hidden_args: list[str] = []
     for imp in hidden_imports:
         hidden_args.extend(["--hidden-import", imp])
-    collect_args = _windows_pyinstaller_collect_args()
+    collect_args = _windows_pyinstaller_collect_args(
+        external_python_sandbox=external_python_sandbox
+    )
+    exclude_args = build_runtime.pyinstaller_exclude_args(
+        external_python_sandbox=external_python_sandbox
+    )
 
     cmd = [
         sys.executable, "-m", "PyInstaller",
@@ -188,7 +200,7 @@ def _run_pyinstaller(bin_dir: Path) -> None:
         "--distpath", str(dist_dir),
         "--workpath", str(work_dir),
         "--specpath", str(spec_dir),
-        *datas_args, *hidden_args, *collect_args,
+        *datas_args, *hidden_args, *collect_args, *exclude_args,
         str(entry_point),
     ]
 
@@ -238,7 +250,9 @@ def _install_node_win(runtime_dir: Path) -> None:
     print(f"[win] Node runtime ready: {node_root}")
 
 
-def _write_manifest(runtime_dir: Path, version: str) -> None:
+def _write_manifest(
+    runtime_dir: Path, version: str, *, external_python_sandbox: bool = True
+) -> None:
     from scripts import build_runtime
 
     manifest = build_runtime.build_runtime_manifest(
@@ -246,11 +260,11 @@ def _write_manifest(runtime_dir: Path, version: str) -> None:
         plat="win32",
         arch="x64",
         entry_path="bin/box-agent-acp.exe",
-        external_python_sandbox=False,
+        external_python_sandbox=external_python_sandbox,
         bundled_components=build_runtime.bundled_stable_runtime_components(
             plat="win32",
             arch="x64",
-            external_python_sandbox=False,
+            external_python_sandbox=external_python_sandbox,
         ),
     )
     (runtime_dir / "manifest.json").write_text(
@@ -304,10 +318,14 @@ def main() -> None:
                         help="Only rebuild bin/ (PyInstaller). Keep existing runtime/ and runtimes/.")
     parser.add_argument("--no-tar", action="store_true",
                         help="Skip the tar.gz archive step (faster dev iteration).")
+    parser.add_argument("--bundled-python-sandbox", action="store_true",
+                        help="Legacy standalone bundle including Python analysis dependencies. "
+                             "By default Windows builds ACP only and uses the host's managed tools.")
     parser.add_argument("--install-to", default=None,
                         help="After build, copy artifacts to this path "
                              "(e.g. officev3 build-resources/box-agent-runtime).")
     args = parser.parse_args()
+    external_python_sandbox = not args.bundled_python_sandbox
 
     version = args.version or _read_version_from_package()
     output_dir = Path(args.output).resolve()
@@ -336,9 +354,9 @@ def main() -> None:
         bin_dir = runtime_dir / "bin"
         if bin_dir.exists():
             _rmtree_with_retry(bin_dir)
-        _run_pyinstaller(bin_dir)
+        _run_pyinstaller(bin_dir, external_python_sandbox=external_python_sandbox)
         # Manifest version bump so consumers see the new exe
-        _write_manifest(runtime_dir, version)
+        _write_manifest(runtime_dir, version, external_python_sandbox=external_python_sandbox)
     else:
         # Full clean build
         if runtime_dir.exists():
@@ -346,15 +364,16 @@ def main() -> None:
         runtime_dir.mkdir(parents=True)
         bin_dir = runtime_dir / "bin"
         bin_dir.mkdir()
-        _run_pyinstaller(bin_dir)
-        _write_manifest(runtime_dir, version)
+        _run_pyinstaller(bin_dir, external_python_sandbox=external_python_sandbox)
+        _write_manifest(runtime_dir, version, external_python_sandbox=external_python_sandbox)
         # bash + python + sandbox packages + node
-        _install_portable_git_win(runtime_dir)
-        _install_portable_python_win(runtime_dir)
-        python_exe = runtime_dir / "runtime" / "python" / "python.exe"
-        if python_exe.is_file():
-            _install_sandbox_packages_win(python_exe)
-        _install_node_win(runtime_dir)
+        if not external_python_sandbox:
+            _install_portable_git_win(runtime_dir)
+            _install_portable_python_win(runtime_dir)
+            python_exe = runtime_dir / "runtime" / "python" / "python.exe"
+            if python_exe.is_file():
+                _install_sandbox_packages_win(python_exe)
+            _install_node_win(runtime_dir)
 
     print(f"\n[win] Runtime tree assembled: {runtime_dir}")
 

--- a/scripts/build_win_runtime.py
+++ b/scripts/build_win_runtime.py
@@ -7,6 +7,8 @@ Stages:
     runtimes/         ← Node (only --bundled-python-sandbox)
 
 `--exe-only` rebuilds **bin/ only**, leaving runtime/ and runtimes/ untouched.
+The selected profile must match the existing output and --install-to manifests;
+switch profiles with a clean build (without --exe-only).
 Use this when you change BoxAgent Python source but don't touch bash/node/python.
 
 Usage:
@@ -273,6 +275,25 @@ def _write_manifest(
     (runtime_dir / "VERSION").write_text(version + "\n", encoding="utf-8")
 
 
+def _validate_exe_only_profile(runtime_dir: Path, *, external_python_sandbox: bool) -> None:
+    """Reject an in-place rebuild that would mislabel retained runtime files."""
+    rebuild_hint = "Run a clean build without --exe-only to create or switch profiles."
+    try:
+        manifest = json.loads((runtime_dir / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Cannot read runtime manifest at {runtime_dir}. {rebuild_hint}") from exc
+    existing = manifest.get("external_python_sandbox") if isinstance(manifest, dict) else None
+    if not isinstance(existing, bool):
+        raise ValueError(f"Cannot determine runtime profile at {runtime_dir}. {rebuild_hint}")
+    if existing != external_python_sandbox:
+        existing_name = "slim" if existing else "full"
+        requested_name = "slim" if external_python_sandbox else "full"
+        raise ValueError(
+            f"--exe-only profile mismatch at {runtime_dir}: existing {existing_name}, "
+            f"requested {requested_name}. {rebuild_hint}"
+        )
+
+
 def _create_tar(output_dir: Path, runtime_dir: Path, version: str) -> Path:
     archive_name = f"box-agent-runtime-v{version}-win32-x64.tar.gz"
     archive_path = output_dir / archive_name
@@ -315,7 +336,8 @@ def main() -> None:
     parser.add_argument("--output", default="dist/runtime",
                         help="Output directory (default: dist/runtime)")
     parser.add_argument("--exe-only", action="store_true",
-                        help="Only rebuild bin/ (PyInstaller). Keep existing runtime/ and runtimes/.")
+                        help="Only rebuild bin/ (PyInstaller), keeping the same slim/full profile "
+                             "and existing runtime/ and runtimes/ in output and --install-to.")
     parser.add_argument("--no-tar", action="store_true",
                         help="Skip the tar.gz archive step (faster dev iteration).")
     parser.add_argument("--bundled-python-sandbox", action="store_true",
@@ -329,8 +351,17 @@ def main() -> None:
 
     version = args.version or _read_version_from_package()
     output_dir = Path(args.output).resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
     runtime_dir = output_dir / "box-agent-runtime"
+    if args.exe_only:
+        try:
+            _validate_exe_only_profile(runtime_dir, external_python_sandbox=external_python_sandbox)
+            if args.install_to:
+                _validate_exe_only_profile(
+                    Path(args.install_to).resolve(), external_python_sandbox=external_python_sandbox
+                )
+        except ValueError as exc:
+            parser.error(str(exc))
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     print("\n[win] Installing runtime extras...")
     _install_runtime_extras()
@@ -342,14 +373,6 @@ def main() -> None:
     print(f"Mode: {'exe-only' if args.exe_only else 'full'}")
 
     if args.exe_only:
-        if not runtime_dir.exists():
-            print(
-                f"\nERROR: --exe-only requires an existing runtime at:\n  {runtime_dir}\n"
-                "Run a full build first (drop --exe-only) to bootstrap "
-                "runtime/ and runtimes/.",
-                file=sys.stderr,
-            )
-            sys.exit(3)
         # Wipe only bin/
         bin_dir = runtime_dir / "bin"
         if bin_dir.exists():

--- a/tests/pptx_test_support.py
+++ b/tests/pptx_test_support.py
@@ -1,0 +1,27 @@
+"""Optional host-runtime checks shared by PPTX integration test runners."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+def skip_unavailable_pptx_runtime(result: subprocess.CompletedProcess[str]) -> None:
+    """Skip missing host dependencies, not script, rendering, or QA failures."""
+    if result.returncode == 0:
+        return
+    output = result.stdout + result.stderr
+    unavailable = (
+        "Cannot find module 'playwright'",
+        "Missing dependency: playwright",
+        "Executable doesn't exist",
+        "Playwright Chromium is not available",
+    )
+    if any(marker in output for marker in unavailable):
+        pytest.skip("Managed Playwright browser is unavailable")
+    if any(marker in output for marker in (
+        "Cannot find module '@napi-rs/canvas'",
+        "Missing dependency: @napi-rs/canvas",
+    )):
+        pytest.skip("Managed Canvas dependency is unavailable")

--- a/tests/test_build_win_runtime.py
+++ b/tests/test_build_win_runtime.py
@@ -114,10 +114,15 @@ def test_windows_build_entry_preserves_selected_profile_and_existing_tools(
     python_exe = runtime_dir / "runtime" / "python" / "python.exe"
     old_node = runtime_dir / "runtimes" / "node" / "existing.txt"
     if exe_only:
-        python_exe.parent.mkdir(parents=True)
-        python_exe.write_bytes(b"existing python")
-        old_node.parent.mkdir(parents=True)
-        old_node.write_bytes(b"existing node")
+        runtime_dir.mkdir(parents=True)
+        build_win_runtime._write_manifest(
+            runtime_dir, "0.9.6", external_python_sandbox=not bundled
+        )
+        if bundled:
+            python_exe.parent.mkdir(parents=True)
+            python_exe.write_bytes(b"existing python")
+            old_node.parent.mkdir(parents=True)
+            old_node.write_bytes(b"existing node")
 
     def install_python(_runtime_dir: Path) -> None:
         python_exe.parent.mkdir(parents=True)
@@ -160,9 +165,136 @@ def test_windows_build_entry_preserves_selected_profile_and_existing_tools(
             installer.assert_called_once_with(target)
         else:
             installer.assert_not_called()
-    if exe_only:
+    if exe_only and bundled:
         assert python_exe.read_bytes() == b"existing python"
         assert old_node.read_bytes() == b"existing node"
     elif not bundled:
         assert not (runtime_dir / "runtime").exists()
         assert not (runtime_dir / "runtimes").exists()
+
+
+@pytest.mark.parametrize("existing_external", [True, False])
+@pytest.mark.parametrize("mismatch_at", ["output", "install-to"])
+def test_exe_only_rejects_cross_profile_rebuild_without_changing_artifacts(
+    tmp_path, monkeypatch, capsys, existing_external, mismatch_at
+):
+    output_dir = tmp_path / "output"
+    runtime_dir = output_dir / "box-agent-runtime"
+    target_dir = tmp_path / "installed-runtime"
+    requested_external = not existing_external
+    roots = [runtime_dir] if mismatch_at == "output" else [runtime_dir, target_dir]
+    before = {}
+    for root in roots:
+        (root / "bin").mkdir(parents=True)
+        (root / "bin" / "box-agent-acp.exe").write_bytes(b"original exe")
+        profile = requested_external if mismatch_at == "install-to" and root == runtime_dir else existing_external
+        build_win_runtime._write_manifest(root, "0.9.6", external_python_sandbox=profile)
+        if not profile:
+            for name in ("runtime/PortableGit/usr/bin/bash.exe", "runtime/python/python.exe", "runtimes/node/manifest.json"):
+                component = root / name
+                component.parent.mkdir(parents=True, exist_ok=True)
+                component.write_bytes(b"existing component")
+        before[root] = {file.relative_to(root): file.read_bytes() for file in root.rglob("*") if file.is_file()}
+
+    install_extras = Mock()
+
+    def fake_build(bin_dir, **kwargs):
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "box-agent-acp.exe").write_bytes(b"rebuilt exe")
+
+    build = Mock(side_effect=fake_build)
+    monkeypatch.setattr(build_win_runtime, "_ensure_win", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "_install_runtime_extras", install_extras)
+    monkeypatch.setattr(build_win_runtime, "_load_build_dependencies", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "BUILD_TOOLS_CACHE", tmp_path / "cache", raising=False)
+    monkeypatch.setattr(build_win_runtime, "_run_pyinstaller", build)
+    args = ["build_win_runtime.py", "--exe-only", "--no-tar", "--output", str(output_dir)]
+    if not requested_external:
+        args.append("--bundled-python-sandbox")
+    if mismatch_at == "install-to":
+        args.extend(["--install-to", str(target_dir)])
+    monkeypatch.setattr(build_win_runtime.sys, "argv", args)
+
+    with pytest.raises(SystemExit) as exc:
+        build_win_runtime.main()
+
+    assert exc.value.code == 2
+    assert "without --exe-only" in capsys.readouterr().err
+    install_extras.assert_not_called()
+    build.assert_not_called()
+    for root in roots:
+        assert {file.relative_to(root): file.read_bytes() for file in root.rglob("*") if file.is_file()} == before[root]
+
+
+@pytest.mark.parametrize("raw_manifest", [None, "{invalid", "[]", "{}", '{"external_python_sandbox": "false"}'])
+def test_exe_only_rejects_unknown_profiles_before_modifying_the_runtime(
+    tmp_path, monkeypatch, capsys, raw_manifest
+):
+    runtime_dir = tmp_path / "box-agent-runtime"
+    (runtime_dir / "bin").mkdir(parents=True)
+    executable = runtime_dir / "bin" / "box-agent-acp.exe"
+    executable.write_bytes(b"original exe")
+    manifest_path = runtime_dir / "manifest.json"
+    if raw_manifest is not None:
+        manifest_path.write_text(raw_manifest, encoding="utf-8")
+    install_extras = Mock()
+    monkeypatch.setattr(build_win_runtime, "_ensure_win", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "_install_runtime_extras", install_extras)
+    monkeypatch.setattr(build_win_runtime.sys, "argv", [
+        "build_win_runtime.py", "--exe-only", "--output", str(tmp_path),
+    ])
+
+    with pytest.raises(SystemExit) as exc:
+        build_win_runtime.main()
+
+    assert exc.value.code == 2
+    assert "without --exe-only" in capsys.readouterr().err
+    install_extras.assert_not_called()
+    assert executable.read_bytes() == b"original exe"
+    if raw_manifest is not None:
+        assert manifest_path.read_text(encoding="utf-8") == raw_manifest
+    else:
+        assert not manifest_path.exists()
+
+
+@pytest.mark.parametrize("external", [True, False])
+def test_exe_only_install_preserves_tools_in_a_matching_target(tmp_path, monkeypatch, external):
+    runtime_dir = tmp_path / "output" / "box-agent-runtime"
+    target_dir = tmp_path / "installed-runtime"
+    for root in (runtime_dir, target_dir):
+        (root / "bin").mkdir(parents=True)
+        (root / "bin" / "box-agent-acp.exe").write_bytes(b"original exe")
+        build_win_runtime._write_manifest(root, "0.9.6", external_python_sandbox=external)
+        if not external:
+            component = root / "runtime" / "PortableGit" / "usr" / "bin" / "bash.exe"
+            component.parent.mkdir(parents=True)
+            component.write_bytes(b"existing bash")
+
+    def fake_build(bin_dir, **kwargs):
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "box-agent-acp.exe").write_bytes(b"rebuilt exe")
+
+    monkeypatch.setattr(build_win_runtime, "_ensure_win", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "_install_runtime_extras", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "_load_build_dependencies", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "BUILD_TOOLS_CACHE", tmp_path / "cache", raising=False)
+    monkeypatch.setattr(build_win_runtime, "_run_pyinstaller", fake_build)
+    args = [
+        "build_win_runtime.py", "--exe-only", "--no-tar", "--version", "0.9.7",
+        "--output", str(runtime_dir.parent), "--install-to", str(target_dir),
+    ]
+    if not external:
+        args.append("--bundled-python-sandbox")
+    monkeypatch.setattr(build_win_runtime.sys, "argv", args)
+
+    build_win_runtime.main()
+
+    assert (target_dir / "bin" / "box-agent-acp.exe").read_bytes() == b"rebuilt exe"
+    manifest = json.loads((target_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.9.7"
+    assert manifest["external_python_sandbox"] is external
+    if external:
+        assert not (target_dir / "runtime").exists()
+        assert not (target_dir / "runtimes").exists()
+    else:
+        assert (target_dir / "runtime" / "PortableGit" / "usr" / "bin" / "bash.exe").read_bytes() == b"existing bash"

--- a/tests/test_build_win_runtime.py
+++ b/tests/test_build_win_runtime.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from subprocess import CompletedProcess
+from unittest.mock import Mock
+
+import pytest
 
 from scripts import build_runtime, build_win_runtime
 
@@ -14,14 +17,26 @@ def test_windows_builder_uses_shared_pyinstaller_contract() -> None:
     collect = build_win_runtime._windows_pyinstaller_collect_args()
 
     assert hidden == build_runtime.pyinstaller_hidden_imports(
-        external_python_sandbox=False
+        external_python_sandbox=True
     )
     assert collect == build_runtime.pyinstaller_collect_args(
-        external_python_sandbox=False
+        external_python_sandbox=True
     )
     assert "box_agent.mcp_servers" in hidden
     assert "box_agent.mcp_servers.web_extract" in hidden
     assert "box_agent.mcp_servers.web_extract_server" in hidden
+    assert "PIL.Image" in hidden
+    assert "ipykernel" not in hidden
+    assert "sklearn" not in collect
+
+
+def test_windows_legacy_bundle_remains_explicitly_available() -> None:
+    assert build_win_runtime._windows_pyinstaller_hidden_imports(
+        external_python_sandbox=False
+    ) == build_runtime.pyinstaller_hidden_imports(external_python_sandbox=False)
+    assert build_win_runtime._windows_pyinstaller_collect_args(
+        external_python_sandbox=False
+    ) == build_runtime.pyinstaller_collect_args(external_python_sandbox=False)
 
 
 def test_windows_pyinstaller_command_includes_web_extract_server(
@@ -49,6 +64,9 @@ def test_windows_pyinstaller_command_includes_web_extract_server(
         "box_agent.mcp_servers.web_extract_server",
     ) in hidden_pairs
     assert (bin_dir / "box-agent-acp.exe").is_file()
+    assert ("--exclude-module", "ipykernel") in hidden_pairs
+    assert ("--exclude-module", "sklearn") in hidden_pairs
+    assert ("--hidden-import", "PIL.Image") in hidden_pairs
 
 
 def test_windows_manifest_advertises_bundled_web_extract_mcp(
@@ -66,12 +84,8 @@ def test_windows_manifest_advertises_bundled_web_extract_mcp(
     assert manifest["arch"] == "x64"
     assert manifest["entry"] == "bin/box-agent-acp.exe"
     assert manifest["managed_mcp_config_version"] == 1
-    assert manifest["external_python_sandbox"] is False
-    assert manifest["bundled_stable_runtimes"] == [
-        "portable_git",
-        "python",
-        "node",
-    ]
+    assert manifest["external_python_sandbox"] is True
+    assert manifest["bundled_stable_runtimes"] == []
     assert manifest["mcp_servers"] == {
         "box-agent-web-extract": {
             "entry": "bin/box-agent-acp.exe",
@@ -80,3 +94,75 @@ def test_windows_manifest_advertises_bundled_web_extract_mcp(
         }
     }
     assert (runtime_dir / "VERSION").read_text(encoding="utf-8") == "0.9.7\n"
+
+
+def test_windows_legacy_manifest_lists_its_bundled_tools(tmp_path: Path) -> None:
+    build_win_runtime._write_manifest(
+        tmp_path, "0.9.7", external_python_sandbox=False
+    )
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["external_python_sandbox"] is False
+    assert manifest["bundled_stable_runtimes"] == ["portable_git", "python", "node"]
+
+
+@pytest.mark.parametrize("bundled", [False, True])
+@pytest.mark.parametrize("exe_only", [False, True])
+def test_windows_build_entry_preserves_selected_profile_and_existing_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bundled: bool, exe_only: bool
+) -> None:
+    runtime_dir = tmp_path / "output" / "box-agent-runtime"
+    python_exe = runtime_dir / "runtime" / "python" / "python.exe"
+    old_node = runtime_dir / "runtimes" / "node" / "existing.txt"
+    if exe_only:
+        python_exe.parent.mkdir(parents=True)
+        python_exe.write_bytes(b"existing python")
+        old_node.parent.mkdir(parents=True)
+        old_node.write_bytes(b"existing node")
+
+    def install_python(_runtime_dir: Path) -> None:
+        python_exe.parent.mkdir(parents=True)
+        python_exe.write_bytes(b"bundled python")
+
+    build = Mock()
+    installers = {
+        "_install_portable_git_win": Mock(),
+        "_install_portable_python_win": Mock(side_effect=install_python),
+        "_install_sandbox_packages_win": Mock(),
+        "_install_node_win": Mock(),
+    }
+    monkeypatch.setattr(build_win_runtime, "_ensure_win", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "_install_runtime_extras", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "_load_build_dependencies", lambda: None)
+    monkeypatch.setattr(build_win_runtime, "BUILD_TOOLS_CACHE", tmp_path / "cache", raising=False)
+    monkeypatch.setattr(build_win_runtime, "_run_pyinstaller", build)
+    for name, installer in installers.items():
+        monkeypatch.setattr(build_win_runtime, name, installer, raising=False)
+    args = [
+        "build_win_runtime.py", "--version", "0.9.7",
+        "--output", str(runtime_dir.parent), "--no-tar",
+    ]
+    if bundled:
+        args.append("--bundled-python-sandbox")
+    if exe_only:
+        args.append("--exe-only")
+    monkeypatch.setattr(build_win_runtime.sys, "argv", args)
+
+    build_win_runtime.main()
+
+    build.assert_called_once_with(runtime_dir / "bin", external_python_sandbox=not bundled)
+    manifest = json.loads((runtime_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["external_python_sandbox"] is not bundled
+    expected_components = ["portable_git", "python", "node"] if bundled else []
+    assert manifest["bundled_stable_runtimes"] == expected_components
+    for name, installer in installers.items():
+        if bundled and not exe_only:
+            target = python_exe if name == "_install_sandbox_packages_win" else runtime_dir
+            installer.assert_called_once_with(target)
+        else:
+            installer.assert_not_called()
+    if exe_only:
+        assert python_exe.read_bytes() == b"existing python"
+        assert old_node.read_bytes() == b"existing node"
+    elif not bundled:
+        assert not (runtime_dir / "runtime").exists()
+        assert not (runtime_dir / "runtimes").exists()

--- a/tests/test_pptx_controlled_deck.py
+++ b/tests/test_pptx_controlled_deck.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 
 from box_agent.tools.skill_loader import SkillLoader
+from tests.pptx_test_support import skip_unavailable_pptx_runtime
 
 
 SKILL_DIR = (
@@ -110,15 +111,7 @@ def _run(
         cwd=cwd,
         env=env,
     )
-    # ── playwright probe ──────────────────────────────────────────
-    # Several scripts need playwright but CI runners don't have it.
-    # Skip the whole test instead of failing with an opaque exit code.
-    if result.returncode != 0 and (
-        "Cannot find module 'playwright'" in result.stderr
-        or "Executable doesn't exist" in result.stderr
-        or "Missing dependency: playwright" in result.stderr
-    ):
-        pytest.skip("Managed Playwright browser is unavailable")
+    skip_unavailable_pptx_runtime(result)
     return result
 
 

--- a/tests/test_pptx_html_export.py
+++ b/tests/test_pptx_html_export.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from tests.pptx_test_support import skip_unavailable_pptx_runtime
+
 
 SCRIPTS_DIR = (
     Path(__file__).resolve().parents[1]
@@ -39,16 +41,7 @@ def _run_node(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
         text=True,
         check=False,
     )
-    unavailable = (
-        "Cannot find module 'playwright'",
-        "Missing dependency: playwright",
-        "Executable doesn't exist",
-        "Playwright Chromium is not available",
-    )
-    if result.returncode != 0 and any(
-        marker in result.stdout + result.stderr for marker in unavailable
-    ):
-        pytest.skip("Managed Playwright browser is unavailable")
+    skip_unavailable_pptx_runtime(result)
     return result
 
 

--- a/tests/test_pptx_presentation_system.py
+++ b/tests/test_pptx_presentation_system.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.pptx_test_support import skip_unavailable_pptx_runtime
+
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / "box_agent/skills/document-skills/pptx"
 NODE = os.environ.get("BOX_AGENT_NODE") or shutil.which("node")
@@ -17,12 +19,15 @@ pytestmark = pytest.mark.skipif(NODE is None, reason="Node.js is required")
 
 def node(code: str, *args: str) -> dict:
     result = subprocess.run([str(NODE), "-e", code, str(SKILL), *map(str, args)], text=True, capture_output=True, check=False)
+    skip_unavailable_pptx_runtime(result)
     assert result.returncode == 0, result.stdout + result.stderr
     return json.loads(result.stdout)
 
 
 def run(script: str, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run([str(NODE), str(SKILL / "scripts" / script), *map(str, args)], text=True, capture_output=True, check=False)
+    result = subprocess.run([str(NODE), str(SKILL / "scripts" / script), *map(str, args)], text=True, capture_output=True, check=False)
+    skip_unavailable_pptx_runtime(result)
+    return result
 
 
 def test_all_themes_and_layouts_inherit_one_presentation_contract():

--- a/tests/test_pptx_test_support.py
+++ b/tests/test_pptx_test_support.py
@@ -1,0 +1,63 @@
+"""Missing optional hosts must not hide real PPTX script failures."""
+
+import subprocess
+
+import pytest
+
+from tests import (
+    test_pptx_controlled_deck as controlled,
+    test_pptx_html_export as export,
+    test_pptx_presentation_system as presentation,
+)
+
+
+@pytest.fixture(params=[controlled._run, export._run_node, presentation.run, presentation.node])
+def runner(request, monkeypatch):
+    for module in (controlled, export, presentation):
+        monkeypatch.setattr(module, "NODE", "node")
+    return request.param
+
+
+@pytest.mark.parametrize("message", [
+    "Cannot find module 'playwright'",
+    "Missing dependency: playwright",
+    "browserType.launch: Executable doesn't exist at /missing/chromium",
+    "Playwright Chromium is not available",
+    "Cannot find module '@napi-rs/canvas'",
+    "Missing dependency: @napi-rs/canvas",
+])
+@pytest.mark.parametrize("channel", ["stdout", "stderr"])
+def test_runners_skip_only_unavailable_optional_hosts(runner, monkeypatch, message, channel):
+    output = {"stdout": "", "stderr": "", channel: message}
+    result = subprocess.CompletedProcess(["node"], 1, **output)
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: result)
+
+    with pytest.raises(pytest.skip.Exception, match="Managed"):
+        runner("unused.js")
+
+
+@pytest.mark.parametrize("message", [
+    "TypeError: cannot read properties of undefined",
+    "Cannot find module './presentation-system.js'",
+    "browserType.launch: Target page, context or browser has been closed",
+    "QA failed: text/content overflow",
+])
+def test_runners_preserve_real_script_failures(runner, monkeypatch, message):
+    result = subprocess.CompletedProcess(["node"], 1, stdout="", stderr=message)
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: result)
+
+    if runner is presentation.node:
+        with pytest.raises(AssertionError, match=message):
+            runner("unused.js")
+    else:
+        assert runner("unused.js") is result
+
+
+def test_runners_do_not_skip_successful_results(runner, monkeypatch):
+    result = subprocess.CompletedProcess(
+        ["node"], 0, stdout='{"ok": true}', stderr="Missing dependency: playwright"
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: result)
+
+    actual = runner("unused.js")
+    assert actual == ({"ok": True} if runner is presentation.node else result)


### PR DESCRIPTION
## TPR

### Task
- 优化 Windows ACP 精简构建，移除重复的内置分析依赖，使用宿主提供的 Python/Node/Git。
- 保留 `--bundled-python-sandbox` 全量构建入口。
- 不修改 Agent 业务逻辑，不引入三件套内置归档方案。

### Proof
- Windows 构建专项测试 9 项通过。
- 已完成精简 ACP、unsigned Electron 打包，以及包内 ACP 会话、数据分析和文档处理验证。


### Risk
- 精简模式依赖宿主运行时就绪；首次缺包自动安装存在已知问题，本次未修复。
- 可通过全量构建参数或回退本提交恢复旧策略。
- 需配合 Officev3 提交 `d249ff3e6` 使用。

### Design and architecture impact
- 仅修改 Windows 构建脚本及测试，复用共享构建规则。
- 无 ACP 协议、业务配置或 Skill 改动；已更新脚本用法说明。

### Target branch consistency
- 基线：main `56ee390`；当前 Head：`c95f652`。
- 未再次确认最新 main，未运行 `teamwork/local-ci`。