### PR TITLE
feat(runtime): Add isolated profiles and hosted model compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ box-agent doctor                    # check environment & API connectivity
 box-agent doctor --json             # machine-readable health check
 ```
 
+### Isolated runtime profiles
+
+Hosts may opt into a dedicated absolute `BOX_AGENT_HOME` before starting the runtime. This routes Box-Agent-owned configuration and state away from the default user profile without changing the operating-system `HOME`; unset behavior stays compatible. Explicit profiles require their own `config/config.yaml` and never fall back to legacy configuration or login-token environment variables.
+
+See [isolated runtime profiles](docs/isolated-runtime-profile.md) and the no-background-startup [example configuration](box_agent/config/isolated-profile-example.yaml). This is path/configuration isolation, not an OS sandbox or permission to call a model.
+
 ## CLI Usage
 
 ```bash

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -197,6 +197,8 @@ from box_agent.workspace_registry import WorkspaceRegistry, WorkspaceRegistryErr
 
 from .debug_logger import acp_logger as log
 
+from box_agent.user_paths import configured_box_agent_home, state_path
+
 # Keep stdlib logger for backward compat with existing log calls
 logger = logging.getLogger(__name__)
 _DEFAULT_AGENT_TITLE = "Box-Agent"
@@ -1918,7 +1920,7 @@ class BoxACPAgent:
                     existing_log.assert_workspace(workspace)
                     existing_log.close()
                 del self._sessions[existing_handle]
-            session_root = Path.home() / ".box-agent" / "sessions"
+            session_root = state_path('sessions')
             try:
                 session_log = SessionLog.open(
                     session_root,
@@ -2193,7 +2195,7 @@ class BoxACPAgent:
         memory_scarce = is_memory_scarce(self._memory.read_core() if self._memory else None)
 
         try:
-            _user_mcp = Path.home() / ".box-agent" / "config" / "mcp.json"
+            _user_mcp = state_path('config/mcp.json')
             mcp_path = _user_mcp if _user_mcp.exists() else Config.find_config_file(self._config.tools.mcp_config_path)
         except Exception:
             mcp_path = None
@@ -5461,8 +5463,10 @@ async def run_acp_server(config: Config | None = None) -> None:
     import os as _os
     _os.environ.setdefault(
         "PLAYWRIGHT_BROWSERS_PATH",
-        str(Path.home() / ".box-agent" / "browsers"),
+        str(state_path('browsers')),
     )
+    if configured_box_agent_home() is not None:
+        _os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(state_path("browsers", _os.environ["PLAYWRIGHT_BROWSERS_PATH"]))
 
     # ── Stdout guard ────────────────────────────────────────
     # ACP protocol owns stdout exclusively.  Redirect sys.stdout to

--- a/box_agent/acp/debug_logger.py
+++ b/box_agent/acp/debug_logger.py
@@ -26,6 +26,8 @@ import traceback
 from datetime import datetime, timezone
 from typing import Any
 
+from box_agent.user_paths import state_path
+
 # ── Level constants ──────────────────────────────────────────
 
 _LEVELS = {"error": 40, "warn": 30, "info": 20, "debug": 10}
@@ -69,6 +71,7 @@ class ACPDebugLogger:
 
         file_path = os.environ.get("BOX_AGENT_LOG_FILE")
         if file_path:
+            file_path = str(state_path("log/box-agent.log", file_path))
             try:
                 self._file_handle = open(file_path, "a", encoding="utf-8", buffering=1)  # line-buffered
                 self._file_path = file_path

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -58,6 +58,8 @@ from .tool_result_storage import ToolResultStorage
 from .utils import calculate_display_width
 from .session_continuation import ContinuationMessage
 
+from box_agent.user_paths import state_path
+
 
 _log = logging.getLogger(__name__)
 _ACTIVE_SKILL_TOKEN_BUDGET = 32_000
@@ -529,7 +531,7 @@ class Agent:
                 ),
             )
         self.tool_result_storage = ToolResultStorage(
-            Path.home() / ".box-agent" / "sessions"
+            state_path('sessions')
         )
         self.token_limit = token_limit
         self.workspace_dir = Path(workspace_dir)

--- a/box_agent/auth.py
+++ b/box_agent/auth.py
@@ -16,6 +16,8 @@ from uuid import uuid4
 
 import httpx
 
