### PR TITLE
fix(mcp): Pass isolated profiles to managed stdio servers

### DIFF
--- a/box_agent/tools/mcp_bootstrap.py
+++ b/box_agent/tools/mcp_bootstrap.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
-from box_agent.user_paths import state_path
+from box_agent.user_paths import PROFILE_ENV, configured_box_agent_home, state_path
 
 
 MANAGED_MCP_SCHEMA_KEY = "boxAgentManagedMcpVersion"
@@ -242,6 +242,7 @@ def bootstrap_managed_mcp_config(
     Later runs preserve explicit user ``disabled`` and hosted-search URL choices
     while refreshing runtime-relative executable paths.
     """
+    profile_root = configured_box_agent_home()
     path = path.expanduser()
     hosted_search_server, hosted_search_warning, host_override = (
         _resolve_hosted_search_server(hosted_search_url)
@@ -296,6 +297,14 @@ def bootstrap_managed_mcp_config(
             managed,
             migrate_legacy_disabled=not already_migrated,
         )
+        if profile_root is not None and "command" in managed:
+            # The MCP SDK does not inherit BOX_AGENT_HOME by default. Keep
+            # managed children on the current profile even after a profile move.
+            server_env = servers[name].get("env")
+            servers[name]["env"] = {
+                **(server_env if isinstance(server_env, dict) else {}),
+                PROFILE_ENV: str(profile_root),
+            }
 
     updated = dict(payload)
     updated["mcpServers"] = servers

--- a/docs/isolated-runtime-profile.md
+++ b/docs/isolated-runtime-profile.md
@@ -42,6 +42,8 @@ BOX_AGENT_HOME="$BOX_PREVIEW_ROOT" uv run --no-sync --offline python -m box_agen
 
 日志、trace、模型档案、auth、Obsidian 设置和 Skill 缓存的已有路径覆盖在显式 profile 下也须位于该根内；不设置 profile 时原覆盖行为保持。MCP 配置工具继续跟随 loader 的实际配置文件，但会拒绝指向 profile 外的旧路径。用户 Skill 根位于 profile，builtin 相对目录只从安装包查找，不再自动扫描 cwd。
 
+Box-Agent 管理的 stdio MCP（包括内置 Web Extract）会在启动配置中显式传入当前 `BOX_AGENT_HOME`，覆盖该管理项中残留的旧 profile 值，并保留其他环境配置。自定义 MCP 和远端 HTTP 服务配置不受此规则影响；未启用 profile 时保留原行为。
+
 ## 凭据与背景能力
 
 - 显式 profile 不回退读取 `BOX_AGENT_AUTH_TOKEN`、Office/Raccoon 等旧登录 token 环境变量；只接受显式调用参数或 profile 内 auth 文件。LLM/config 中显式提供的 key 仍按原协议处理。

--- a/tests/test_mcp_bootstrap.py
+++ b/tests/test_mcp_bootstrap.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from box_agent.tools.mcp_bootstrap import (
     HOSTED_SEARCH_URL_ENV,
     HOSTED_SEARCH_SERVER_NAME,
@@ -276,3 +278,109 @@ def test_bootstrap_rejects_runtime_entry_outside_root(tmp_path: Path) -> None:
     payload = json.loads(config.read_text(encoding="utf-8"))
 
     assert "unsafe" not in payload["mcpServers"]
+
+
+@pytest.mark.parametrize("bundled", [False, True])
+def test_managed_stdio_uses_current_profile_and_preserves_other_server_env(
+    tmp_path, monkeypatch, bundled,
+):
+    root = tmp_path / "profile"
+    root.mkdir()
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    config = root / "mcp.json"
+    custom = {"command": "custom-mcp", "env": {"CUSTOM": "kept"}}
+    config.write_text(json.dumps({"mcpServers": {
+        "box-agent-web-extract": {"env": {
+            "BOX_AGENT_HOME": str(tmp_path / "old-profile"), "CUSTOM": "kept",
+        }},
+        "custom": custom,
+    }}), encoding="utf-8")
+    kwargs = {"runtime_root": _runtime(tmp_path)} if bundled else {
+        "web_extract_command": "fixture-web-extract",
+    }
+    bootstrap_managed_mcp_config(config, **kwargs)
+    servers = json.loads(config.read_text(encoding="utf-8"))["mcpServers"]
+    assert servers["box-agent-web-extract"]["env"] == {
+        "BOX_AGENT_HOME": str(root.resolve()), "CUSTOM": "kept",
+    }
+    assert servers["custom"] == custom
+    assert "env" not in servers[HOSTED_SEARCH_SERVER_NAME]
+    assert not bootstrap_managed_mcp_config(config, **kwargs).changed
+
+
+def test_unset_profile_preserves_managed_server_environment(tmp_path, monkeypatch):
+    monkeypatch.delenv("BOX_AGENT_HOME", raising=False)
+    config = tmp_path / "mcp.json"
+    existing_env = {"CUSTOM": "kept"}
+    config.write_text(json.dumps({"mcpServers": {
+        "box-agent-web-extract": {"env": existing_env},
+    }}), encoding="utf-8")
+    bootstrap_managed_mcp_config(config, web_extract_command="fixture-web-extract")
+    servers = json.loads(config.read_text(encoding="utf-8"))["mcpServers"]
+    assert servers["box-agent-web-extract"]["env"] == existing_env
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("has_config", [True, False])
+async def test_managed_web_extract_child_loads_only_profile_config(
+    tmp_path, monkeypatch, has_config,
+):
+    import sys
+    from box_agent.tools.mcp_loader import MCPServerConnection
+
+    root = tmp_path / "profile"
+    (root / "config").mkdir(parents=True)
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    if has_config:
+        (root / "config/config.yaml").write_text(
+            "api_key: fixture-key\napi_base: https://example.invalid/v1\n"
+            "provider: openai\nmodel: profile-fixture\n",
+            encoding="utf-8",
+        )
+    child = tmp_path / "web_extract_fixture.py"
+    child.write_text('''
+import json, os, sys
+from types import SimpleNamespace
+sys.path.insert(0, sys.argv[1])
+from box_agent.mcp_servers import web_extract_server as server
+from box_agent.tools.base import ToolResult
+
+original_create_llm = server._create_configured_llm
+def checked_create_llm():
+    # Fail before config lookup if propagation regresses; never read real user data.
+    assert os.environ.get("BOX_AGENT_HOME") == sys.argv[2], "Missing child profile"
+    return original_create_llm()
+server._create_configured_llm = checked_create_llm
+server.LLMClient = lambda **kwargs: SimpleNamespace(**kwargs)
+def fake_extractor(llm):
+    async def execute(**kwargs):
+        return ToolResult(success=True, content=json.dumps({
+            "model": llm.model, "auth_file": llm.auth_file,
+        }))
+    return SimpleNamespace(execute=execute)
+server.WebExtractTool = fake_extractor
+server.main()
+''', encoding="utf-8")
+    config = root / "config/mcp.json"
+    bootstrap_managed_mcp_config(config, web_extract_command=sys.executable)
+    entry = json.loads(config.read_text(encoding="utf-8"))["mcpServers"]["box-agent-web-extract"]
+    connection = MCPServerConnection(
+        name="box-agent-web-extract", command=entry["command"],
+        args=[str(child), str(Path(__file__).resolve().parents[1]), str(root.resolve())],
+        env=entry.get("env"), connect_timeout=15, execute_timeout=15,
+    )
+    try:
+        assert await connection.connect()
+        result = await connection.session.call_tool(
+            "web_extract", {"url": "https://example.invalid/fixture"},
+        )
+        if has_config:
+            assert not result.isError, result.content
+            assert json.loads(result.content[0].text) == {
+                "model": "profile-fixture", "auth_file": str(root.resolve() / "config/auth.json"),
+            }
+        else:
+            assert result.isError
+            assert "Explicit profile config.yaml is missing" in result.content[0].text
+    finally:
+        await connection.disconnect()


### PR DESCRIPTION
## TPR

### Task

修复 #110 引入独立 profile 后，受管理 stdio MCP 子进程未收到 `BOX_AGENT_HOME`、内置 Web Extract 因而可能读取旧配置的问题。

- Bootstrap 为 runtime manifest 中的 stdio MCP 和 CLI 安装的 Web Extract 显式传入校验后的当前 profile；覆盖管理项残留的旧 profile 值，保留其他环境配置。
- CLI / ACP 共用这一 bootstrap。自定义 MCP、远端 HTTP、未启用 profile 的行为保持不变。
- 不改系统 HOME，不透传整份父进程环境，不修改模型回放或抓取语义，不迁移用户数据。

### Proof

在 macOS 的独立工作树中执行：

```sh
UV_PROJECT_ENVIRONMENT=/Users/malin1/Dev/ai/Box-Agent/.venv uv run --no-sync --offline python -m pytest tests/test_mcp_bootstrap.py tests/test_user_paths.py tests/test_isolated_profile.py tests/test_mcp.py tests/test_mcp_config_tool.py tests/test_web_extract_server.py -q --tb=short --deselect tests/test_mcp.py::test_connection_timeout_on_unreachable_server
git diff origin/main...HEAD --check
```

- 126 passed、3 skipped、1 deselected；跳过项涉及未配置的 MCP 集成环境，明确 deselect 仓库 preflight 排除的不可达连接超时测试。
- 新增回归在修复前 4 failed / 1 passed，修复后全部通过。覆盖 bundled / CLI 管理项、旧 profile 覆盖、环境保留、幂等性、无 profile 默认兼容。
- 真实 stdio MCP 子进程完成 initialize / list_tools / call_tool，确认 Web Extract 加载 profile 的模型与 auth 路径；缺配置时明确失败。模型和网络抓取使用合成替身，测试不读取真实用户配置或调用真实服务。
- 尚未在本机运行全量 preflight、物理 Windows、运行时打包/安装、客户端重启和真实模型任务；等待当前 Head 的 GitHub / teamwork 门禁，不将源码测试视为已部署证明。

### Risk

- 管理项的 `BOX_AGENT_HOME` 以父进程当前 profile 为准，其他环境项保留。现存管理配置会由正常 bootstrap 更新。
- 仅源码修复；OfficeV3 等消费者仍需重建、安装、重启 runtime 后验证。
- 无真实配置、凭据、日志或生成状态进入补丁；不提供 OS sandbox 或第三方服务隔离。
- 可回退此单一提交；没有跨仓修改或用户数据迁移。

### Design and architecture impact

- 变更位于共享 MCP bootstrap，不在 CLI/ACP 复制策略，也不修改通用 SDK 的默认环境继承规则。
- 更新 `docs/isolated-runtime-profile.md`；无 builtin Skill 内容或 manifest 变更。
- 图谱基线早于 profile 改动，已以当前源码、调用链及子进程测试验证。

### Target branch consistency

- Base: `main` / `2d0646931aa00a665b4661890f5e081ce2cc8430`（#110 合并提交）。
- Head: `49f1a7523c436c3a08832abc67b78c21484d7b84`。
- 创建 PR 前已 fetch 并执行 `git rebase origin/main`，分支已是最新基线；仅包含一个 MCP profile 修复提交。

## Checklist

- [x] 单一行为范围；共享实现与默认兼容性已核对。
- [x] 相关源码测试和真实 stdio 合成子进程探针通过。
- [x] 文档、运行时边界、回退方式与未验证项已说明。
- [x] 无本地配置、日志、凭据或生成状态；无需更新 Skill manifest。
- [x] 已 rebase 最新 main，并核对准确 Head。
- [x] 当前 Head `49f1a7523c436c3a08832abc67b78c21484d7b84` 的 teamwork/local-ci、Python 3.10/3.11/3.12 和 GitGuardian 全部通过；自动完整代码审核未发现阻塞问题。