+from box_agent.user_paths import configured_box_agent_home, state_path
+
 AUTH_TOKEN_ENV_VARS = (
     "BOX_AGENT_AUTH_TOKEN",
     "OFFICEV3_AUTH_TOKEN",
@@ -48,7 +50,7 @@ def _read_auth_state(auth_file: str | Path | None) -> tuple[Path | None, dict[st
     if not auth_file:
         return None, {}
 
-    path = Path(auth_file).expanduser()
+    path = state_path("config/auth.json", auth_file)
     if not path.exists():
         return path, {}
 
@@ -236,6 +238,9 @@ def resolve_auth_token(
     file_token = read_auth_token_file(auth_file)
     if file_token:
         return file_token
+
+    if configured_box_agent_home() is not None:
+        return ""  # An isolated profile must not inherit the desktop user's login token.
 
     for name in AUTH_TOKEN_ENV_VARS:
         token = os.environ.get(name, "").strip()

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -87,6 +87,8 @@ from box_agent.utils import calculate_display_width
 from box_agent.acp.project_context import build_project_startup_context_prompt
 from box_agent.workspace_registry import WorkspaceRegistry, WorkspaceRegistryError
 
+from box_agent.user_paths import state_path
+
 
 _CLI_PROBE_MAX_OUTPUT_TOKENS = 4_096
 
@@ -494,7 +496,7 @@ def _config_exit_error(message: str, json_output: bool = False) -> int:
 
 def get_log_directory() -> Path:
     """Get the log directory path."""
-    return Path.home() / ".box-agent" / "log"
+    return state_path('log')
 
 
 def show_log_directory(open_file_manager: bool = True) -> None:
@@ -755,7 +757,7 @@ def print_goal_status(agent: Agent) -> None:
 
 def _goal_store_path(workspace_dir: Path) -> Path:
     key = hashlib.sha256(str(workspace_dir.expanduser().absolute()).encode("utf-8")).hexdigest()[:24]
-    return Path.home() / ".box-agent" / "goals" / f"{key}.json"
+    return state_path('goals') / f"{key}.json"
 
 
 def _load_goal_state(workspace_dir: Path) -> GoalState | None:
@@ -1511,7 +1513,7 @@ def _doctor_sandbox_status() -> dict[str, Any]:
 
 
 def _doctor_mcp_status() -> dict[str, Any]:
-    _user_mcp = Path.home() / ".box-agent" / "config" / "mcp.json"
+    _user_mcp = state_path('config/mcp.json')
     mcp_path = _user_mcp if _user_mcp.exists() else Config.find_config_file("mcp.json")
     if mcp_path:
         return _doctor_check("ok", str(mcp_path), config_file=str(mcp_path))
@@ -1559,7 +1561,7 @@ async def cmd_doctor(json_output: bool = False) -> int:
 
 def _default_browsers_path() -> Path:
     """Default Chromium cache directory shared by CLI install and ACP runtime."""
-    return Path.home() / ".box-agent" / "browsers"
+    return state_path('browsers')
 
 
 def _playwright_env() -> dict[str, str]:
@@ -1702,7 +1704,7 @@ def cmd_install_node(version: str = DEFAULT_NODE_VERSION) -> None:
 
 def _ensure_user_mcp_config() -> Path:
     """Return path to the user-writable mcp.json, copying the example if needed."""
-    user_dir = Path.home() / ".box-agent" / "config"
+    user_dir = state_path('config')
     user_dir.mkdir(parents=True, exist_ok=True)
     target = user_dir / "mcp.json"
     if target.exists():
@@ -2506,7 +2508,7 @@ async def run_agent(
 
     # Create prompt session with history and auto-suggest
     # Use FileHistory for persistent history across sessions (stored in user's home directory)
-    history_file = Path.home() / ".box-agent" / ".history"
+    history_file = state_path('.history')
     history_file.parent.mkdir(parents=True, exist_ok=True)
     session = PromptSession(
         history=FileHistory(str(history_file)),

--- a/box_agent/config.py
+++ b/box_agent/config.py
@@ -11,6 +11,13 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from .auth import should_attach_auth_header
+from .user_paths import (
+    box_agent_home,
+    configured_box_agent_home,
+    default_memory_dir,
+    default_workspace_dir,
+    state_path,
+)
 
 DEFAULT_API_KEY_PLACEHOLDER = "YOUR_API_KEY_HERE"
 DEFAULT_MODEL = "claude-sonnet-4-20250514"
@@ -193,7 +200,7 @@ class AgentConfig(BaseModel):
     """Agent configuration"""
 
     max_steps: int = 300
-    workspace_dir: str = "./workspace"
+    workspace_dir: str = Field(default_factory=default_workspace_dir)
     # Hard ceiling on how many parallel_safe tool calls (sub_agent,
     # generate_image) run concurrently within a single step, regardless of how
     # many the model emits. Excess calls queue and run as slots free up. Guards
@@ -249,7 +256,7 @@ class AgentConfig(BaseModel):
     code_prompt_path: str = "code_prompt.md"
     # Memory
     enable_memory: bool = True
-    memory_dir: str = "~/.box-agent/memory"
+    memory_dir: str = Field(default_factory=default_memory_dir)
     # Memory auto-extraction
     enable_memory_extraction: bool = True
     memory_extraction_cooldown: int = 300  # seconds between extractions
@@ -369,6 +376,8 @@ class HooksConfig(BaseModel):
 class Config(BaseModel):
     """Main configuration class"""
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     llm: LLMConfig
     lite_llm: LiteLLMConfig = Field(default_factory=LiteLLMConfig)
     image_generation: ImageGenerationConfig = Field(default_factory=ImageGenerationConfig)
@@ -377,6 +386,24 @@ class Config(BaseModel):
     tools: ToolsConfig
     officev3: Officev3Config = Field(default_factory=Officev3Config)
     hooks: HooksConfig = Field(default_factory=HooksConfig)
+
+    @model_validator(mode="after")
+    def _resolve_profile_paths(self) -> "Config":
+        if configured_box_agent_home() is None:
+            return self
+        self.llm.auth_file = str(state_path("config/auth.json", self.llm.auth_file or None))
+        if self.lite_llm.auth_file:
+            self.lite_llm.auth_file = str(
+                state_path("config/auth.json", self.lite_llm.auth_file)
+            )
+        self.image_generation.auth_file = str(
+            state_path("config/auth.json", self.image_generation.auth_file or self.llm.auth_file)
+        )
+        self.agent.memory_dir = str(state_path("memory", self.agent.memory_dir))
+        self.agent.workspace_dir = str(state_path("workspace", self.agent.workspace_dir))
+        mcp_path = state_path("config") / self.tools.mcp_config_path
+        self.tools.mcp_config_path = str(state_path("config/mcp.json", mcp_path))
+        return self
 
     @classmethod
     def load(cls) -> "Config":
@@ -401,6 +428,8 @@ class Config(BaseModel):
             ValueError: Invalid configuration format or missing required fields
         """
         config_path = Path(config_path)
+        if configured_box_agent_home() is not None:
+            config_path = state_path("config/config.yaml", config_path)
 
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file does not exist: {config_path}")
@@ -645,13 +674,24 @@ class Config(BaseModel):
         Returns:
             Path to found config file, or None if not found
         """
+        if configured_box_agent_home() is not None:
+            configured = state_path("config", box_agent_home() / "config" / filename)
+            if configured.is_file():
+                return configured
+            # Only immutable packaged prompt resources may fall back, never credentials/config/MCP.
+            if filename in {"system_prompt.md", "analysis_prompt.md", "code_prompt.md"}:
+                bundled = cls.get_package_dir() / "config" / filename
+                if bundled.is_file():
+                    return bundled
+            return None
+
         # Priority 1: Development mode - current directory's config/ subdirectory
         dev_config = Path.cwd() / "box_agent" / "config" / filename
         if dev_config.exists():
             return dev_config
 
         # Priority 2: User config directory
-        user_config = Path.home() / ".box-agent" / "config" / filename
+        user_config = box_agent_home() / "config" / filename
         if user_config.exists():
             return user_config
 
@@ -676,6 +716,9 @@ class Config(BaseModel):
         if config_path:
             return config_path
 
+        if configured_box_agent_home() is not None:
+            raise FileNotFoundError(f"Explicit profile config.yaml is missing: {state_path('config/config.yaml')}")
+
         # No config.yaml found anywhere — bootstrap from example
         return cls._ensure_user_config()
 
@@ -686,7 +729,7 @@ class Config(BaseModel):
         Returns:
             Path to the newly created config.yaml
         """
-        user_config_dir = Path.home() / ".box-agent" / "config"
+        user_config_dir = state_path("config")
         user_config_dir.mkdir(parents=True, exist_ok=True)
         target = user_config_dir / "config.yaml"
 

--- a/box_agent/config/isolated-profile-example.yaml
+++ b/box_agent/config/isolated-profile-example.yaml
@@ -1,0 +1,20 @@
+# Copy explicitly to $BOX_AGENT_HOME/config/config.yaml before starting a test profile.
+# This is a no-background-startup example, not a tool/OS sandbox or production credential.
+# Replace endpoint/key/model only after the host authorizes a real model call.
+api_key: isolated-fixture-key
+api_base: https://example.invalid/v1
+provider: openai
+model: isolated-fixture
+enable_memory: false
+enable_memory_extraction: false
+memory_maintainer_enabled: false
+hooks: []
+tools:
+  enable_file_tools: false
+  enable_bash: false
+  enable_todo: false
+  enable_plan: false
+  enable_sub_agent: false
+  enable_skills: false
+  enable_mcp: false
+  allow_full_access: false

--- a/box_agent/hooks.py
+++ b/box_agent/hooks.py
@@ -30,8 +30,9 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
-from pathlib import Path
 from typing import Any
+
+from box_agent.user_paths import state_path
 
 log = logging.getLogger(__name__)
 
@@ -270,7 +271,7 @@ class HookManager:
 
 # User hooks directory — added to sys.path so that config.yaml
 # can reference modules by short name (e.g. ``"safety.SafetyHook"``).
-USER_HOOKS_DIR = Path.home() / ".box-agent" / "hooks"
+USER_HOOKS_DIR = state_path('hooks')
 
 
 def _ensure_hooks_dir_on_path() -> None:

--- a/box_agent/kernel/loop.py
+++ b/box_agent/kernel/loop.py
@@ -218,6 +218,8 @@ from ..loop_guards import (
     truncation_continuation_text,
 )
 
+from box_agent.user_paths import state_path
+
 __all__ = ["run_agent_loop"]
 
 _log = logging.getLogger("box_agent.core")
@@ -872,7 +874,7 @@ async def _run_agent_loop_impl(
         else None
     )
     result_storage = tool_result_storage or ToolResultStorage(
-        Path.home() / ".box-agent" / "sessions"
+        state_path('sessions')
     )
     result_storage.set_context_token_limit(token_limit)
     result_storage.initialize_history(messages)

--- a/box_agent/llm/model_profiles.py
+++ b/box_agent/llm/model_profiles.py
@@ -16,6 +16,8 @@ from box_agent.schema import LLMProvider
 
 from .llm_wrapper import LLMClient
 
+from box_agent.user_paths import state_path
+
 
 REGISTRY_VERSION = 1
 
@@ -27,8 +29,8 @@ class ModelProfileUnavailable(ValueError):
 def default_model_profile_registry_path() -> Path:
     configured = os.environ.get("BOX_AGENT_MODEL_PROFILES_FILE", "").strip()
     if configured:
-        return Path(configured).expanduser()
-    return Path.home() / ".box-agent" / "config" / "model-profiles.json"
+        return state_path("config/model-profiles.json", configured)
+    return state_path('config/model-profiles.json')
 
 
 def _positive_int(value: Any, *, field: str, default: int | None = None) -> int:

--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -45,6 +45,12 @@ _GLM_5_3_MODEL_MARKERS = ("glm-5-3", "glm-5.3")
 _GEMINI_NO_DISABLE_MARKERS = ("gemini-2.5-pro", "gemini-3.1-pro")
 # Replay formats are gateway-specific; only change combinations verified live.
 _REASONING_CONTENT_REPLAY_MODELS = {
+    "https://xiaohuanxiong.com/api/web/llm/v2": frozenset({
+        "sn-sensenova-6-8-flash-lite",
+        "sn-glm-5-2",
+        "sn-glm-5-3-flash",
+        "sn-deepseek-v4-pro",
+    }),
     "https://code-stage.xiaohuanxiong.com/api/web/llm/v2": frozenset({
         "sn-kimi-k3",
     }),

--- a/box_agent/logger.py
+++ b/box_agent/logger.py
@@ -11,6 +11,8 @@ from .llm.debug_logging import (
 )
 from .schema import Message, ToolCall
 
+from box_agent.user_paths import state_path
+
 
 class AgentLogger:
     """Agent run logger
@@ -26,7 +28,7 @@ class AgentLogger:
         Logs are stored in ~/.box-agent/log/ directory
         """
         # Use ~/.box-agent/log/ directory for logs
-        self.log_dir = Path.home() / ".box-agent" / "log"
+        self.log_dir = state_path('log')
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.log_file = None
         self.log_index = 0

--- a/box_agent/mcp_servers/web_extract_server.py
+++ b/box_agent/mcp_servers/web_extract_server.py
@@ -5,22 +5,13 @@ from __future__ import annotations
 from functools import lru_cache
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.tools import Tool as MCPFunctionTool
 
 from box_agent.config import Config
 from box_agent.llm import LLMClient
 from box_agent.mcp_servers.web_extract import WebExtractTool
 from box_agent.retry import RetryConfig
 from box_agent.schema import LLMProvider
-
-
-mcp = FastMCP(
-    "box-agent-web-extract",
-    instructions=(
-        "Fetch public HTTP(S) pages without executing JavaScript. Long pages are "
-        "summarized with the configured Box-Agent model or the model requested by "
-        "the caller."
-    ),
-)
 
 
 def _create_configured_llm() -> LLMClient:
@@ -54,14 +45,6 @@ def _extractor() -> WebExtractTool:
     return WebExtractTool(llm=_create_configured_llm())
 
 
-@mcp.tool(
-    name="web_extract",
-    description=(
-        "Fetch and extract text from one public web page. Pages over 5,000 "
-        "characters are summarized with the configured Box-Agent model, or with "
-        "the optional model supplied by the caller. JavaScript is not executed."
-    ),
-)
 async def web_extract(
     url: str,
     model: str | None = None,
@@ -76,6 +59,29 @@ async def web_extract(
     if not result.success:
         raise ValueError(result.error or "Web extraction failed")
     return result.content or ""
+
+
+_mcp_tool = MCPFunctionTool.from_function(
+    web_extract,
+    name="web_extract",
+    description=(
+        "Fetch and extract text from one public web page. Pages over 5,000 "
+        "characters are summarized with the configured Box-Agent model, or with "
+        "the optional model supplied by the caller. JavaScript is not executed."
+    ),
+)
+# Reuse the tool's explicit schema: FastMCP's inferred nullable unions can be
+# rejected by model APIs. Keep the function metadata accepting legacy nulls.
+_mcp_tool.parameters = WebExtractTool(llm=None).parameters
+mcp = FastMCP(
+    "box-agent-web-extract",
+    instructions=(
+        "Fetch public HTTP(S) pages without executing JavaScript. Long pages are "
+        "summarized with the configured Box-Agent model or the model requested by "
+        "the caller."
+    ),
+    tools=[_mcp_tool],
+)
 
 
 def main() -> None:

--- a/box_agent/memory.py
+++ b/box_agent/memory.py
@@ -25,6 +25,7 @@ from time import monotonic
 from typing import TYPE_CHECKING, Any, Iterator
 
 from .llm.model_routing import resolve_model_client
+from .user_paths import configured_box_agent_home, default_memory_dir, state_path
 
 if TYPE_CHECKING:
     from .schema import Message
@@ -516,12 +517,14 @@ class MemoryManager:
 
     def __init__(
         self,
-        memory_dir: str = "~/.box-agent/memory",
+        memory_dir: str | None = None,
         *,
         dedup_jaccard_threshold: float = 0.85,
         **_kwargs,
     ):
-        self.memory_dir = Path(memory_dir).expanduser()
+        self.memory_dir = state_path(
+            "memory", memory_dir if memory_dir is not None else default_memory_dir()
+        )
         self.memory_dir.mkdir(parents=True, exist_ok=True)
         self.dedup_jaccard_threshold = dedup_jaccard_threshold
         self._context_transaction_lock = threading.RLock()
@@ -1190,6 +1193,8 @@ class MemoryManager:
 
         Returns the imported content, or empty string if nothing to import.
         """
+        if configured_box_agent_home() is not None:
+            return ""  # Do not read global memories or write an "imported" marker for this profile.
         if self._openclaw_imported_marker.exists():
             return ""
 

--- a/box_agent/session_trace.py
+++ b/box_agent/session_trace.py
@@ -22,6 +22,8 @@ from typing import Any, TypeVar
 
 from .llm.debug_logging import sanitize_for_logging
 
+from box_agent.user_paths import state_path
+
 logger = logging.getLogger(__name__)
 
 _TRACE_SCHEMA_VERSION = "box-agent-session-trace/v1"
@@ -57,8 +59,8 @@ def session_trace_enabled() -> bool:
 def default_session_trace_dir() -> Path:
     configured = os.environ.get("BOX_AGENT_SESSION_TRACE_DIR", "").strip()
     if configured:
-        return Path(configured).expanduser()
-    return Path.home() / ".box-agent" / "log" / "sessions"
+        return state_path("log/sessions", configured)
+    return state_path('log/sessions')
 
 
 def session_trace_retention_enabled() -> bool:

--- a/box_agent/tools/jupyter_tool.py
+++ b/box_agent/tools/jupyter_tool.py
@@ -23,6 +23,8 @@ from ..artifacts import ensure_output_dir
 from ._win_job import assign_pid_to_job
 from .base import Tool, ToolResult
 
+from box_agent.user_paths import state_path
+
 # True when running inside a PyInstaller frozen binary
 IS_FROZEN = getattr(sys, "frozen", False)
 
@@ -62,7 +64,7 @@ SANDBOX_DEFAULT_PACKAGES = [
     "chardet",          # encoding detection for text/CSV
 ]
 
-SANDBOX_BASE_DIR = Path.home() / ".box-agent" / "sandbox"
+SANDBOX_BASE_DIR = state_path('sandbox')
 
 # Keep generated tool-call JSON below provider completion caps. Match the file
 # chunk size so large static bodies do not migrate into Python string literals.
@@ -71,7 +73,7 @@ MAX_EXECUTE_CODE_CHARS_DISPLAY = f"{MAX_EXECUTE_CODE_CHARS:,}"
 
 # User-level directory for packages installed at runtime in frozen mode.
 # Survives across sessions; kept separate from the frozen binary itself.
-RUNTIME_PACKAGES_DIR = Path.home() / ".box-agent" / "runtime-packages"
+RUNTIME_PACKAGES_DIR = state_path('runtime-packages')
 
 
 async def _communicate_sandbox_process(

--- a/box_agent/tools/mcp_bootstrap.py
+++ b/box_agent/tools/mcp_bootstrap.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
+from box_agent.user_paths import state_path
+
 
 MANAGED_MCP_SCHEMA_KEY = "boxAgentManagedMcpVersion"
 MANAGED_MCP_SCHEMA_VERSION = 1
@@ -53,7 +55,7 @@ def _runtime_root(explicit_root: Path | None = None) -> Path | None:
 
 def default_managed_mcp_config_path() -> Path:
     """Return the shared user MCP configuration owned by Box-Agent."""
-    return Path.home() / ".box-agent" / "config" / "mcp.json"
+    return state_path('config/mcp.json')
 
 
 def _normalize_hosted_search_url(value: str) -> str | None:

--- a/box_agent/tools/mcp_config_tool.py
+++ b/box_agent/tools/mcp_config_tool.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from box_agent.config import Config
 from box_agent.tools.base import Tool, ToolResult
+from box_agent.user_paths import configured_box_agent_home, state_path
 
 
 _ALLOWED_SERVER_FIELDS = frozenset(
@@ -128,6 +129,11 @@ def _browser_config_summary(config: Any) -> list[str]:
 
 
 def _resolve_write_target() -> Path:
+    if configured_box_agent_home() is not None:
+        from box_agent.tools.mcp_loader import get_mcp_config_path
+        target = state_path("config/mcp.json", get_mcp_config_path() or None)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target
     # Priority: loader's actual runtime path > user config dir > packaged config.
     # In dev, box-agent may boot before ~/.box-agent/config/mcp.json exists and
     # end up loading ./box_agent/config/mcp.json. Writing to user dir here would
@@ -144,7 +150,7 @@ def _resolve_write_target() -> Path:
     except Exception:
         pass
 
-    user_path = Path("~/.box-agent/config/mcp.json").expanduser()
+    user_path = state_path("config/mcp.json")
     if user_path.exists():
         return user_path
     try:

--- a/box_agent/tools/obsidian_tool.py
+++ b/box_agent/tools/obsidian_tool.py
@@ -12,19 +12,21 @@ from typing import Any
 
 from .base import Tool, ToolResult
 
+from box_agent.user_paths import state_path
+
 OBSIDIAN_PERMISSION_SCOPE = "external_app"
 OBSIDIAN_LAUNCH_SCOPE = "obsidian_launch"
 OBSIDIAN_CONFIG_ENV = "BOX_AGENT_OBSIDIAN_CONFIG"
 OBSIDIAN_CLI_ENV = "BOX_AGENT_OBSIDIAN_CLI"
 OBSIDIAN_APP_ENV = "BOX_AGENT_OBSIDIAN_APP"
 
-_DEFAULT_CONFIG_PATH = Path.home() / ".box-agent" / "config" / "obsidian.json"
+_DEFAULT_CONFIG_PATH = state_path('config/obsidian.json')
 _DEFAULT_CLI_NAME = "obsidian"
 _NOTE_TITLE_RE = re.compile(r"[^A-Za-z0-9\u4e00-\u9fff._ -]+")
 
 
 def obsidian_config_path() -> Path:
-    return Path(os.environ.get(OBSIDIAN_CONFIG_ENV, str(_DEFAULT_CONFIG_PATH))).expanduser()
+    return state_path("config/obsidian.json", os.environ.get(OBSIDIAN_CONFIG_ENV, str(_DEFAULT_CONFIG_PATH)))
 
 
 def _launch_permission_request(reason: str) -> dict[str, Any]:

--- a/box_agent/tools/permissions.py
+++ b/box_agent/tools/permissions.py
@@ -29,6 +29,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from box_agent.user_paths import state_path
+
 if TYPE_CHECKING:
     from box_agent.config import Config
 
@@ -173,7 +175,7 @@ class PermissionEngine:
         # trash, log, ...). It is engine-internal data, not user business
         # data — never prompt for it, regardless of scope or config.
         try:
-            self._box_agent_dir: Path | None = (self._home_dir / ".box-agent").resolve()
+            self._box_agent_dir: Path | None = state_path("", home_dir=self._home_dir).resolve()
         except (OSError, RuntimeError):
             self._box_agent_dir = None
 

--- a/box_agent/tools/runtime.py
+++ b/box_agent/tools/runtime.py
@@ -16,11 +16,13 @@ from typing import Any, Literal
 
 from box_agent.tools.jupyter_tool import SandboxEnvironment
 
+from box_agent.user_paths import configured_box_agent_home, state_path
+
 RuntimeKind = Literal["python", "node"]
 RuntimeProvider = Literal["box_agent", "host", "missing"]
 RuntimeStatus = Literal["available", "missing", "unavailable"]
 
-DEFAULT_NODE_RUNTIME_ROOT = Path.home() / ".box-agent" / "runtimes" / "node"
+DEFAULT_NODE_RUNTIME_ROOT = state_path('runtimes/node')
 DEFAULT_NODE_VERSION = "v24.15.0"
 NODE_DIST_BASE_URL = "https://nodejs.org/dist"
 _MAX_RUNTIME_PATH_LEN = 1024
@@ -262,6 +264,8 @@ class NodeRuntimeManager:
     """Discover Box-Agent's self-managed Node runtime from a manifest."""
 
     def __init__(self, root: Path | None = None):
+        if root is None and configured_box_agent_home() is not None:
+            root = state_path("runtimes/node")
         self.root = (root or _bundled_node_runtime_root() or DEFAULT_NODE_RUNTIME_ROOT).expanduser()
         self.manifest_path = self.root / "manifest.json"
         self.downloads_dir = self.root / "downloads"
@@ -763,11 +767,7 @@ def _build_node_runtime(
         office_root = (
             Path(configured_office_root).expanduser()
             if configured_office_root
-            else Path.home()
-            / ".box-agent"
-            / "box-agent-runtime"
-            / "runtimes"
-            / "node"
+            else state_path('box-agent-runtime/runtimes/node')
         )
     office_runtime = NodeRuntimeManager(root=office_root).discover()
     return office_runtime if office_runtime.available else runtime

--- a/box_agent/tools/safety.py
+++ b/box_agent/tools/safety.py
@@ -15,8 +15,10 @@ from pathlib import Path
 
 from .shell_inspection import ShellInspection, ShellInvocation, inspect_shell_command
 
+from box_agent.user_paths import state_path
+
 # Global trash directory for file backups
-TRASH_DIR = Path.home() / ".box-agent" / "trash"
+TRASH_DIR = state_path('trash')
 
 _DANGEROUS_EXECUTABLE_REASONS = {
     "chmod": "chmod: changes file permissions",

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -55,6 +55,8 @@ from box_agent.tools.sub_agent_tool import SubAgentTool
 from box_agent.tools.todo_tool import TodoReadTool, TodoStore, TodoWriteTool
 from box_agent.tools.image_inspection_tool import ImageInspectionTool
 
+from box_agent.user_paths import configured_box_agent_home, state_path
+
 if TYPE_CHECKING:
     from box_agent.tools.permissions import PermissionEngine
 
@@ -331,16 +333,24 @@ async def initialize_base_tools(
                     Path("box_agent") / skills_path,  # ./box_agent/skills
                     Config.get_package_dir() / skills_path,  # site-packages/box_agent/skills
                 ]
+                if configured_box_agent_home() is not None:
+                    # Explicit profiles never auto-discover a cwd's legacy skills directory.
+                    search_paths = [Config.get_package_dir() / skills_path]
 
-                builtin_dir = skills_path  # default
+                builtin_dir = search_paths[0] if configured_box_agent_home() is not None else skills_path
                 for path in search_paths:
                     if path.exists():
                         builtin_dir = path.resolve()
                         break
 
+            if configured_box_agent_home() is not None:
+                resolved_builtin = builtin_dir.resolve()
+                if not resolved_builtin.is_relative_to(Config.get_package_dir().resolve()):
+                    builtin_dir = state_path("skills", resolved_builtin)
+
             # User skills directory: ~/.box-agent/skills/
             # Auto-created so officev3 can drop new skills in and we pick them up on mtime change.
-            user_skills_dir = Path.home() / ".box-agent" / "skills"
+            user_skills_dir = state_path('skills')
             user_skills_dir.mkdir(parents=True, exist_ok=True)
 
             # User skills take priority on ordinary name conflicts. Runtime-
@@ -412,8 +422,10 @@ async def initialize_base_tools(
         bootstrap_target = (
             configured_mcp
             if configured_mcp.is_absolute()
-            else Path.home() / ".box-agent" / "config" / "mcp.json"
+            else state_path('config/mcp.json')
         )
+        if configured_box_agent_home() is not None:
+            bootstrap_target = state_path("config/mcp.json", bootstrap_target)
         bootstrap = bootstrap_managed_mcp_config(bootstrap_target)
         if bootstrap.warning:
             _out(f"{Colors.YELLOW}⚠️  {bootstrap.warning}{Colors.RESET}")

--- a/box_agent/tools/skill_execution_env.py
+++ b/box_agent/tools/skill_execution_env.py
@@ -9,6 +9,12 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from box_agent.tools.runtime import SkillRuntimeContext
+from box_agent.user_paths import (
+    PROFILE_ENV,
+    box_agent_home,
+    configured_box_agent_home,
+    state_path,
+)
 
 
 _MAX_SOURCE_TEXT_ENV_CHARS = 120_000
@@ -51,11 +57,16 @@ def build_skill_execution_env(
     is_windows = target_platform == "win32"
     separator = ";" if is_windows else ":"
 
-    default_root = (home_dir or Path.home()) / ".box-agent" / "skill-tools"
+    profile_root = configured_box_agent_home(inherited)
+    default_root = state_path("skill-tools", env=inherited, home_dir=home_dir)
     skill_tools_root = _safe_skill_tools_root(
         inherited.get("BOX_AGENT_SKILL_TOOLS_ROOT"),
         default=default_root,
     )
+    if profile_root is not None:
+        skill_tools_root = state_path(
+            "skill-tools", inherited.get("BOX_AGENT_SKILL_TOOLS_ROOT") or None, env=inherited
+        )
     npm_bin_dir = skill_tools_root if is_windows else skill_tools_root / "bin"
     python_user_base = skill_tools_root / "python"
     python_user_bin = python_user_base / ("Scripts" if is_windows else "bin")
@@ -104,8 +115,12 @@ def build_skill_execution_env(
 
     browser_root = Path(
         inherited.get("PLAYWRIGHT_BROWSERS_PATH")
-        or (home_dir or Path.home()) / ".box-agent" / "browsers"
+        or box_agent_home(home_dir, env=inherited) / "browsers"
     )
+    if profile_root is not None:
+        browser_root = state_path(
+            "browsers", inherited.get("PLAYWRIGHT_BROWSERS_PATH") or None, env=inherited
+        )
     browser_executable = _resolve_skill_browser_executable(
         inherited,
         browser_root=browser_root,
@@ -114,6 +129,7 @@ def build_skill_execution_env(
 
     result = {
         **runtime_env,
+        **({PROFILE_ENV: str(profile_root)} if profile_root is not None else {}),
         "BOX_AGENT_SKILL_TOOLS_ROOT": str(skill_tools_root),
         "BOX_AGENT_SKILL_PATH_PREFIX": separator.join(path_prefix),
         "PATH": separator.join(final_path),

--- a/box_agent/tools/skill_loader.py
+++ b/box_agent/tools/skill_loader.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 import yaml
 
+from box_agent.user_paths import state_path
+
 SkillSource = Literal["builtin", "user"]
 
 MANIFEST_FILENAME = "_manifest.json"
@@ -56,7 +58,7 @@ def _tokenize(text: str) -> Set[str]:
 
 
 SKILL_SLOT_SENTINEL = "__BOX_AGENT_SKILLS_SLOT__"
-SKILL_SETTINGS_PATH = Path.home() / ".box-agent" / "config" / "skill-settings.json"
+SKILL_SETTINGS_PATH = state_path('config/skill-settings.json')
 _SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
 
@@ -332,7 +334,7 @@ class SkillLoader:
         Tests and standalone loaders often point at temporary skill roots; they
         must not be affected by the developer machine's real desktop settings.
         """
-        user_skills_dir = Path.home() / ".box-agent" / "skills"
+        user_skills_dir = state_path('skills')
         for entry in self._sources:
             try:
                 if entry.directory.expanduser().resolve() == user_skills_dir.resolve():

--- a/box_agent/user_paths.py
+++ b/box_agent/user_paths.py
@@ -1,0 +1,69 @@
+"""Box-Agent-owned profile paths. Set BOX_AGENT_HOME before importing the runtime.
+
+This relocates engine state; it is not an OS sandbox or a tool permission grant.
+No directories are created here and the operating-system HOME is never changed.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+PROFILE_ENV = "BOX_AGENT_HOME"
+
+
+def configured_box_agent_home(env: Mapping[str, str] | None = None) -> Path | None:
+    source = os.environ if env is None else env
+    if PROFILE_ENV not in source:
+        return None
+    raw = source[PROFILE_ENV].strip()
+    candidate = Path(raw)
+    if not raw or "\0" in raw or not candidate.is_absolute():
+        raise ValueError("BOX_AGENT_HOME must be an absolute dedicated directory")
+    candidate = candidate.resolve()
+    if candidate == candidate.parent or Path.home().resolve().is_relative_to(candidate):
+        raise ValueError("BOX_AGENT_HOME must not be the system root or a user-home ancestor")
+    return candidate
+
+
+def box_agent_home(
+    home_dir: Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    configured = configured_box_agent_home(env)
+    return configured if configured is not None else (home_dir or Path.home()) / ".box-agent"
+
+
+def state_path(
+    relative: str,
+    override: str | Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    home_dir: Path | None = None,
+) -> Path:
+    """Resolve an owned state path; explicit profiles reject escaping overrides/symlinks."""
+    configured = configured_box_agent_home(env)
+    candidate = (
+        Path(override).expanduser()
+        if override is not None
+        else box_agent_home(home_dir, env=env) / relative
+    )
+    if configured is not None:
+        candidate = (configured / candidate).resolve()
+        if not candidate.is_relative_to(configured):
+            raise ValueError("State path is outside BOX_AGENT_HOME")
+    return candidate
+
+
+def default_memory_dir() -> str:
+    if configured_box_agent_home() is None:
+        return "~/.box-agent/memory"
+    return str(state_path("memory"))
+
+
+def default_workspace_dir() -> str:
+    if configured_box_agent_home() is None:
+        return "./workspace"
+    return str(state_path("workspace"))

--- a/box_agent/workspace_registry.py
+++ b/box_agent/workspace_registry.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
+from .user_paths import state_path
+
 
 WorkspaceTaskType = Literal["general", "code"]
 WORKSPACE_CONFIG_SCHEMA_VERSION = 1
@@ -33,7 +35,7 @@ class WorkspaceProfile:
 
 
 def default_workspace_registry_path(home_dir: Path | None = None) -> Path:
-    return (home_dir or Path.home()) / ".box-agent" / "config" / "workspaces.json"
+    return state_path("config/workspaces.json", home_dir=home_dir)
 
 
 def normalize_workspace_path(value: str | Path) -> str:

--- a/docs/PRODUCTION_GUIDE.md
+++ b/docs/PRODUCTION_GUIDE.md
@@ -130,6 +130,15 @@ each other; runtime-relative executable paths are still refreshed from the
 active manifest. Source installs use the `box-agent-web-extract-mcp` console
 script when no frozen manifest is available.
 
+The `web_extract` MCP declaration reuses the built-in tool's explicit parameter
+schema to avoid missing-`type` errors from nullable unions in some Gemini
+gateways. Only `url` is required. Model callers should omit unused `model` and
+`max_output_tokens` arguments instead of sending `null`; supplied values must
+be a string and a positive integer respectively, with no undeclared arguments.
+The MCP execution entrypoint still accepts direct legacy calls with `null`.
+Packaged users need a runtime update, an MCP/host restart, and a retry with the
+original model; source tests do not establish that deployment result.
+
 The dedicated Windows builder consumes the same PyInstaller hidden-import,
 collection, and runtime-manifest helpers as the generic builder. This keeps the
 `web_extract` dispatch and `mcp_servers` declaration identical for

--- a/docs/PRODUCTION_GUIDE_CN.md
+++ b/docs/PRODUCTION_GUIDE_CN.md
@@ -92,6 +92,12 @@ OfficeV3 不再需要单独实现注册逻辑：
 仍按当前 manifest 刷新。源码安装环境在没有 frozen manifest 时使用
 `box-agent-web-extract-mcp` console script。
 
+`web_extract` 的 MCP 声明复用内置工具的显式参数 schema，避免可空联合类型在
+部分 Gemini 网关中触发缺少 `type` 的错误。仅 `url` 必填；模型侧应省略不需要的
+`model` / `max_output_tokens`，不要传 `null`。提供时分别为字符串和正整数，
+不接受未声明的参数。MCP 服务的执行入口仍兼容旧客户端直接传入 `null`。
+已打包用户需更新 runtime、重启 MCP/宿主并用原模型复测；源码测试不能替代此步骤。
+
 Windows 专用构建器复用通用构建器的 PyInstaller hidden-import、collection 和
 runtime manifest helper，确保 `bin/box-agent-acp.exe` 的 `web_extract`
 dispatch 与 `mcp_servers` 声明一致；不要再维护 Windows 独立副本。

--- a/docs/THIRD_PARTY_API_COMPATIBILITY.md
+++ b/docs/THIRD_PARTY_API_COMPATIBILITY.md
@@ -88,11 +88,13 @@ Kimi K3 始终开启思考，因此关闭开关表示降低思考强度，不表
 
 | API Base | 模型 |
 | --- | --- |
+| `https://xiaohuanxiong.com/api/web/llm/v2` | `sn-sensenova-6-8-flash-lite`、`sn-glm-5-2`、`sn-glm-5-3-flash`、`sn-deepseek-v4-pro` |
 | `https://code-stage.xiaohuanxiong.com/api/web/llm/v2` | `sn-kimi-k3` |
 
 该名单基于真实工具续轮对照，按地址和模型精确匹配；其他组合保留现有回传行为。
-此转换不解决结构化思考块、签名或加密内容的保留问题；这些需要独立的供应商
-协议适配。
+线上 `sn-glm-5-3` 尚未验证思考回传有效，不在名单中。DeepSeek V4 有部分历史样本
+未生效，因此字段修正不代表所有续轮场景均已验证。此转换不解决结构化思考块、签名
+或加密内容的保留问题；这些需要独立的供应商协议适配。
 
 ## SenseNova OpenAI 兼容模式
 

--- a/docs/isolated-runtime-profile.md
+++ b/docs/isolated-runtime-profile.md
@@ -1,0 +1,62 @@
+# 独立运行时 profile：BOX_AGENT_HOME
+
+`BOX_AGENT_HOME` 是显式、进程级的 Box-Agent 自有状态根。宿主需要在启动 Python/独立 runtime **之前**传入一个独立的绝对目录；它不修改系统 `HOME`，也不迁移、复制或读取旧 profile 的数据。
+
+不设置该变量时，原配置搜索顺序、`~/.box-agent` 默认路径和功能默认值保持不变。空值、相对路径、系统根或用户 home 及其祖先目录作为显式值时直接报错，不按“未设置”处理。路径按宿主平台的 `pathlib.Path` 解析；不能在已导入运行时的同一个进程中切换 profile，一些既有工具常量在 import 时确定。
+
+## 配置入口
+
+显式 profile 只从 `<root>/config/config.yaml` 加载主配置。缺文件即失败，不自动生成、不从 cwd 开发配置、旧用户目录或打包的 config.yaml 兜底。
+
+仅 `system_prompt.md`、`analysis_prompt.md`、`code_prompt.md` 三种不可变提示资源可以从安装包目录补充；MCP、auth、模型档案及自定义配置没有这个回退。显式 config/auth/memory/default-workspace/MCP 路径必须解析在 profile 内；相对覆盖路径以 profile 为根，已存在的越界符号链接会被拒绝。Config 校验异常的文字不会附带整份配置输入，避免错误信息夹带凭据；调用方仍不应主动 dump 配置对象或完整 Pydantic errors 输入。
+
+开发环境可参考以下步骤（示例文件无真实凭据）：
+
+```sh
+BOX_PREVIEW_ROOT="$(mktemp -d)"
+mkdir "$BOX_PREVIEW_ROOT/config"
+cp box_agent/config/isolated-profile-example.yaml "$BOX_PREVIEW_ROOT/config/config.yaml"
+BOX_AGENT_HOME="$BOX_PREVIEW_ROOT" uv run --no-sync --offline python -m box_agent.acp.server
+```
+
+以上命令在本源码仓库中执行，使用当前 checkout，不从 PATH 猜测可能较旧的 box-agent-acp。宿主程序应自行创建并保护 profile 目录（例如 macOS/Linux 的私有临时目录），再设置子进程环境。Windows 同样传入一个本机绝对目录，不套用 POSIX 路径或更改 USERPROFILE。
+
+打包宿主必须先核验 runtime 的构建来源确实包含本改动；不能通过试启动旧 binary 来检测它是否支持这个变量，因为旧 binary 可能忽略它。改源码不会更新已安装客户端，版本号相同也不是支持证明。
+
+## 路径归属
+
+| 自有内容 | 显式 profile 默认位置 |
+| --- | --- |
+| 配置、默认 auth、MCP、模型/工作区/Skill/Obsidian 设置 | `config/` |
+| Agent 上下文持久化与长工具结果 | `sessions/` |
+| Agent 日志与诊断 trace | `log/`、`log/sessions/` |
+| 记忆 | `memory/` |
+| 默认工作区 | `workspace/` |
+| 用户 Skills / hooks | `skills/`、`hooks/` |
+| Python sandbox 与运行时安装包 | `sandbox/`、`runtime-packages/` |
+| 自管理 Node、Office 稳定运行时回退位置 | `runtimes/node/`、`box-agent-runtime/` |
+| Skill 子进程缓存 / 浏览器缓存 / 删除备份 | `skill-tools/`、`browsers/`、`trash/` |
+| CLI 历史与 Goal 元数据 | `.history`、`goals/` |
+
+统一解析由 `box_agent/user_paths.py` 提供。原权限引擎的“引擎内部数据”例外只指向当前 profile，不同时授予旧 `~/.box-agent` 的访问例外。用户显式指定的 session 工作区、项目内 `.box-agent` task registry/scratch、普通文件路径的 `~` 语义不被改写，仍由原工作区/权限逻辑控制。
+
+日志、trace、模型档案、auth、Obsidian 设置和 Skill 缓存的已有路径覆盖在显式 profile 下也须位于该根内；不设置 profile 时原覆盖行为保持。MCP 配置工具继续跟随 loader 的实际配置文件，但会拒绝指向 profile 外的旧路径。用户 Skill 根位于 profile，builtin 相对目录只从安装包查找，不再自动扫描 cwd。
+
+## 凭据与背景能力
+
+- 显式 profile 不回退读取 `BOX_AGENT_AUTH_TOKEN`、Office/Raccoon 等旧登录 token 环境变量；只接受显式调用参数或 profile 内 auth 文件。LLM/config 中显式提供的 key 仍按原协议处理。
+- 不自动导入全局 `~/.openclaw`，也不因此写“已导入/无内容”标记。
+- 根目录设置本身**不会关闭模型、MCP、Skill、hook 或记忆维护**。`isolated-profile-example.yaml` 另外关闭记忆、提取/维护、MCP、Skill 和 hooks 等后台配置；它只是无后台启动的样例，不代表所有内置工具都不再注册。
+- 上述启动示例使用 ACP 入口。普通 CLI 的 API 验证和显式任务调用仍保留原行为，不能把设置 profile 当作“禁止网络/模型调用”的开关。
+- 宿主仍应使用环境白名单，显式提供必要的 executable/只读 runtime 依赖，不继承不相关凭据、Python 搜索路径、MCP/第三方 CLI 配置或连接器。已有显式二进制路径不在此机制中自动搬动。
+- 这不是 OS sandbox、网络防火墙或用户文件访问授权。第三方 SDK/Skills/CLI 自己使用的缓存、系统 Jupyter 配置等不能靠改 Box-Agent 的根目录来统一约束。正式接入还需独立验证启动配置、工具权限、输出策略和子进程树清理；不应仅凭该环境变量宣称生产隔离完成。
+
+## 验证与回退
+
+新测试覆盖默认路径兼容、严格配置搜索、缺失配置、路径越界/符号链接、凭据与 OpenClaw 边界、权限内部目录例外、MCP 实际路径一致性和 Node 缓存选择。新进程测试在导入前设置 profile，并用 Python audit hook 拦截旧用户状态访问；使用假 LLM 完成 ACP 单轮与 SessionLog 恢复。启动测试使用假连接/假 LLM 和禁用后台的样例配置完成 initialize，禁止网络 connect。
+
+2026-09-08 源码验收：436 项相关测试通过，旧用户状态访问审计为 0；9 个纯路径替换模块反向还原后的非 import AST 与改动前一致。没有运行全仓真实网络/模型测试；两条 tar 解包弃用提示来自既有测试路径，未在本批夹带修改。
+
+所有这些都属于源码/受控测试证据，不是已打包或已安装 runtime 的真实模型验证。本分支不改版本、不安装、不迁移生产数据。回退宿主的 opt-in 只需停止该测试进程并移除子进程 `BOX_AGENT_HOME` 配置；旧 profile 未被改写。不要把测试目录直接当成生产数据迁移结果。
+
+本轮未刷新 Understand Anything 图谱；新路径模块及导入关系以当前源码为准。

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -586,6 +586,7 @@ def test_main_returns_run_agent_exit_code(
 ) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)
+    monkeypatch.setattr(cli, "WorkspaceRegistry", lambda: WorkspaceRegistry(tmp_path / "workspaces.json"))
 
     async def fake_run_agent(*args, **kwargs):
         assert args[0] == tmp_path

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -401,10 +401,12 @@ async def test_duck_typing():
 
 
 @pytest.mark.asyncio
-async def test_hook_via_agent_class():
+async def test_hook_via_agent_class(tmp_path, monkeypatch):
     """Hooks work through the Agent wrapper."""
     from box_agent.agent import Agent
     from box_agent.llm import LLMClient
+
+    monkeypatch.setattr("box_agent.logger.state_path", lambda _name: tmp_path / "log")
 
     hook = RecordingHook()
 
@@ -415,6 +417,7 @@ async def test_hook_via_agent_class():
         tools=[],
         max_steps=5,
         hooks=[hook],
+        workspace_dir=str(tmp_path / "workspace"),
     )
     agent.add_user_message("hi")
     await agent.run()

--- a/tests/test_isolated_profile.py
+++ b/tests/test_isolated_profile.py
@@ -1,0 +1,149 @@
+"""Fresh-process profile probes with only synthetic config/data and fake LLMs."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def run_profile_probe(tmp_path, script):
+    root = tmp_path / "profile"
+    root.mkdir()
+    # Preserve OS identity, not credentials or runtime overrides. Never replace HOME.
+    keep = {"PATH", "HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "SYSTEMROOT", "WINDIR", "TMP", "TEMP", "TMPDIR", "LANG"}
+    env = {key: value for key, value in os.environ.items() if key in keep}
+    env.update({"BOX_AGENT_HOME": str(root), "PYTHONDONTWRITEBYTECODE": "1", "BOX_AGENT_SESSION_TRACE_ENABLED": "0"})
+    prefix = '''
+import os, sys
+from pathlib import Path
+root = Path(os.environ["BOX_AGENT_HOME"])
+old_roots = [Path.home() / ".box-agent", Path.home() / ".openclaw"]
+blocked_attempts = []
+def audit(event, args):
+    if event not in {"open", "os.listdir", "os.scandir", "os.mkdir", "os.remove", "os.rename"}: return
+    for raw in args[:2] if event == "os.rename" else args[:1]:
+        if not isinstance(raw, (str, bytes, os.PathLike)): continue
+        path = Path(os.fsdecode(raw)).absolute()
+        if any(path == old or old in path.parents for old in old_roots):
+            blocked_attempts.append(event)
+            raise AssertionError("Probe touched legacy user state")
+sys.addaudithook(audit)
+'''
+    verified_script = prefix + script + '\nassert not blocked_attempts, "Legacy access was attempted even if caught"\n'
+    result = subprocess.run([sys.executable, "-c", verified_script], cwd=Path(__file__).resolve().parents[1], env=env, capture_output=True, text=True, timeout=45)
+    assert result.returncode == 0, result.stdout + result.stderr
+    return root
+
+
+def test_all_engine_default_providers_and_constructor_writes_use_profile(tmp_path):
+    run_profile_probe(tmp_path, '''
+from box_agent.logger import AgentLogger
+from box_agent.memory import MemoryManager
+from box_agent.workspace_registry import WorkspaceRegistry, default_workspace_registry_path
+from box_agent.session_trace import default_session_trace_dir
+from box_agent.llm.model_profiles import default_model_profile_registry_path
+from box_agent.tools.mcp_bootstrap import default_managed_mcp_config_path
+from box_agent.tools.obsidian_tool import obsidian_config_path
+from box_agent.tools.skill_loader import SKILL_SETTINGS_PATH
+from box_agent.tools.safety import TRASH_DIR
+from box_agent.tools.jupyter_tool import SANDBOX_BASE_DIR, RUNTIME_PACKAGES_DIR
+from box_agent.tools.runtime import DEFAULT_NODE_RUNTIME_ROOT, SkillRuntimeContext
+from box_agent.tools.skill_execution_env import build_skill_execution_env
+from box_agent.hooks import USER_HOOKS_DIR
+from box_agent.config import AgentConfig
+
+paths = [AgentLogger().log_dir, MemoryManager().memory_dir, default_workspace_registry_path(),
+    default_session_trace_dir(), default_model_profile_registry_path(), default_managed_mcp_config_path(),
+    obsidian_config_path(), SKILL_SETTINGS_PATH, TRASH_DIR, SANDBOX_BASE_DIR, RUNTIME_PACKAGES_DIR,
+    DEFAULT_NODE_RUNTIME_ROOT, USER_HOOKS_DIR, Path(AgentConfig().workspace_dir)]
+assert all(path.is_relative_to(root) for path in paths), paths
+WorkspaceRegistry().set(root / "workspace", "general")
+assert (root / "config/workspaces.json").is_file()
+env = build_skill_execution_env(SkillRuntimeContext(runtimes={}))
+assert env["BOX_AGENT_HOME"] == str(root)
+assert Path(env["BOX_AGENT_SKILL_TOOLS_ROOT"]).is_relative_to(root)
+assert Path(env["PLAYWRIGHT_BROWSERS_PATH"]).is_relative_to(root)
+''')
+
+
+def test_fake_acp_turn_and_session_recovery_never_access_legacy_profile(tmp_path):
+    root = run_profile_probe(tmp_path, '''
+import asyncio
+from types import SimpleNamespace
+from box_agent.acp import BoxACPAgent
+from box_agent.config import AgentConfig, Config, LLMConfig, ToolsConfig
+from tests.test_acp import DummyConn, DoneLLM
+
+async def probe():
+    config = Config(llm=LLMConfig(api_key="fixture-key"),
+        agent=AgentConfig(workspace_dir=str(root / "workspace"), enable_memory=False, max_steps=2),
+        tools=ToolsConfig(enable_mcp=False, enable_skills=False, enable_sub_agent=False))
+    request = SimpleNamespace(cwd=str(root / "workspace"), field_meta={"session_id": "isolated-fixture"})
+    first = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
+    session = await first.newSession(request)
+    response = await first.prompt(SimpleNamespace(sessionId=session.sessionId, prompt=[{"text": "fixture"}], field_meta={}))
+    assert response.field_meta["ok"] is True
+    first._sessions[session.sessionId].agent.session_log.close()
+    second = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
+    restored = await second.newSession(request)
+    state = second._sessions[restored.sessionId]
+    assert [message.content for message in state.agent.messages][-2:] == ["fixture", "done"]
+    state.agent.session_log.close()
+asyncio.run(probe())
+''')
+    assert list((root / "sessions").rglob("session.jsonl"))
+
+
+def test_profile_example_reaches_acp_initialize_without_memory_mcp_skills_or_network(tmp_path):
+    run_profile_probe(tmp_path, '''
+import asyncio, shutil, socket
+from types import SimpleNamespace
+import box_agent.acp as acp
+from box_agent.config import Config
+from tests.test_acp import DummyConn
+
+(root / "config").mkdir()
+shutil.copyfile(Config.get_package_dir() / "config/isolated-profile-example.yaml", root / "config/config.yaml")
+config = Config.load()
+assert not config.agent.enable_memory and not config.agent.enable_memory_extraction
+assert not config.tools.enable_mcp and not config.tools.enable_skills and not config.hooks.hooks
+def forbidden(*args, **kwargs): raise AssertionError("Unexpected background or network work")
+socket.socket.connect = forbidden
+acp.MemoryManager = forbidden
+calls = []
+def fake_llm(**kwargs):
+    assert kwargs["api_key"] == "isolated-fixture-key"
+    assert Path(kwargs["auth_file"]).is_relative_to(root)
+    calls.append("llm-constructor-only")
+    return SimpleNamespace()
+acp.LLMClient = fake_llm
+real_tools = acp.initialize_base_tools
+async def tools(*args, **kwargs):
+    result = await real_tools(*args, **kwargs)
+    assert result[1:] == (None, None, None)
+    calls.append("no-background-tools")
+    return result
+acp.initialize_base_tools = tools
+async def streams(): return object(), SimpleNamespace(transport=SimpleNamespace(_is_closing=False))
+acp.stdio_streams_largebuf = streams
+
+async def probe():
+    loop = asyncio.get_running_loop()
+    shutdown = []
+    loop.add_signal_handler = lambda signal, callback: shutdown.append(callback)
+    loop.remove_signal_handler = lambda signal: True
+    initialized = []
+    def connected(factory, writer, reader):
+        agent = factory(DummyConn())
+        async def handshake():
+            response = await agent.initialize(SimpleNamespace(field_meta={}))
+            initialized.append(response.protocolVersion)
+            assert response.agentCapabilities.loadSession is False
+            shutdown[0]()
+        asyncio.create_task(handshake())
+    acp.AgentSideConnection = connected
+    await acp.run_acp_server(config)
+    assert initialized == [1]
+asyncio.run(probe())
+assert calls == ["llm-constructor-only", "no-background-tools"]
+''')

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -872,10 +872,10 @@ def test_openai_response_parses_reasoning_aliases(reasoning_fields):
 @pytest.mark.parametrize(
     ("api_base", "model", "replay_field"),
     [
-        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-sensenova-6-8-flash-lite", "reasoning_details"),
-        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-glm-5-2", "reasoning_details"),
-        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-glm-5-3-flash", "reasoning_details"),
-        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-deepseek-v4-pro", "reasoning_details"),
+        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-sensenova-6-8-flash-lite", "reasoning_content"),
+        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-glm-5-2", "reasoning_content"),
+        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-glm-5-3-flash", "reasoning_content"),
+        ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-deepseek-v4-pro", "reasoning_content"),
         ("https://code-stage.xiaohuanxiong.com/api/web/llm/v2", "sn-kimi-k3", "reasoning_content"),
         ("https://code-stage.xiaohuanxiong.com/api/web/llm/v2/", " SN-Kimi-K3 ", "reasoning_content"),
         ("https://xiaohuanxiong.com/api/web/llm/v2", "sn-glm-5-3", "reasoning_details"),
@@ -917,6 +917,73 @@ def test_openai_reasoning_replay_matches_verified_gateway(
             replay_field: thinking if replay_field == "reasoning_content" else [{"text": thinking}],
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize(
+    ("api_base", "replay_field"),
+    [
+        ("https://xiaohuanxiong.com/api/web/llm/v2", "reasoning_content"),
+        ("https://other.example/v1", "reasoning_details"),
+    ],
+)
+async def test_tool_followup_wire_preserves_reasoning_and_tool_identity(
+    streaming, api_base, replay_field,
+):
+    captured = {}
+    thinking = "  Remember the lookup result.\nKeep this text unchanged.\n"
+
+    async def handler(request):
+        captured.update(json.loads(request.content))
+        common = {"id": "test", "created": 0, "model": "sn-glm-5-2"}
+        if streaming:
+            chunk = {
+                **common, "object": "chat.completion.chunk",
+                "choices": [{"index": 0, "delta": {"content": "42"}, "finish_reason": "stop"}],
+            }
+            return httpx.Response(
+                200, headers={"content-type": "text/event-stream"},
+                text=f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n",
+            )
+        return httpx.Response(200, json={
+            **common, "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "42"}, "finish_reason": "stop"}],
+        })
+
+    client = OpenAIClient(api_key="k", api_base=api_base, model="sn-glm-5-2")
+    await client.client.close()
+    client.client = AsyncOpenAI(
+        api_key="k", base_url=api_base,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    messages = [
+        Message(role="user", content="Look up the number."),
+        Message(role="assistant", content="", thinking=thinking, tool_calls=[{
+            "id": "call-1", "type": "function", "function": {"name": "lookup", "arguments": {}},
+        }]),
+        Message(role="tool", content="42", tool_call_id="call-1"),
+    ]
+    try:
+        if streaming:
+            events = [event async for event in client.generate_stream(messages)]
+            assert "".join(event.delta or "" for event in events if event.type == "text") == "42"
+        else:
+            assert (await client.generate(messages)).content == "42"
+    finally:
+        await client.client.close()
+
+    assistant = captured["messages"][1]
+    assert assistant[replay_field] == (
+        thinking if replay_field == "reasoning_content" else [{"text": thinking}]
+    )
+    other_field = "reasoning_details" if replay_field == "reasoning_content" else "reasoning_content"
+    assert other_field not in assistant
+    assert assistant["tool_calls"] == [{
+        "id": "call-1", "type": "function",
+        "function": {"name": "lookup", "arguments": "{}"},
+    }]
+    assert captured["messages"][2] == {"role": "tool", "content": "42", "tool_call_id": "call-1"}
 
 
 # ───────────────────────── Core plumbing ─────────────────────────

--- a/tests/test_user_paths.py
+++ b/tests/test_user_paths.py
@@ -1,0 +1,214 @@
+"""Opt-in profile routing; tests never change the process HOME variable."""
+
+from pathlib import Path
+
+import pytest
+
+from box_agent.config import AgentConfig, Config
+from box_agent.user_paths import box_agent_home, configured_box_agent_home, state_path
+
+
+def write_config(path: Path, **extra) -> None:
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump({
+        "api_key": "fixture-key", "api_base": "https://example.invalid/v1",
+        "provider": "openai", "model": "fixture", "enable_memory": False,
+        "tools": {"enable_skills": False, "enable_mcp": False}, **extra,
+    }), encoding="utf-8")
+
+
+def test_unset_root_keeps_legacy_paths_and_config_defaults(tmp_path, monkeypatch):
+    monkeypatch.delenv("BOX_AGENT_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert configured_box_agent_home() is None
+    assert box_agent_home() == tmp_path / ".box-agent"
+    assert box_agent_home(home_dir=tmp_path / "another") == tmp_path / "another/.box-agent"
+    assert state_path("sessions") == tmp_path / ".box-agent/sessions"
+    assert state_path("log", "relative-log") == Path("relative-log")
+    assert AgentConfig().memory_dir == "~/.box-agent/memory"
+    assert AgentConfig().workspace_dir == "./workspace"
+
+
+def test_explicit_root_is_authoritative_without_creating_directories(tmp_path, monkeypatch):
+    root = tmp_path / "独立 profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    assert box_agent_home(home_dir=tmp_path / "ignored") == root
+    assert state_path("config/auth.json") == root / "config/auth.json"
+    assert state_path("log", "custom/log") == root / "custom/log"
+    assert not root.exists()
+    assert AgentConfig().memory_dir == str(root / "memory")
+    assert AgentConfig().workspace_dir == str(root / "workspace")
+
+
+@pytest.mark.parametrize("value", ["", " ", "relative/profile", "~/profile", "C:relative", "/"])
+def test_invalid_explicit_root_never_falls_back(value, monkeypatch):
+    monkeypatch.setenv("BOX_AGENT_HOME", value)
+    with pytest.raises(ValueError, match="BOX_AGENT_HOME"):
+        box_agent_home()
+
+
+def test_explicit_root_rejects_home_and_owned_path_escape(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path))
+    with pytest.raises(ValueError, match="BOX_AGENT_HOME"):
+        box_agent_home()
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    for override in [tmp_path / "old/auth.json", "../old/auth.json"]:
+        with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+            state_path("config/auth.json", override)
+
+
+def test_symlink_escape_is_rejected(tmp_path, monkeypatch):
+    root = tmp_path / "profile"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (root / "config").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("Directory symlinks unavailable on this platform")
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+        state_path("config/auth.json")
+
+
+def test_config_is_only_loaded_from_explicit_profile(tmp_path, monkeypatch):
+    root, cwd, package = tmp_path / "profile", tmp_path / "cwd", tmp_path / "package"
+    cwd.mkdir()
+    write_config(cwd / "box_agent/config/config.yaml", model="wrong-cwd")
+    write_config(package / "config/config.yaml", model="wrong-package")
+    write_config(root / "config/config.yaml")
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    monkeypatch.setattr(Config, "get_package_dir", classmethod(lambda cls: package))
+    config = Config.load()
+    assert config.llm.model == "fixture"
+    assert config.llm.auth_file == str(root / "config/auth.json")
+    assert config.agent.memory_dir == str(root / "memory")
+    assert not config.agent.enable_memory
+
+
+def test_missing_isolated_config_does_not_bootstrap_or_fall_back(tmp_path, monkeypatch):
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    with pytest.raises(FileNotFoundError, match="config.yaml"):
+        Config.load()
+    assert not root.exists()
+
+
+def test_only_bundled_prompt_resources_may_fall_back(tmp_path, monkeypatch):
+    root, package = tmp_path / "profile", tmp_path / "package"
+    (package / "config").mkdir(parents=True)
+    for name in ["system_prompt.md", "mcp.json", "auth.json", "config.yaml"]:
+        (package / "config" / name).write_text("fixture", encoding="utf-8")
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    monkeypatch.setattr(Config, "get_package_dir", classmethod(lambda cls: package))
+    assert Config.find_config_file("system_prompt.md") == package / "config/system_prompt.md"
+    for name in ["mcp.json", "auth.json", "config.yaml"]:
+        assert Config.find_config_file(name) is None
+
+
+def test_explicit_config_and_memory_auth_paths_cannot_read_old_profile(tmp_path, monkeypatch):
+    root = tmp_path / "profile"
+    outside = tmp_path / "outside.yaml"
+    write_config(outside)
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+        Config.from_yaml(outside)
+    for key in ["auth_file", "memory_dir"]:
+        write_config(root / "config/config.yaml", **{key: str(tmp_path / "old")})
+        with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+            Config.load()
+
+
+@pytest.mark.asyncio
+async def test_profile_does_not_inherit_login_token_env_or_openclaw_memory(tmp_path, monkeypatch):
+    from box_agent.auth import resolve_auth_token
+    from box_agent.memory import MemoryManager
+
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    monkeypatch.setenv("BOX_AGENT_AUTH_TOKEN", "not-a-real-token")
+    assert resolve_auth_token() == ""
+    assert resolve_auth_token("explicit-fixture") == "explicit-fixture"
+    auth_file = root / "config/auth.json"
+    auth_file.parent.mkdir(parents=True)
+    auth_file.write_text('{"token":"profile-fixture"}', encoding="utf-8")
+    assert resolve_auth_token(auth_file=auth_file) == "profile-fixture"
+    memory = MemoryManager()
+    original_is_dir = Path.is_dir
+
+    def guard(path):
+        assert path != Path.home() / ".openclaw", "Global OpenClaw must not be inspected"
+        return original_is_dir(path)
+
+    monkeypatch.setattr(Path, "is_dir", guard)
+    assert await memory.import_openclaw(object()) == ""
+    assert not memory._openclaw_imported_marker.exists()
+
+
+def test_mcp_writer_preserves_in_profile_loader_path_but_rejects_external_path(tmp_path, monkeypatch):
+    from box_agent.tools import mcp_loader
+    from box_agent.tools.mcp_config_tool import _resolve_write_target
+
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    custom = root / "config/custom/mcp.json"
+    monkeypatch.setattr(mcp_loader, "get_mcp_config_path", lambda: str(custom))
+    assert _resolve_write_target() == custom
+    outside = tmp_path / "outside/mcp.json"
+    monkeypatch.setattr(mcp_loader, "get_mcp_config_path", lambda: str(outside))
+    with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+        _resolve_write_target()
+    assert not outside.parent.exists()
+
+
+def test_profile_private_data_allowance_does_not_include_legacy_box_agent(tmp_path, monkeypatch):
+    from box_agent.tools.permissions import CapabilityPolicy, PermissionEngine
+
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    policy = CapabilityPolicy(filesystem_scope="session_workspace", session_workspace_root=str(root / "workspace"))
+    engine = PermissionEngine(policy, root / "workspace")
+    assert engine.check("filesystem.read", {"path": str(root / "config/auth.json")}).allowed
+    assert not engine.check("filesystem.read", {"path": str(Path.home() / ".box-agent/config/auth.json")}).allowed
+
+
+def test_absolute_config_lookup_and_owned_overrides_are_contained(tmp_path, monkeypatch):
+    from box_agent.llm.model_profiles import default_model_profile_registry_path
+    from box_agent.session_trace import default_session_trace_dir
+
+    root = tmp_path / "profile"
+    write_config(root / "config/config.yaml")
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    assert Config.find_config_file(str(root / "config/config.yaml")) == root / "config/config.yaml"
+    with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+        Config.find_config_file(str(tmp_path / "old/config.yaml"))
+    for name, getter in [("BOX_AGENT_MODEL_PROFILES_FILE", default_model_profile_registry_path), ("BOX_AGENT_SESSION_TRACE_DIR", default_session_trace_dir)]:
+        monkeypatch.setenv(name, str(tmp_path / "old"))
+        with pytest.raises(ValueError, match="outside BOX_AGENT_HOME"):
+            getter()
+
+
+def test_profile_default_node_cache_does_not_choose_a_bundled_write_location(tmp_path, monkeypatch):
+    from box_agent.tools import runtime
+
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    monkeypatch.setattr(runtime, "_bundled_node_runtime_root", lambda: tmp_path / "readonly-bundle")
+    assert runtime.NodeRuntimeManager().root == root / "runtimes/node"
+
+
+def test_profile_validation_error_does_not_echo_config_credentials(tmp_path, monkeypatch):
+    from box_agent.config import LLMConfig, ToolsConfig
+
+    root = tmp_path / "profile"
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    with pytest.raises(ValueError) as error:
+        Config(llm=LLMConfig(api_key="credential-must-not-appear"),
+               agent=AgentConfig(memory_dir=str(tmp_path / "outside")), tools=ToolsConfig())
+    assert "credential-must-not-appear" not in str(error.value)
+    assert "input_value" not in str(error.value)

--- a/tests/test_web_extract_server.py
+++ b/tests/test_web_extract_server.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from jsonschema import Draft202012Validator
+from mcp.server.fastmcp.exceptions import ToolError
+
+from box_agent.llm import AnthropicClient, OpenAIClient
+from box_agent.mcp_servers import web_extract_server
+from box_agent.tools.base import ToolResult
+from box_agent.tools.mcp_loader import MCPTool
+
+
+@pytest.mark.asyncio
+async def test_advertised_parameters_have_explicit_types_in_both_provider_formats():
+    listed = await web_extract_server.mcp.list_tools()
+    assert len(listed) == 1
+    tool = listed[0]
+    assert tool.name == "web_extract"
+    wrapper = MCPTool(
+        name=tool.name,
+        description=tool.description or "",
+        parameters=tool.inputSchema,
+        session=SimpleNamespace(),
+    )
+    openai = OpenAIClient._convert_tools(None, [wrapper])[0]
+    anthropic = AnthropicClient._convert_tools(None, [wrapper])[0]
+
+    for schema in (
+        tool.inputSchema,
+        openai["function"]["parameters"],
+        anthropic["input_schema"],
+    ):
+        Draft202012Validator.check_schema(schema)
+        assert schema["required"] == ["url"]
+        for name, expected_type in (
+            ("url", "string"),
+            ("model", "string"),
+            ("max_output_tokens", "integer"),
+        ):
+            parameter = schema["properties"][name]
+            assert parameter["type"] == expected_type
+            assert "anyOf" not in parameter
+            assert "default" not in parameter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "optional_arguments",
+    [{}, {"model": "summary-model", "max_output_tokens": 8_000}],
+)
+async def test_advertised_tool_accepts_omitted_or_typed_optional_arguments(
+    optional_arguments,
+):
+    tool = (await web_extract_server.mcp.list_tools())[0]
+    session = SimpleNamespace(
+        call_tool=AsyncMock(
+            return_value=SimpleNamespace(content=[], isError=False),
+        ),
+    )
+    wrapper = MCPTool(
+        name=tool.name,
+        description=tool.description or "",
+        parameters=tool.inputSchema,
+        session=session,
+    )
+    arguments = {"url": "https://example.com", **optional_arguments}
+    result = await wrapper.invoke(arguments)
+    assert result.success
+    session.call_tool.assert_awaited_once_with("web_extract", arguments=arguments)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {},
+        {"url": "https://example.com", "model": 12},
+        {"url": "https://example.com", "max_output_tokens": "invalid"},
+        {"url": "https://example.com", "max_output_tokens": 0},
+        {"url": "https://example.com", "model": None},
+        {"url": "https://example.com", "max_output_tokens": None},
+        {"url": "https://example.com", "unknown": True},
+    ],
+)
+async def test_advertised_tool_rejects_invalid_arguments_before_dispatch(arguments):
+    tool = (await web_extract_server.mcp.list_tools())[0]
+    session = SimpleNamespace(call_tool=AsyncMock())
+    wrapper = MCPTool(
+        name=tool.name,
+        description=tool.description or "",
+        parameters=tool.inputSchema,
+        session=session,
+    )
+    result = await wrapper.invoke(arguments)
+    assert not result.success
+    assert result.error.startswith("INVALID_TOOL_ARGUMENTS:")
+    session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "optional_arguments",
+    [
+        {},
+        {"model": "summary-model", "max_output_tokens": 8_000},
+        {"model": None, "max_output_tokens": None},
+    ],
+)
+async def test_mcp_execution_preserves_defaults_values_and_legacy_nulls(
+    monkeypatch, optional_arguments,
+):
+    extractor = SimpleNamespace(
+        execute=AsyncMock(return_value=ToolResult(success=True, content="extracted")),
+    )
+    monkeypatch.setattr(web_extract_server, "_extractor", lambda: extractor)
+    content, structured = await web_extract_server.mcp.call_tool(
+        "web_extract", {"url": "https://example.com", **optional_arguments},
+    )
+    assert content[0].text == "extracted"
+    assert structured == {"result": "extracted"}
+    extractor.execute.assert_awaited_once_with(
+        url="https://example.com",
+        model=optional_arguments.get("model"),
+        max_output_tokens=optional_arguments.get("max_output_tokens"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_execution_reports_extraction_failure(monkeypatch):
+    extractor = SimpleNamespace(
+        execute=AsyncMock(
+            return_value=ToolResult(success=False, error="Web extraction timed out"),
+        ),
+    )
+    monkeypatch.setattr(web_extract_server, "_extractor", lambda: extractor)
+    with pytest.raises(ToolError, match="Web extraction timed out"):
+        await web_extract_server.mcp.call_tool(
+            "web_extract", {"url": "https://example.com"},
+        )


### PR DESCRIPTION
## TPR

### Task

为宿主增加显式的 `BOX_AGENT_HOME` 配置与状态根，并交付本地剩余的模型回传和 MCP 参数兼容修复。本 PR 保持 Draft，暂不合并。

- 运行时目录隔离：配置、auth、会话、日志、记忆、用户 Skills/hooks 及缓存共用 `user_paths.py`。未设置变量时保留现有默认路径；显式 profile 要求独立配置，并拒绝越界的自有状态路径、旧登录 token 环境变量回退及全局 OpenClaw 自动导入。
- 模型兼容：对指定生产网关的 SenseNova Flash Lite、GLM 5.2、GLM 5.3 Flash、DeepSeek V4 Pro 回传 `reasoning_content`；未命中的地址和模型继续使用原字段。新增流式和非流式工具续轮请求体检查。
- MCP 参数：包含当前分支已有的 web_extract 修复，使用显式 string/integer 参数 schema，保留直接执行时的 legacy-null 兼容。
- 受影响入口：CLI、ACP、共享配置/认证、状态存储、Skill 环境和 OpenAI 兼容适配器。
- 范围边界：不更改系统 HOME，不迁移用户数据，不安装运行时，不更改版本，不修改 OfficeV3，不合并本 PR。

远端 `main` 已包含 K3 提交 `a327208`，本 PR 不重复包含 K3 的改动。提交按职责拆分：

- `b9fc731`：MCP web_extract 参数 schema。
- `7e13fac`：其他模型的思考回传兼容。
- `748c320`：运行时目录隔离、测试与文档。

### Proof

- 当前源码相关回归：**976 passed, 1 skipped**。跳过项为 `tests/test_safety.py 中的 test_windows_drive_inside_workspace_allowed` 的 Windows 路径语义测试；本机为 macOS。两个 warning 来自既有 tar 解包弃用提示。

```sh
uv run --no-sync --offline pytest tests/test_user_paths.py tests/test_isolated_profile.py tests/test_cli_config.py tests/test_cli_runtime.py tests/test_skill_runtime.py tests/test_thinking.py tests/test_auth.py tests/test_memory.py tests/test_permissions.py tests/test_session_trace.py tests/test_workspace_registry.py tests/test_model_profiles.py tests/test_hooks.py tests/test_mcp_config_tool.py tests/test_mcp_bootstrap.py tests/test_skill_loader.py tests/test_acp.py tests/test_core.py tests/test_web_extract_server.py tests/test_obsidian_tool.py tests/test_safety.py -q --tb=short
uv run --no-sync --offline python -m compileall -q box_agent
git diff origin/main...HEAD --check
```

- 新进程测试在 import 前传入 profile，审计旧用户状态访问；模拟 ACP 初始化、单轮请求和 SessionLog 恢复。无后台配置的启动探针拒绝网络连接。
- 34 个原工作文件与提交前的 SHA-256 完全一致，没有将本地日志、凭据、输出产物或缓存加入提交。
- 未运行完整 `general_review/ci/preflight.sh`（全依赖安装、全仓测试及发行构建）；本次验证覆盖相关源码路径，`teamwork/local-ci` 尚无通过结论。
- 本次未进行新的真实网关调用、物理 Windows 测试、运行时打包/安装、宿主重启或真实 OfficeV3 任务验证。

### Risk

- 默认兼容：未启用 profile 时保留现有路径和配置查找；显式启用后缺配置、越界路径和旧凭据回退会报错或被拒绝。宿主必须在导入/启动运行时之前设置变量。
- 隔离边界：只管理 Box-Agent 自有路径；不提供 OS sandbox、网络隔离，也不自动约束第三方 SDK/CLI 缓存和配置。
- 模型协议：回传规则按 API base + model 精确匹配；DeepSeek V4 仍有历史样本未生效，字段修正不等于所有续轮场景均通过。签名/加密思考块不在此转换范围。
- MCP 兼容：公开 schema 要求可选参数省略而非 null，token 上限为正整数；直接 MCP 执行仍接受旧 null 调用。
- 打包与宿主：目前仅源码验证。消费者须重建、安装并重启对应 runtime 后重新验证；无跨仓修改、真实凭据或生产数据迁移。
- 回退：提交按职责拆分，可独立回退；profile opt-in 可在停止测试进程后移除宿主环境配置。原用户 profile 不迁移、不改写。

### Design and architecture impact

- `user_paths.py` 统一配置与状态路径，CLI/ACP 共用契约；kernel 循环只替换工具结果存储的默认路径。
- 模型请求仍由共享 OpenAI 适配器转换；web_extract 复用已有工具参数 schema，不全局改写第三方 MCP schema。
- 更新 README、隔离 profile 指南/示例、第三方 API 兼容说明和生产指南。没有修改 builtin Skill 内容，manifest 不需重生成。
- Understand Anything 图谱早于这批改动，未刷新；本次以真实源码、差异和测试为准。

### Target branch consistency

- Base: `main` / a327208747bcd4e6bf6bf0595ac1b9ea7f2d9e4a
- Head: `748c32009f96d72e4fcd85fc37bd7b780372109e`
- 更新 PR 前已 fetch 并完成 `git rebase origin/main`；已自动跳过 main 中等价的 K3 提交，未将 main merge 到功能分支。rebase 前后 Git tree 完全相同，因此上述 976 项测试对应当前源码。
- 基线包含 K3 与既有 web_search/tool_search schema 兼容修复。当前 PR 的 MCP schema 修复限定于 bundled web_extract；保留 main 的 K3 行为。

## Checklist

- [x] 本地剩余改动按独立职责提交，完整范围已在 Task 中列明。
- [x] 从当前源码核对实际调用路径和归属，共享策略未在 CLI/ACP 中重复实现。
- [x] 相关工具、模型、配置、权限、CLI、ACP、memory 与 core 回归通过。
- [x] 用户文档、示例及运行时边界已说明。
- [x] 未包含本地配置、凭据、日志、workspace 产物或图谱缓存。
- [x] 已 rebase 最新远端 main，没有反向 merge main。
- [ ] 完整 preflight / teamwork/local-ci 通过（本次未运行，不能据此声称 merge-ready）。
- [ ] 已打包宿主与真实模型验证（本次未执行）。
