### PR TITLE
feat(connectors): isolate MCP sources and session capabilities

### DIFF
--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "affe4e2b57c0de58db749543333eae4b2e27aab1",
-  "generatedAt": "2026-09-10T16:52:54.361Z",
+  "gitCommitHash": "9f1bb264f5b9356a5b9f4b5c49026612301cc03d",
+  "generatedAt": "2026-09-10T17:31:11.523Z",
   "files": {
     ".dockerignore": {
       "filePath": ".dockerignore",
@@ -178,7 +178,7 @@
     },
     "box_agent/acp/__init__.py": {
       "filePath": "box_agent/acp/__init__.py",
-      "contentHash": "e61090db394fc554e20b45e6480b1783000da18c1a1e1d178ba5546dbbd55efc",
+      "contentHash": "1f094802023e674aa3daa5c394edaf3dac80cd19885dd9ab406ecdc910b9250a",
       "functions": [
         {
           "name": "_artifact_envelope",
@@ -619,7 +619,7 @@
             "_SESSION_UPDATE_TIMEOUT_SECONDS"
           ],
           "exported": true,
-          "lineCount": 3802
+          "lineCount": 3792
         },
         {
           "name": "_PermissionNegotiator",
@@ -1235,7 +1235,7 @@
         "run_acp_server",
         "main"
       ],
-      "totalLines": 5655,
+      "totalLines": 5645,
       "hasStructuralAnalysis": true
     },
     "box_agent/acp/action_hints.py": {
@@ -25537,7 +25537,7 @@
     },
     "box_agent/tools/mcp_loader.py": {
       "filePath": "box_agent/tools/mcp_loader.py",
-      "contentHash": "8a0e73057b1dd729683e9cb61d023b8f74a012fb85e763d3aea6e5b86acd9f1d",
+      "contentHash": "2031e0b99d73ead3b6204d0173ebdb903b93bfa43a2154720f277ae0f39fd776",
       "functions": [
         {
           "name": "_warn",
@@ -25788,7 +25788,7 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 13
+          "lineCount": 15
         },
         {
           "name": "_waiting_for_credential",
@@ -25870,7 +25870,7 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 59
+          "lineCount": 64
         },
         {
           "name": "_reconcile_mcp_sources_locked",
@@ -25880,7 +25880,7 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 72
+          "lineCount": 80
         },
         {
           "name": "reconnect_auth_failed_mcp_servers_if_token_changed",
@@ -26197,12 +26197,12 @@
         "reconnect_auth_failed_mcp_servers_if_token_changed",
         "_reconnect_mcp_server_locked"
       ],
-      "totalLines": 1719,
+      "totalLines": 1734,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_sources.py": {
       "filePath": "box_agent/tools/mcp_sources.py",
-      "contentHash": "9399974dc6214c0e453e843bd53561d6ac6914137dcf3a89aa60396f085306f4",
+      "contentHash": "3b03e8be49ab60123caf76a6400839b05688527e1aef5173d8ad92c4e692d3a9",
       "functions": [
         {
           "name": "configured_mcp_sources",
@@ -26265,7 +26265,7 @@
           ],
           "returnType": "ResolvedMcpSources",
           "exported": true,
-          "lineCount": 47
+          "lineCount": 49
         }
       ],
       "classes": [
@@ -26362,7 +26362,7 @@
         "_fingerprint",
         "resolve_mcp_sources"
       ],
-      "totalLines": 190,
+      "totalLines": 192,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_tool_catalog.py": {
@@ -26528,7 +26528,7 @@
     },
     "box_agent/tools/mcp_tool_search.py": {
       "filePath": "box_agent/tools/mcp_tool_search.py",
-      "contentHash": "d41e09b4a0fc7b619a07ebb7eb62225b6f563523aefbfacb43216c3611485d90",
+      "contentHash": "f3d412184cc19881e0daae971caeccb3a2ea14988ffffd02aee096cb09032f5b",
       "functions": [],
       "classes": [
         {
@@ -26572,13 +26572,14 @@
           "methods": [
             "__init__",
             "_entry_is_allowed",
+            "_connector_is_allowed",
             "prepare_tools",
             "inherited_tools",
             "validate_call"
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 118
+          "lineCount": 126
         }
       ],
       "imports": [
@@ -26630,7 +26631,7 @@
         "ToolSearchTool",
         "MCPToolExposureManager"
       ],
-      "totalLines": 590,
+      "totalLines": 598,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/memory_tool.py": {
@@ -32478,12 +32479,12 @@
     },
     "docs/CONNECTOR_RUNTIME_RESTORE.md": {
       "filePath": "docs/CONNECTOR_RUNTIME_RESTORE.md",
-      "contentHash": "7b0cbfa223093043ec3ac1b8fa02a75ba2bdbbf8aa3b967418e59c5900f1ec14",
+      "contentHash": "7cba91561267f3e56006bc6d073496f431afef711021a51b33f53d8205b063a3",
       "functions": [],
       "classes": [],
       "imports": [],
       "exports": [],
-      "totalLines": 28,
+      "totalLines": 38,
       "hasStructuralAnalysis": true
     },
     "docs/CONTEXT_COMPRESSION_CN.md": {

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "ea99fc5ae17f19f2dd752b2264cd3134a36c07ae",
-  "generatedAt": "2026-09-10T16:15:04.013Z",
+  "gitCommitHash": "affe4e2b57c0de58db749543333eae4b2e27aab1",
+  "generatedAt": "2026-09-10T16:52:54.361Z",
   "files": {
     ".dockerignore": {
       "filePath": ".dockerignore",
@@ -178,7 +178,7 @@
     },
     "box_agent/acp/__init__.py": {
       "filePath": "box_agent/acp/__init__.py",
-      "contentHash": "01bd6249275d3d47e615df6cbf396179da677d15265736fd4051578e435e766f",
+      "contentHash": "e61090db394fc554e20b45e6480b1783000da18c1a1e1d178ba5546dbbd55efc",
       "functions": [
         {
           "name": "_artifact_envelope",
@@ -419,6 +419,80 @@
           "lineCount": 31
         },
         {
+          "name": "_connector_ids_from_meta",
+          "params": [
+            "meta"
+          ],
+          "returnType": "set[str] | None",
+          "exported": true,
+          "lineCount": 18
+        },
+        {
+          "name": "_connector_statuses_from_meta",
+          "params": [
+            "meta"
+          ],
+          "returnType": "tuple[tuple[str, str, str], ...] | None",
+          "exported": true,
+          "lineCount": 41
+        },
+        {
+          "name": "_connector_status_unavailable_from_meta",
+          "params": [
+            "meta"
+          ],
+          "returnType": "bool | None",
+          "exported": true,
+          "lineCount": 12
+        },
+        {
+          "name": "_connector_server_statuses",
+          "params": [],
+          "returnType": "dict[str, list[tuple[str, str, str]]]",
+          "exported": true,
+          "lineCount": 19
+        },
+        {
+          "name": "_connected_connector_ids",
+          "params": [
+            "selected_connector_ids"
+          ],
+          "returnType": "frozenset[str]",
+          "exported": true,
+          "lineCount": 11
+        },
+        {
+          "name": "_connector_skill_is_available",
+          "params": [
+            "skill",
+            "selected_connector_ids"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "_connector_skill_is_granted",
+          "params": [
+            "skill",
+            "connector_skill_grants"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 5
+        },
+        {
+          "name": "_connector_status_context",
+          "params": [
+            "selected_connector_ids",
+            "connector_statuses",
+            "connector_status_unavailable"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 45
+        },
+        {
           "name": "_bind_user_source_text",
           "params": [
             "state",
@@ -481,6 +555,11 @@
             "session_mode",
             "llm_binding",
             "seen_injection_ids",
+            "connector_skill_grants",
+            "selected_connector_ids",
+            "connector_statuses",
+            "connector_status_unavailable",
+            "utility_session",
             "expert_context",
             "upstream_session_id",
             "current_task_id",
@@ -490,7 +569,7 @@
             "follow_up_suggestions_task"
           ],
           "exported": true,
-          "lineCount": 23
+          "lineCount": 28
         },
         {
           "name": "BoxACPAgent",
@@ -540,7 +619,7 @@
             "_SESSION_UPDATE_TIMEOUT_SECONDS"
           ],
           "exported": true,
-          "lineCount": 3651
+          "lineCount": 3802
         },
         {
           "name": "_PermissionNegotiator",
@@ -593,6 +672,12 @@
           "source": "platform",
           "specifiers": [
             "platform"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
           ]
         },
         {
@@ -1060,6 +1145,13 @@
           ]
         },
         {
+          "source": "box_agent.tools.mcp_loader",
+          "specifiers": [
+            "get_mcp_connector_server_names",
+            "get_mcp_status"
+          ]
+        },
+        {
           "source": "box_agent.tools.runtime",
           "specifiers": [
             "SkillRuntimeContext",
@@ -1128,6 +1220,14 @@
         "_goal_request_from_meta",
         "_tool_result_raw_output",
         "SessionState",
+        "_connector_ids_from_meta",
+        "_connector_statuses_from_meta",
+        "_connector_status_unavailable_from_meta",
+        "_connector_server_statuses",
+        "_connected_connector_ids",
+        "_connector_skill_is_available",
+        "_connector_skill_is_granted",
+        "_connector_status_context",
         "_bind_user_source_text",
         "BoxACPAgent",
         "_PermissionNegotiator",
@@ -1135,7 +1235,7 @@
         "run_acp_server",
         "main"
       ],
-      "totalLines": 5320,
+      "totalLines": 5655,
       "hasStructuralAnalysis": true
     },
     "box_agent/acp/action_hints.py": {
@@ -1823,7 +1923,7 @@
     },
     "box_agent/agent_runtime.py": {
       "filePath": "box_agent/agent_runtime.py",
-      "contentHash": "88a38f2da92dcd83461ceaf9e7c57580362762f3fd144852ae53f12d75dcb0d6",
+      "contentHash": "fcfa3dfecf886d98b11edaace60b0a00b9d5b4d968673316ec2521655cec2a49",
       "functions": [
         {
           "name": "build_llm_client",
@@ -1867,6 +1967,7 @@
             "max_truncated_tool_call_retries",
             "truncated_tool_call_boost_cap",
             "context_resource_dedup_enabled",
+            "allowed_connector_ids_provider",
             "deferred_mcp_loading_enabled",
             "session_log",
             "enable_builtin_tools",
@@ -1874,7 +1975,7 @@
           ],
           "returnType": "Agent",
           "exported": true,
-          "lineCount": 64
+          "lineCount": 66
         },
         {
           "name": "build_permission_engine",
@@ -1980,7 +2081,7 @@
         "build_memory_manager",
         "build_memory_extractor"
       ],
-      "totalLines": 208,
+      "totalLines": 210,
       "hasStructuralAnalysis": true
     },
     "box_agent/agent_service.py": {
@@ -2028,7 +2129,7 @@
     },
     "box_agent/agent_session.py": {
       "filePath": "box_agent/agent_session.py",
-      "contentHash": "cd78b0fa9fb628a14d60f19758602272d7386229857b2faec8eb644e7c7a02fa",
+      "contentHash": "fa979b49bd0053474d0661c5e4286e5386b3c379399622b21da7dd96b71bdae1",
       "functions": [],
       "classes": [
         {
@@ -2082,7 +2183,7 @@
             "mcp_fallback_tools"
           ],
           "exported": true,
-          "lineCount": 373
+          "lineCount": 375
         }
       ],
       "imports": [
@@ -2168,12 +2269,12 @@
       "exports": [
         "AgentSession"
       ],
-      "totalLines": 408,
+      "totalLines": 410,
       "hasStructuralAnalysis": true
     },
     "box_agent/agent.py": {
       "filePath": "box_agent/agent.py",
-      "contentHash": "ee39a5c4f1397a4e77c4debd48a6d189f9e0a5f94ac949777abc3abe47fc0c4c",
+      "contentHash": "2a03a93bd04e9b23248c2d134784543d4a28557da3adb9f80437bd9c317ff029",
       "functions": [
         {
           "name": "_clean_goal_text",
@@ -2384,7 +2485,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 854
+          "lineCount": 860
         }
       ],
       "imports": [
@@ -2608,7 +2709,7 @@
         "_GoalWriteTool",
         "Agent"
       ],
-      "totalLines": 1290,
+      "totalLines": 1296,
       "hasStructuralAnalysis": true
     },
     "box_agent/artifacts.py": {
@@ -13713,7 +13814,7 @@
     },
     "box_agent/session_assembly.py": {
       "filePath": "box_agent/session_assembly.py",
-      "contentHash": "3711f543181eed03b820a21ac88d4d50de1905bc0a1fb12da7d909bbc905590b",
+      "contentHash": "0758bbacdd87f0c9706662cc82fcbf469580369648305ac8412e5a208c3033e2",
       "functions": [
         {
           "name": "_prepared",
@@ -13758,7 +13859,7 @@
           ],
           "returnType": "None",
           "exported": true,
-          "lineCount": 99
+          "lineCount": 101
         },
         {
           "name": "prepare_prompt",
@@ -13786,7 +13887,7 @@
           ],
           "returnType": "None",
           "exported": true,
-          "lineCount": 45
+          "lineCount": 49
         },
         {
           "name": "_workspace_layout_path",
@@ -13827,7 +13928,7 @@
           ],
           "returnType": "str",
           "exported": true,
-          "lineCount": 18
+          "lineCount": 23
         },
         {
           "name": "build_acp_session_prompt",
@@ -13882,6 +13983,12 @@
           "source": "asyncio",
           "specifiers": [
             "asyncio"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
           ]
         },
         {
@@ -13989,12 +14096,12 @@
         "build_session_permission_policy",
         "close_owned_clients"
       ],
-      "totalLines": 644,
+      "totalLines": 656,
       "hasStructuralAnalysis": true
     },
     "box_agent/session_context.py": {
       "filePath": "box_agent/session_context.py",
-      "contentHash": "84e1d625e63ba1cd23f564b0cf63411e3f618c15a7404741132b36ffd9fcec09",
+      "contentHash": "afb5575b27e6f2f6adbd78846ffde7f75b5920b846bdb1d3bbcd0188684eeb37",
       "functions": [],
       "classes": [
         {
@@ -14040,12 +14147,14 @@
             "base_tools_factory",
             "workspace_tools_factory",
             "capability_state_provider",
+            "skill_access_filter",
+            "skill_catalog_filter",
             "extra_tools",
             "prompt_suffix",
             "diagnostics"
           ],
           "exported": true,
-          "lineCount": 27
+          "lineCount": 29
         },
         {
           "name": "SessionContext",
@@ -14116,7 +14225,7 @@
         "SessionContext",
         "RunContext"
       ],
-      "totalLines": 96,
+      "totalLines": 98,
       "hasStructuralAnalysis": true
     },
     "box_agent/session_continuation.py": {
@@ -25118,7 +25227,7 @@
     },
     "box_agent/tools/mcp_bootstrap.py": {
       "filePath": "box_agent/tools/mcp_bootstrap.py",
-      "contentHash": "cc8a3872a16e3185b8b789a4999926508de2a48b5cf3b5e1043b37bce62f4b2c",
+      "contentHash": "57ba3a52406b2aa768539538d23ad26110d3991893a6a67fa91c5845f7d079a4",
       "functions": [
         {
           "name": "_runtime_root",
@@ -25134,7 +25243,7 @@
           "params": [],
           "returnType": "Path",
           "exported": true,
-          "lineCount": 3
+          "lineCount": 6
         },
         {
           "name": "_normalize_hosted_search_url",
@@ -25323,12 +25432,12 @@
         "_atomic_write_json",
         "bootstrap_managed_mcp_config"
       ],
-      "totalLines": 316,
+      "totalLines": 319,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_config_tool.py": {
       "filePath": "box_agent/tools/mcp_config_tool.py",
-      "contentHash": "d6bf19be0102c4e717701daee677170f1c15b0992e049ef005d74a09285a9114",
+      "contentHash": "7523c297e838726ac0824b3e3bcdea6a6d33c39fb9b7e5253c2978ba55b36d20",
       "functions": [
         {
           "name": "_updated_server_config",
@@ -25354,7 +25463,7 @@
           "params": [],
           "returnType": "Path",
           "exported": true,
-          "lineCount": 33
+          "lineCount": 38
         }
       ],
       "classes": [
@@ -25376,6 +25485,12 @@
           "source": "json",
           "specifiers": [
             "json"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
           ]
         },
         {
@@ -25417,12 +25532,12 @@
         "_resolve_write_target",
         "McpConfigTool"
       ],
-      "totalLines": 371,
+      "totalLines": 377,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_loader.py": {
       "filePath": "box_agent/tools/mcp_loader.py",
-      "contentHash": "9eafb521ce652c40958af3db9b62dce3c7a8638e66215f3b8a8e4150a0a42e26",
+      "contentHash": "8a0e73057b1dd729683e9cb61d023b8f74a012fb85e763d3aea6e5b86acd9f1d",
       "functions": [
         {
           "name": "_warn",
@@ -25437,11 +25552,23 @@
           "name": "_public_mcp_tool_name",
           "params": [
             "server_name",
-            "remote_name"
+            "remote_name",
+            "connector_id"
           ],
           "returnType": "str",
           "exported": true,
-          "lineCount": 15
+          "lineCount": 21
+        },
+        {
+          "name": "_mcp_tool_always_load",
+          "params": [
+            "server_name",
+            "tool",
+            "server_default"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 3
         },
         {
           "name": "_replace_server_catalog",
@@ -25565,6 +25692,13 @@
           "lineCount": 2
         },
         {
+          "name": "get_mcp_config_paths",
+          "params": [],
+          "returnType": "dict[str, str]",
+          "exported": true,
+          "lineCount": 2
+        },
+        {
           "name": "get_mcp_tools_for_server",
           "params": [
             "name"
@@ -25598,18 +25732,19 @@
             "tool_count",
             "tools",
             "error",
-            "auth_status"
+            "auth_status",
+            "definition"
           ],
           "returnType": "None",
           "exported": true,
-          "lineCount": 19
+          "lineCount": 28
         },
         {
           "name": "get_mcp_status",
           "params": [],
           "returnType": "list[dict]",
           "exported": true,
-          "lineCount": 13
+          "lineCount": 18
         },
         {
           "name": "_determine_connection_type",
@@ -25619,6 +25754,68 @@
           "returnType": "ConnectionType",
           "exported": true,
           "lineCount": 9
+        },
+        {
+          "name": "set_mcp_runtime_credential",
+          "params": [
+            "credential_ref",
+            "headers"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "get_mcp_connector_server_names",
+          "params": [],
+          "returnType": "dict[str, frozenset[str]]",
+          "exported": true,
+          "lineCount": 11
+        },
+        {
+          "name": "clear_mcp_runtime_credential",
+          "params": [
+            "credential_ref"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 11
+        },
+        {
+          "name": "_materialize_server_config",
+          "params": [
+            "definition"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 13
+        },
+        {
+          "name": "_waiting_for_credential",
+          "params": [
+            "definition"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "_build_connection",
+          "params": [
+            "definition"
+          ],
+          "returnType": "\"MCPServerConnection\"",
+          "exported": true,
+          "lineCount": 37
+        },
+        {
+          "name": "_resolve_registered_sources",
+          "params": [
+            "config_path"
+          ],
+          "returnType": "dict[str, ResolvedMcpServer]",
+          "exported": true,
+          "lineCount": 36
         },
         {
           "name": "_resolve_mcp_config_path",
@@ -25638,13 +25835,13 @@
           ],
           "returnType": "list[Tool]",
           "exported": true,
-          "lineCount": 177
+          "lineCount": 155
         },
         {
           "name": "cleanup_mcp_connections",
           "params": [],
           "exported": true,
-          "lineCount": 8
+          "lineCount": 12
         },
         {
           "name": "reconnect_mcp_server",
@@ -25653,7 +25850,37 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 5
+          "lineCount": 17
+        },
+        {
+          "name": "reconcile_mcp_sources",
+          "params": [
+            "source"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "replace_mcp_source",
+          "params": [
+            "source",
+            "config",
+            "connector_ids"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 59
+        },
+        {
+          "name": "_reconcile_mcp_sources_locked",
+          "params": [
+            "source",
+            "connector_ids"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 72
         },
         {
           "name": "reconnect_auth_failed_mcp_servers_if_token_changed",
@@ -25669,7 +25896,7 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 111
+          "lineCount": 75
         }
       ],
       "classes": [
@@ -25704,6 +25931,8 @@
             "server_name",
             "remote_name",
             "mcp_tool_id",
+            "mcp_connector_id",
+            "mcp_connector_name",
             "mcp_generation",
             "mcp_always_load",
             "description",
@@ -25712,7 +25941,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 187
+          "lineCount": 199
         },
         {
           "name": "MCPServerConnection",
@@ -25731,7 +25960,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 403
+          "lineCount": 413
         },
         {
           "name": "McpServerStatus",
@@ -25739,6 +25968,11 @@
           "properties": [
             "name",
             "state",
+            "owner",
+            "config_id",
+            "connector_id",
+            "connector_name",
+            "source_path",
             "transport",
             "tool_count",
             "tools",
@@ -25746,7 +25980,7 @@
             "auth_status"
           ],
           "exported": true,
-          "lineCount": 8
+          "lineCount": 13
         }
       ],
       "imports": [
@@ -25901,6 +26135,15 @@
           ]
         },
         {
+          "source": ".mcp_sources",
+          "specifiers": [
+            "McpConfigSource",
+            "ResolvedMcpServer",
+            "configured_mcp_sources",
+            "resolve_mcp_sources"
+          ]
+        },
+        {
           "source": ".model_tool_context",
           "specifiers": [
             "current_model_tool_context"
@@ -25910,6 +26153,7 @@
       "exports": [
         "_warn",
         "_public_mcp_tool_name",
+        "_mcp_tool_always_load",
         "_replace_server_catalog",
         "_structured_mcp_error_message",
         "_walk_exception_tree",
@@ -25929,25 +26173,201 @@
         "_current_mcp_auth_fingerprint",
         "is_mcp_loading",
         "get_mcp_config_path",
+        "get_mcp_config_paths",
         "get_mcp_tools_for_server",
         "get_all_mcp_tools",
         "disconnect_mcp_server",
         "_record_status",
         "get_mcp_status",
         "_determine_connection_type",
+        "set_mcp_runtime_credential",
+        "get_mcp_connector_server_names",
+        "clear_mcp_runtime_credential",
+        "_materialize_server_config",
+        "_waiting_for_credential",
+        "_build_connection",
+        "_resolve_registered_sources",
         "_resolve_mcp_config_path",
         "load_mcp_tools_async",
         "cleanup_mcp_connections",
         "reconnect_mcp_server",
+        "reconcile_mcp_sources",
+        "replace_mcp_source",
+        "_reconcile_mcp_sources_locked",
         "reconnect_auth_failed_mcp_servers_if_token_changed",
         "_reconnect_mcp_server_locked"
       ],
-      "totalLines": 1396,
+      "totalLines": 1719,
+      "hasStructuralAnalysis": true
+    },
+    "box_agent/tools/mcp_sources.py": {
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "contentHash": "9399974dc6214c0e453e843bd53561d6ac6914137dcf3a89aa60396f085306f4",
+      "functions": [
+        {
+          "name": "configured_mcp_sources",
+          "params": [
+            "primary_path"
+          ],
+          "returnType": "tuple[McpConfigSource, ...]",
+          "exported": true,
+          "lineCount": 21
+        },
+        {
+          "name": "_read_servers",
+          "params": [
+            "source"
+          ],
+          "returnType": "dict[str, dict]",
+          "exported": true,
+          "lineCount": 16
+        },
+        {
+          "name": "_copy_servers",
+          "params": [
+            "raw_servers",
+            "source_label"
+          ],
+          "returnType": "dict[str, dict]",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "_server_identity",
+          "params": [
+            "source",
+            "name",
+            "config"
+          ],
+          "returnType": "tuple[str, str | None, str | None]",
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "_fingerprint",
+          "params": [
+            "source",
+            "config_id",
+            "config",
+            "credential_version"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 18
+        },
+        {
+          "name": "resolve_mcp_sources",
+          "params": [
+            "sources",
+            "credential_versions",
+            "reserved_names",
+            "source_server_overrides"
+          ],
+          "returnType": "ResolvedMcpSources",
+          "exported": true,
+          "lineCount": 47
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpConfigSource",
+          "methods": [],
+          "properties": [
+            "owner",
+            "path"
+          ],
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "ResolvedMcpServer",
+          "methods": [],
+          "properties": [
+            "name",
+            "config",
+            "owner",
+            "config_id",
+            "connector_id",
+            "connector_name",
+            "source_path",
+            "fingerprint"
+          ],
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "ResolvedMcpSources",
+          "methods": [],
+          "properties": [
+            "sources",
+            "servers",
+            "conflicts"
+          ],
+          "exported": true,
+          "lineCount": 4
+        }
+      ],
+      "imports": [
+        {
+          "source": "hashlib",
+          "specifiers": [
+            "hashlib"
+          ]
+        },
+        {
+          "source": "json",
+          "specifiers": [
+            "json"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
+          ]
+        },
+        {
+          "source": "dataclasses",
+          "specifiers": [
+            "dataclass"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Literal"
+          ]
+        }
+      ],
+      "exports": [
+        "McpConfigSource",
+        "ResolvedMcpServer",
+        "ResolvedMcpSources",
+        "configured_mcp_sources",
+        "_read_servers",
+        "_copy_servers",
+        "_server_identity",
+        "_fingerprint",
+        "resolve_mcp_sources"
+      ],
+      "totalLines": 190,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_tool_catalog.py": {
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
-      "contentHash": "fb93cdec2afa4034502d470fd1b360a7a40732bc360a13e34d32dc8eee9c26e7",
+      "contentHash": "4e072207821e0fba07405e7b3ed27f16f05ffa7ff6919b30c1c68222b3522981",
       "functions": [
         {
           "name": "_normalize",
@@ -26010,10 +26430,13 @@
             "tool",
             "generation",
             "always_load",
+            "connector_id",
+            "connector_name",
+            "remote_name",
             "name_conflict"
           ],
           "exported": true,
-          "lineCount": 9
+          "lineCount": 12
         },
         {
           "name": "MCPToolCatalog",
@@ -26033,6 +26456,8 @@
             "snapshot",
             "get",
             "get_by_model_name",
+            "resolve_connector_id",
+            "_visible",
             "search",
             "search_many",
             "lookup_exact",
@@ -26041,7 +26466,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 369
+          "lineCount": 495
         }
       ],
       "imports": [
@@ -26066,6 +26491,7 @@
         {
           "source": "collections.abc",
           "specifiers": [
+            "Callable",
             "Iterable"
           ]
         },
@@ -26097,12 +26523,12 @@
         "MCPToolCatalog",
         "get_mcp_tool_catalog"
       ],
-      "totalLines": 447,
+      "totalLines": 576,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_tool_search.py": {
       "filePath": "box_agent/tools/mcp_tool_search.py",
-      "contentHash": "c423a513b4ca072db2ee69e73ed5183ed63b6684c26aec966ecdf8c72240df9c",
+      "contentHash": "d41e09b4a0fc7b619a07ebb7eb62225b6f563523aefbfacb43216c3611485d90",
       "functions": [],
       "classes": [
         {
@@ -26131,6 +26557,7 @@
           "name": "ToolSearchTool",
           "methods": [
             "__init__",
+            "_entry_is_allowed",
             "name",
             "description",
             "parameters",
@@ -26138,19 +26565,20 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 352
+          "lineCount": 434
         },
         {
           "name": "MCPToolExposureManager",
           "methods": [
             "__init__",
+            "_entry_is_allowed",
             "prepare_tools",
             "inherited_tools",
             "validate_call"
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 105
+          "lineCount": 118
         }
       ],
       "imports": [
@@ -26202,7 +26630,7 @@
         "ToolSearchTool",
         "MCPToolExposureManager"
       ],
-      "totalLines": 495,
+      "totalLines": 590,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/memory_tool.py": {
@@ -27626,7 +28054,7 @@
     },
     "box_agent/tools/safety.py": {
       "filePath": "box_agent/tools/safety.py",
-      "contentHash": "f044bce4a37ca03412aaa8118f79f75bab3231d02de6d6df277f1387f468ee9b",
+      "contentHash": "024a94a16780235daa1dbd9f7cda18ece9186551ff1f5d7f434c9a5ff8dd2cc0",
       "functions": [
         {
           "name": "trusted_runtime_executable_references",
@@ -27900,7 +28328,7 @@
         "backup_file",
         "extract_rm_targets"
       ],
-      "totalLines": 654,
+      "totalLines": 655,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/schedule_tool.py": {
@@ -28102,7 +28530,7 @@
     },
     "box_agent/tools/setup.py": {
       "filePath": "box_agent/tools/setup.py",
-      "contentHash": "aaf2a5a57e9702340d55a1fc0ae47a313bfe5d1dac0951665e60e97be1acb594",
+      "contentHash": "10ad880561253fbc8342ff175c1e61142dbf32967cd803b19f818beaef5f74f7",
       "functions": [
         {
           "name": "render_system_prompt_template",
@@ -28168,7 +28596,7 @@
             "mcp_start_gate"
           ],
           "exported": true,
-          "lineCount": 221
+          "lineCount": 255
         },
         {
           "name": "await_skill_discovery",
@@ -28245,12 +28673,13 @@
             "skill_runtime_context",
             "skill_loader",
             "capability_state_provider",
+            "skill_access_filter",
             "env_context",
             "process_owner_id",
             "bypass_dangerous_command_approval"
           ],
           "exported": true,
-          "lineCount": 243
+          "lineCount": 247
         }
       ],
       "classes": [
@@ -28267,6 +28696,12 @@
           "source": "asyncio",
           "specifiers": [
             "asyncio"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
           ]
         },
         {
@@ -28517,7 +28952,7 @@
         "sync_mcp_tool_list",
         "add_workspace_tools"
       ],
-      "totalLines": 796,
+      "totalLines": 835,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/shell_inspection.py": {
@@ -28977,7 +29412,7 @@
     },
     "box_agent/tools/skill_loader.py": {
       "filePath": "box_agent/tools/skill_loader.py",
-      "contentHash": "77a77b449282d5182808237df06c0cf54b05ae6c26723bdb18fa022642733d69",
+      "contentHash": "e412d36ac2fc6b046ae26ca95e7393cac0258372f6206aceb73151b12cf127d5",
       "functions": [
         {
           "name": "_warn",
@@ -29028,6 +29463,8 @@
             "description",
             "content",
             "source",
+            "owner_id",
+            "disabled",
             "license",
             "allowed_tools",
             "metadata",
@@ -29040,7 +29477,7 @@
             "broken_reason"
           ],
           "exported": true,
-          "lineCount": 81
+          "lineCount": 85
         },
         {
           "name": "_SourceEntry",
@@ -29087,7 +29524,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 797
+          "lineCount": 829
         },
         {
           "name": "SkillSelector",
@@ -29101,7 +29538,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 100
+          "lineCount": 116
         }
       ],
       "imports": [
@@ -29146,6 +29583,7 @@
           "source": "typing",
           "specifiers": [
             "Any",
+            "Callable",
             "Dict",
             "List",
             "Literal",
@@ -29177,7 +29615,7 @@
         "SkillLoader",
         "SkillSelector"
       ],
-      "totalLines": 1100,
+      "totalLines": 1152,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/skill_preload.py": {
@@ -29615,7 +30053,7 @@
     },
     "box_agent/tools/skill_tool.py": {
       "filePath": "box_agent/tools/skill_tool.py",
-      "contentHash": "189f26420e7382b0cc70ccd6886b830e3797219c0cc74014c5ed0a6b04683b5a",
+      "contentHash": "000f08838d1502cf3d954b8339c5ac7ccc77772cbad67e10fb72f9ee66b75c96",
       "functions": [
         {
           "name": "create_skill_tools",
@@ -29641,7 +30079,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 111
+          "lineCount": 123
         }
       ],
       "imports": [
@@ -29661,6 +30099,7 @@
           "source": "typing",
           "specifiers": [
             "Any",
+            "Callable",
             "Dict",
             "List",
             "Literal",
@@ -29688,7 +30127,7 @@
         "GetSkillTool",
         "create_skill_tools"
       ],
-      "totalLines": 164,
+      "totalLines": 176,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/skillhub_install_tool.py": {
@@ -30006,7 +30445,7 @@
     },
     "box_agent/tools/sub_agent_capabilities.py": {
       "filePath": "box_agent/tools/sub_agent_capabilities.py",
-      "contentHash": "aa69ce3573e04a00ebe68f61cb527d0b1ed7ad715ae6ad738817dc90d154a5f3",
+      "contentHash": "52073dead9cd85077527873f0ac2988357ba451f788a3ee7279de4b6b7b9ab46",
       "functions": [
         {
           "name": "_tool_capability_metadata",
@@ -30180,7 +30619,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 167
+          "lineCount": 179
         }
       ],
       "imports": [
@@ -30194,6 +30633,7 @@
           "source": "typing",
           "specifiers": [
             "Any",
+            "Callable",
             "Mapping"
           ]
         },
@@ -30225,12 +30665,12 @@
         "_tool_denial_reason",
         "CapabilityResolver"
       ],
-      "totalLines": 700,
+      "totalLines": 712,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/sub_agent_tool.py": {
       "filePath": "box_agent/tools/sub_agent_tool.py",
-      "contentHash": "4d6c2039097b8c15e9825a50cbf7d5df12ce004a9a3182ede9b96c9b8572a856",
+      "contentHash": "c927aaeecaf817925f016b3afaa4e4d2b919996a55ea0afe4c8a38b02641f89f",
       "functions": [
         {
           "name": "_child_safe_parent_prompt",
@@ -30282,6 +30722,7 @@
             "set_parent_system_prompt",
             "set_tool_provider",
             "set_skill_provider",
+            "set_skill_access_filter",
             "set_capability_state_provider",
             "set_permission_negotiator",
             "_resolve_child_tools",
@@ -30306,7 +30747,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 1166
+          "lineCount": 1172
         }
       ],
       "imports": [
@@ -30433,7 +30874,7 @@
         "_PermissionGatedBashTool",
         "SubAgentTool"
       ],
-      "totalLines": 1410,
+      "totalLines": 1416,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/todo_tool.py": {
@@ -32035,6 +32476,16 @@
       "totalLines": 817,
       "hasStructuralAnalysis": true
     },
+    "docs/CONNECTOR_RUNTIME_RESTORE.md": {
+      "filePath": "docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "contentHash": "7b0cbfa223093043ec3ac1b8fa02a75ba2bdbbf8aa3b967418e59c5900f1ec14",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 28,
+      "hasStructuralAnalysis": true
+    },
     "docs/CONTEXT_COMPRESSION_CN.md": {
       "filePath": "docs/CONTEXT_COMPRESSION_CN.md",
       "contentHash": "1842dcff665dd1e2e67f8e125e5174eb424094429f7262cff7ce11c764825e36",
@@ -32607,7 +33058,7 @@
     },
     "scripts/build_runtime.py": {
       "filePath": "scripts/build_runtime.py",
-      "contentHash": "4ee723dfc9b53f6a1cd372255dd663ed6eda378f7ceead61534a5a31a658a945",
+      "contentHash": "e707c4bb54d6c172ac1513061641585aab5c236c06bc44749335ce194f8af45b",
       "functions": [
         {
           "name": "env_flag",
@@ -32715,7 +33166,7 @@
           ],
           "returnType": "dict[str, object]",
           "exported": true,
-          "lineCount": 28
+          "lineCount": 30
         },
         {
           "name": "resolve_officev3_dir",
@@ -32956,7 +33407,7 @@
         "_relativize_node_manifest",
         "main"
       ],
-      "totalLines": 1042,
+      "totalLines": 1044,
       "hasStructuralAnalysis": true
     },
     "scripts/build_win_runtime.py": {

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "9f1bb264f5b9356a5b9f4b5c49026612301cc03d",
-  "generatedAt": "2026-09-10T17:31:11.523Z",
+  "gitCommitHash": "be3c151a0d056623795b6c799a298919e6ed6ae0",
+  "generatedAt": "2026-09-10T18:08:25.102Z",
   "files": {
     ".dockerignore": {
       "filePath": ".dockerignore",
@@ -178,7 +178,7 @@
     },
     "box_agent/acp/__init__.py": {
       "filePath": "box_agent/acp/__init__.py",
-      "contentHash": "1f094802023e674aa3daa5c394edaf3dac80cd19885dd9ab406ecdc910b9250a",
+      "contentHash": "4d128cbdfddc929232b56fbd526b57a46e9d7327a28f71b1478e440deb9a4bf6",
       "functions": [
         {
           "name": "_artifact_envelope",
@@ -450,7 +450,7 @@
           "params": [],
           "returnType": "dict[str, list[tuple[str, str, str]]]",
           "exported": true,
-          "lineCount": 19
+          "lineCount": 23
         },
         {
           "name": "_connected_connector_ids",
@@ -1235,7 +1235,7 @@
         "run_acp_server",
         "main"
       ],
-      "totalLines": 5645,
+      "totalLines": 5649,
       "hasStructuralAnalysis": true
     },
     "box_agent/acp/action_hints.py": {
@@ -25537,7 +25537,7 @@
     },
     "box_agent/tools/mcp_loader.py": {
       "filePath": "box_agent/tools/mcp_loader.py",
-      "contentHash": "2031e0b99d73ead3b6204d0173ebdb903b93bfa43a2154720f277ae0f39fd776",
+      "contentHash": "a96d76c583ebf364269e3323dc0f4a1367e657f5355cd552fdc5eb5b2b1548b9",
       "functions": [
         {
           "name": "_warn",
@@ -25853,13 +25853,20 @@
           "lineCount": 17
         },
         {
+          "name": "_mcp_startup_ready",
+          "params": [],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 8
+        },
+        {
           "name": "reconcile_mcp_sources",
           "params": [
             "source"
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 9
+          "lineCount": 7
         },
         {
           "name": "replace_mcp_source",
@@ -25870,7 +25877,7 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 64
+          "lineCount": 66
         },
         {
           "name": "_reconcile_mcp_sources_locked",
@@ -25880,7 +25887,7 @@
           ],
           "returnType": "dict",
           "exported": true,
-          "lineCount": 80
+          "lineCount": 82
         },
         {
           "name": "reconnect_auth_failed_mcp_servers_if_token_changed",
@@ -26191,13 +26198,14 @@
         "load_mcp_tools_async",
         "cleanup_mcp_connections",
         "reconnect_mcp_server",
+        "_mcp_startup_ready",
         "reconcile_mcp_sources",
         "replace_mcp_source",
         "_reconcile_mcp_sources_locked",
         "reconnect_auth_failed_mcp_servers_if_token_changed",
         "_reconnect_mcp_server_locked"
       ],
-      "totalLines": 1734,
+      "totalLines": 1746,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_sources.py": {
@@ -26367,7 +26375,7 @@
     },
     "box_agent/tools/mcp_tool_catalog.py": {
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
-      "contentHash": "4e072207821e0fba07405e7b3ed27f16f05ffa7ff6919b30c1c68222b3522981",
+      "contentHash": "0e99be67adcb90777d3f613ace31dcf4e69518a1547cd416e9fabbacb6450e36",
       "functions": [
         {
           "name": "_normalize",
@@ -26448,6 +26456,7 @@
             "mark_ready",
             "mark_server_loading",
             "mark_server_ready",
+            "initial_loading",
             "loading",
             "wait_until_ready",
             "replace_server",
@@ -26466,7 +26475,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 495
+          "lineCount": 501
         }
       ],
       "imports": [
@@ -26523,7 +26532,7 @@
         "MCPToolCatalog",
         "get_mcp_tool_catalog"
       ],
-      "totalLines": 576,
+      "totalLines": 582,
       "hasStructuralAnalysis": true
     },
     "box_agent/tools/mcp_tool_search.py": {
@@ -32479,12 +32488,12 @@
     },
     "docs/CONNECTOR_RUNTIME_RESTORE.md": {
       "filePath": "docs/CONNECTOR_RUNTIME_RESTORE.md",
-      "contentHash": "7cba91561267f3e56006bc6d073496f431afef711021a51b33f53d8205b063a3",
+      "contentHash": "8b8a58d295d2c64bdc989e208b3cd64c7fe9a11b89530acea4fb7afc6a9ef465",
       "functions": [],
       "classes": [],
       "imports": [],
       "exports": [],
-      "totalLines": 38,
+      "totalLines": 47,
       "hasStructuralAnalysis": true
     },
     "docs/CONTEXT_COMPRESSION_CN.md": {

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -25,8 +25,8 @@
       "GitHub Actions"
     ],
     "description": "一个具备 Jupyter 沙箱、数据分析、MCP 工具、ACP 协议、多模型提供商支持和独立运行时打包能力的 AI Agent 框架。注意：该项目包含超过 100 个源文件；如需更快的分析，可考虑将范围限定到某个子目录。",
-    "analyzedAt": "2026-09-10T16:51:22.244Z",
-    "gitCommitHash": "affe4e2b57c0de58db749543333eae4b2e27aab1"
+    "analyzedAt": "2026-09-10T17:29:11.102Z",
+    "gitCommitHash": "9f1bb264f5b9356a5b9f4b5c49026612301cc03d"
   },
   "nodes": [
     {
@@ -6230,7 +6230,7 @@
       "type": "file",
       "name": "mcp_loader.py",
       "filePath": "box_agent/tools/mcp_loader.py",
-      "summary": "从 system、connector、user 来源组装 MCP 注册表，管理进程内凭据、连接等待、状态与热重连。来源更新串行化，独立服务并发连接；按来源或连接器作用域替换配置并保持逐服务指纹。",
+      "summary": "从 system、connector、user 来源组装 MCP 注册表，管理仅供 connector 使用的进程内凭证、等待状态与逐服务重连。作用域更新保护其他连接器的同名服务；撤销旧 owner 时断开其连接，作用域外的同名后备来源须自行对账后激活。",
       "tags": [
         "mcp",
         "connectors",
@@ -6662,8 +6662,8 @@
       "name": "_resolve_mcp_config_path",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1247,
-        1275
+        1249,
+        1277
       ],
       "summary": "按既有用户、工作目录和项目回退规则解析主 MCP 配置文件。",
       "tags": [
@@ -6681,8 +6681,8 @@
       "name": "load_mcp_tools_async",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1278,
-        1432
+        1280,
+        1434
       ],
       "summary": "解析多来源注册表并并发启动启用服务；有 credentialRef 但缺凭证时记录等待状态，不创建传输，再发布连接状态与工具目录。",
       "tags": [
@@ -6700,8 +6700,8 @@
       "name": "cleanup_mcp_connections",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1435,
-        1446
+        1437,
+        1448
       ],
       "summary": "关闭连接并清空来源定义、内存来源覆盖、状态与工具目录；运行时凭证仍由进程内凭证接口管理。",
       "tags": [
@@ -6719,8 +6719,8 @@
       "name": "reconnect_mcp_server",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1449,
-        1465
+        1451,
+        1467
       ],
       "summary": "串行化同一服务的热重连，只刷新该服务定义的凭证与配置指纹，避免提前推进其他服务的版本状态。",
       "tags": [
@@ -6738,8 +6738,8 @@
       "name": "reconnect_auth_failed_mcp_servers_if_token_changed",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1614,
-        1641
+        1629,
+        1656
       ],
       "summary": "在产品登录指纹变化后重连认证失败的 MCP 服务，保留逐服务重连锁。",
       "tags": [
@@ -6757,8 +6757,8 @@
       "name": "_reconnect_mcp_server_locked",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1644,
-        1718
+        1659,
+        1733
       ],
       "summary": "从已解析注册表重建单个服务连接；缺宿主凭证时只返回等待状态，连接成功后更新工具目录及来源状态。",
       "tags": [
@@ -27995,7 +27995,7 @@
       "type": "file",
       "name": "mcp_tool_search.py",
       "filePath": "box_agent/tools/mcp_tool_search.py",
-      "summary": "统一允许的本地与 MCP 工具发现、会话激活和延迟暴露；支持 Connector 或服务器整组激活，并在提供会话授权查询器时过滤未启用的 Connector 工具。",
+      "summary": "统一本地与 MCP 工具搜索、会话激活和暴露，支持 Connector 或服务器整组激活。提供授权查询器时，eager/deferred 两种模式都过滤连接器工具暴露、子 Agent 继承与调用前授权；缺省查询器继续兼容放行。",
       "tags": [
         "mcp",
         "工具发现",
@@ -28064,9 +28064,9 @@
       "filePath": "box_agent/tools/mcp_tool_search.py",
       "lineRange": [
         472,
-        589
+        597
       ],
-      "summary": "结合本地延迟名称和已激活实例构建工具视图与子任务继承集合；延迟 MCP 模式下按注入的会话授权查询器过滤 Connector，并在调用前检查授权及工具代际。",
+      "summary": "结合本地延迟名称与 MCP 激活实例构建工具视图，eager/deferred 两种模式都按注入的连接器授权查询器限制暴露及子任务继承，并在实际调用前检查目标授权和工具代际。未提供查询器时保留兼容行为。",
       "tags": [
         "数据模型",
         "mcp",
@@ -28429,7 +28429,7 @@
       "type": "file",
       "name": "__init__.py",
       "filePath": "box_agent/acp/__init__.py",
-      "summary": "实现 ACP 协议、宿主元数据和权限交互，通过共享 AgentSession 维护稳定 cwd、日志恢复与资源关闭。承接连接器选择、状态与会话 Skill 授权，并通过凭证更新、来源替换和对账扩展驱动 MCP 能力模块。",
+      "summary": "实现 ACP 协议、宿主元数据和权限交互，通过共享 AgentSession 维护稳定 cwd、日志恢复与资源关闭。承接连接器选择、状态、会话 Skill 授权及 MCP 凭证和来源扩展，共享 MCP 工具注册表同步在常规对账与后台发现中跳过 utility 会话，运行时状态提示也不注入活跃 utility 回合。",
       "tags": [
         "acp",
         "protocol-adapter",
@@ -28894,8 +28894,8 @@
       "name": "run_acp_server",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5384,
-        5647
+        5374,
+        5637
       ],
       "summary": "装配应用级 runtime 与 ACP 服务，运行 stdio 协议，并在退出时按所有权关闭会话和模型客户端。",
       "tags": [
@@ -28912,8 +28912,8 @@
       "name": "main",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5650,
-        5651
+        5640,
+        5641
       ],
       "summary": "启动 ACP 异步服务的命令行入口。",
       "tags": [
@@ -28985,9 +28985,9 @@
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
         1163,
-        4964
+        4954
       ],
-      "summary": "处理 ACP 会话及协议扩展，把连接器选择、目录状态和内部 Skill 授权接入共享会话组装，并调用 MCP 凭证、来源替换与对账能力。宿主公开 Skill 列表排除连接器来源，会话生命周期、稳定 cwd 和日志恢复继续通过共享入口维护。",
+      "summary": "处理 ACP 会话及协议扩展，把连接器选择、目录状态和内部 Skill 授权接入共享组装，并调用 MCP 凭证、来源替换与对账能力。MCP 工具注册表同步统一委托共享控制器，其会话注册表包含常规会话并排除 utility 会话，后台发现使用同一边界，活跃 utility 回合也不会接收 MCP 状态提示与 tool_search 指导。",
       "tags": [
         "acp",
         "protocol-adapter",
@@ -29002,8 +29002,8 @@
       "name": "_PermissionNegotiator",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        4967,
-        5222
+        4957,
+        5212
       ],
       "summary": "串行化和去重宿主权限请求，把审批结果转换为工具授权与目录授权。",
       "tags": [
@@ -29020,8 +29020,8 @@
       "name": "_MemoryProposalNegotiator",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5225,
-        5381
+        5215,
+        5371
       ],
       "summary": "向宿主发出记忆提升提案并将用户响应交回共享记忆流程。",
       "tags": [
@@ -37216,7 +37216,7 @@
         1096,
         1121
       ],
-      "summary": "校验 credentialRef 与 headers 后仅写入进程内存，递增该引用的凭证版本并返回受影响服务名；不写配置文件。",
+      "summary": "校验 credentialRef 与 headers 后仅写入进程内存并递增版本，返回引用该凭证的 connector 服务名；system/user 服务不进入受影响目标列表。",
       "complexity": "simple",
       "tags": [
         "mcp",
@@ -37250,7 +37250,7 @@
         1137,
         1147
       ],
-      "summary": "从进程内存移除指定凭证并递增版本，返回需重新核对连接的服务名。",
+      "summary": "移除进程内凭证并递增版本，仅返回引用该 credentialRef 的 connector 服务名以供后续重连。",
       "complexity": "simple",
       "tags": [
         "mcp",
@@ -37265,9 +37265,9 @@
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
         1150,
-        1162
+        1164
       ],
-      "summary": "复制服务定义并移除来源标记，把 credentialRef 对应的最新内存 headers 合入连接配置。",
+      "summary": "复制服务定义并移除来源标记，仅允许 connector 通过 credentialRef 合入最新内存 headers；system/user 引用凭证时在构造传输前失败。",
       "complexity": "simple",
       "tags": [
         "mcp",
@@ -37281,8 +37281,8 @@
       "name": "_waiting_for_credential",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1165,
-        1167
+        1167,
+        1169
       ],
       "summary": "检查声明了 credentialRef 的服务是否仍缺少宿主恢复的内存凭证。",
       "complexity": "simple",
@@ -37298,8 +37298,8 @@
       "name": "_build_connection",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1170,
-        1206
+        1172,
+        1208
       ],
       "summary": "用已解析定义和最新内存凭证统一构造连接，复用冷启动与重连的认证、超时、连接器身份及加载策略。",
       "complexity": "simple",
@@ -37315,8 +37315,8 @@
       "name": "_resolve_registered_sources",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1209,
-        1244
+        1211,
+        1246
       ],
       "summary": "组合环境来源与内存 connector 覆盖，解析受保护服务名，调用来源解析器并报告冲突；不提交其他服务已使用新凭证的假状态。",
       "complexity": "simple",
@@ -37332,8 +37332,8 @@
       "name": "reconcile_mcp_sources",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1468,
-        1476
+        1470,
+        1478
       ],
       "summary": "等待首次加载就绪后取得来源更新锁，按可选来源作用域对账并调整连接。",
       "complexity": "simple",
@@ -37349,10 +37349,10 @@
       "name": "replace_mcp_source",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1479,
-        1537
+        1481,
+        1544
       ],
-      "summary": "校验并在内存替换 connector 来源；connectorIds 可限定替换和删除范围，保留其他连接器及 system/user 来源，再执行串行对账。",
+      "summary": "在内存替换 connector 来源并按 connectorIds 限定更新及删除，拒绝占用过滤器范围外连接器已拥有的同名服务，再执行来源对账。",
       "complexity": "moderate",
       "tags": [
         "mcp",
@@ -37366,10 +37366,10 @@
       "name": "_reconcile_mcp_sources_locked",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1540,
-        1611
+        1547,
+        1626
       ],
-      "summary": "比较作用域内服务的新旧定义与指纹，处理移除和禁用，并并发重连新增、变更或上次失败的服务；健康及仍加载的未变化服务保持原连接。",
+      "summary": "分别核对变更前后定义是否属于指定来源与连接器范围，撤销离开范围的旧连接且不激活范围外同名后备来源；并发重连新增、变更或上次失败的范围内服务。",
       "complexity": "moderate",
       "tags": [
         "mcp",
@@ -37382,7 +37382,7 @@
       "type": "file",
       "name": "mcp_sources.py",
       "filePath": "box_agent/tools/mcp_sources.py",
-      "summary": "把按优先级隔离的 MCP 配置来源解析为统一服务定义，校验连接器身份、受保护名称与冲突，并将配置内容和凭证版本纳入指纹；不建立连接或持久化凭证。",
+      "summary": "按优先级隔离的来源解析 MCP 服务，校验连接器身份、受保护名称、命名冲突及 credentialRef 的 connector 所有权，并生成包含配置和凭证版本的指纹；不建立连接或持久化凭证。",
       "tags": [
         "mcp",
         "source-isolation",
@@ -37533,9 +37533,9 @@
       "filePath": "box_agent/tools/mcp_sources.py",
       "lineRange": [
         143,
-        189
+        191
       ],
-      "summary": "按来源优先级解析文件或内存覆盖，阻止用户使用受保护名称及后续来源覆盖同名服务，返回带凭证版本指纹的定义与冲突列表。",
+      "summary": "按来源优先级解析文件或内存覆盖，阻止受保护名称和同名覆盖，拒绝 system/user 的 credentialRef，并返回版本化服务定义与冲突列表。",
       "complexity": "simple",
       "tags": [
         "mcp",
@@ -37548,7 +37548,7 @@
       "type": "document",
       "name": "CONNECTOR_RUNTIME_RESTORE.md",
       "filePath": "docs/CONNECTOR_RUNTIME_RESTORE.md",
-      "summary": "规定宿主在每次 ACP 进程初始化后先恢复进程内凭证、再发布连接器来源，并按 connectorIds 作用域更新。说明缺凭证等待、逐服务指纹与失败重试，以及打包宿主验证边界。",
+      "summary": "规定连接器凭证恢复顺序、局部来源更新和凭证所有权，禁止跨连接器同名覆盖并要求撤销旧连接后由后备来源自行对账。补充 eager/deferred 授权、子会话继承、撤销后调用及 utility 目录隔离要求和宿主验证边界。",
       "tags": [
         "documentation",
         "connectors",
@@ -59922,7 +59922,8 @@
       "target": "file:box_agent/tools/mcp_loader.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/tools/setup.py",
@@ -61996,7 +61997,8 @@
       "target": "file:box_agent/tools/mcp_tool_search.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/agent.py",

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -25,8 +25,8 @@
       "GitHub Actions"
     ],
     "description": "一个具备 Jupyter 沙箱、数据分析、MCP 工具、ACP 协议、多模型提供商支持和独立运行时打包能力的 AI Agent 框架。注意：该项目包含超过 100 个源文件；如需更快的分析，可考虑将范围限定到某个子目录。",
-    "analyzedAt": "2026-09-10T17:29:11.102Z",
-    "gitCommitHash": "9f1bb264f5b9356a5b9f4b5c49026612301cc03d"
+    "analyzedAt": "2026-09-10T18:06:25.517Z",
+    "gitCommitHash": "be3c151a0d056623795b6c799a298919e6ed6ae0"
   },
   "nodes": [
     {
@@ -6230,7 +6230,7 @@
       "type": "file",
       "name": "mcp_loader.py",
       "filePath": "box_agent/tools/mcp_loader.py",
-      "summary": "从 system、connector、user 来源组装 MCP 注册表，管理仅供 connector 使用的进程内凭证、等待状态与逐服务重连。作用域更新保护其他连接器的同名服务；撤销旧 owner 时断开其连接，作用域外的同名后备来源须自行对账后激活。",
+      "summary": "从隔离来源管理 MCP 注册表、connector 专属进程内凭证与逐服务重连，来源更新持锁后先等待冷发现就绪，超时不修改配置。作用域撤销与热重连共享同名服务锁，独立服务并发启动，旧 owner 撤销后不会自动激活范围外同名来源。",
       "tags": [
         "mcp",
         "connectors",
@@ -6738,8 +6738,8 @@
       "name": "reconnect_auth_failed_mcp_servers_if_token_changed",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1629,
-        1656
+        1641,
+        1668
       ],
       "summary": "在产品登录指纹变化后重连认证失败的 MCP 服务，保留逐服务重连锁。",
       "tags": [
@@ -6757,8 +6757,8 @@
       "name": "_reconnect_mcp_server_locked",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1659,
-        1733
+        1671,
+        1745
       ],
       "summary": "从已解析注册表重建单个服务连接；缺宿主凭证时只返回等待状态，连接成功后更新工具目录及来源状态。",
       "tags": [
@@ -27852,7 +27852,7 @@
       "type": "file",
       "name": "mcp_tool_catalog.py",
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
-      "summary": "维护进程级 MCP 工具目录、发现就绪状态和名称冲突，保存 Connector 身份与远端原名，并为会话检索提供可过滤的精确匹配和 BM25 排序。",
+      "summary": "维护进程级 MCP 工具目录、发现就绪和名称冲突，保留 Connector 身份及远端原名以供过滤检索。只读 initial_loading 单独表示冷发现，与包含单服务热刷新的 loading 区分。",
       "tags": [
         "mcp",
         "工具目录",
@@ -27939,8 +27939,8 @@
       "name": "get_mcp_tool_catalog",
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
       "lineRange": [
-        574,
-        575
+        580,
+        581
       ],
       "summary": "返回进程内共享的 MCP 工具目录实例，供加载器和会话工具发现复用。",
       "tags": [
@@ -27978,9 +27978,9 @@
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
       "lineRange": [
         74,
-        568
+        574
       ],
-      "summary": "维护工具注册快照与就绪状态，以调用方提供的过滤器限制 Connector 身份解析、精确查找和多查询排名；检索同时覆盖规范名、别名、远端原名及 Connector 元数据。",
+      "summary": "维护工具快照、名称匹配和过滤查询；只读 initial_loading 暴露冷发现状态，loading 仍覆盖冷发现与热刷新，来源更新据此避免被普通热重连全局阻塞。",
       "tags": [
         "class",
         "tools",
@@ -28876,8 +28876,8 @@
       "name": "_bind_user_source_text",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        1157,
-        1160
+        1161,
+        1164
       ],
       "summary": "委托共享 Skill 环境绑定器将用户原文写入会话工具执行上下文。",
       "tags": [
@@ -28894,8 +28894,8 @@
       "name": "run_acp_server",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5374,
-        5637
+        5378,
+        5641
       ],
       "summary": "装配应用级 runtime 与 ACP 服务，运行 stdio 协议，并在退出时按所有权关闭会话和模型客户端。",
       "tags": [
@@ -28912,8 +28912,8 @@
       "name": "main",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5640,
-        5641
+        5644,
+        5645
       ],
       "summary": "启动 ACP 异步服务的命令行入口。",
       "tags": [
@@ -28984,8 +28984,8 @@
       "name": "BoxACPAgent",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        1163,
-        4954
+        1167,
+        4958
       ],
       "summary": "处理 ACP 会话及协议扩展，把连接器选择、目录状态和内部 Skill 授权接入共享组装，并调用 MCP 凭证、来源替换与对账能力。MCP 工具注册表同步统一委托共享控制器，其会话注册表包含常规会话并排除 utility 会话，后台发现使用同一边界，活跃 utility 回合也不会接收 MCP 状态提示与 tool_search 指导。",
       "tags": [
@@ -29002,8 +29002,8 @@
       "name": "_PermissionNegotiator",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        4957,
-        5212
+        4961,
+        5216
       ],
       "summary": "串行化和去重宿主权限请求，把审批结果转换为工具授权与目录授权。",
       "tags": [
@@ -29020,8 +29020,8 @@
       "name": "_MemoryProposalNegotiator",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5215,
-        5371
+        5219,
+        5375
       ],
       "summary": "向宿主发出记忆提升提案并将用户响应交回共享记忆流程。",
       "tags": [
@@ -37097,9 +37097,9 @@
       "complexity": "simple",
       "lineRange": [
         1060,
-        1078
+        1082
       ],
-      "summary": "从 MCP 运行时状态中筛选 connector 所有者的服务器，并按规范连接器 ID 汇总服务器名称、连接器名称和连接状态。"
+      "summary": "从 MCP 运行时状态中筛选 connector 所有者且仍在当前连接器配置内的服务器，按规范连接器 ID 汇总名称和状态，排除已移除服务器的历史状态；当前配置服务器缺少状态仍会阻止授权。"
     },
     {
       "id": "function:box_agent/acp/__init__.py:_connected_connector_ids",
@@ -37114,8 +37114,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        1081,
-        1091
+        1085,
+        1095
       ],
       "summary": "只返回会话已选择且预期服务器集合完整匹配、所有服务器均 connected 的连接器 ID。"
     },
@@ -37132,8 +37132,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        1094,
-        1100
+        1098,
+        1104
       ],
       "summary": "对连接器来源 Skill 的新识别要求所属连接器已选中且运行时完整连接，其他来源直接允许；不移除已经加载的指导。"
     },
@@ -37150,8 +37150,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        1103,
-        1107
+        1107,
+        1111
       ],
       "summary": "访问连接器 Skill 时要求其名称已获本会话内部选择器授权，其他来源 Skill 保持可用。"
     },
@@ -37168,8 +37168,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        1110,
-        1154
+        1114,
+        1158
       ],
       "summary": "生成连接器级状态提示，优先使用宿主完整快照，缺失时聚合已选连接器的运行时状态；刷新失败时明确禁止沿用旧状态。"
     },
@@ -37332,10 +37332,10 @@
       "name": "reconcile_mcp_sources",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1470,
-        1478
+        1480,
+        1486
       ],
-      "summary": "等待首次加载就绪后取得来源更新锁，按可选来源作用域对账并调整连接。",
+      "summary": "先取得来源更新锁，再等待冷发现就绪；等待超时返回失败而不对账或修改配置，就绪后按来源范围执行连接调整。",
       "complexity": "simple",
       "tags": [
         "mcp",
@@ -37349,10 +37349,10 @@
       "name": "replace_mcp_source",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1481,
-        1544
+        1489,
+        1554
       ],
-      "summary": "在内存替换 connector 来源并按 connectorIds 限定更新及删除，拒绝占用过滤器范围外连接器已拥有的同名服务，再执行来源对账。",
+      "summary": "验证 connector 局部替换并持有来源锁，冷发现就绪前不修改覆盖配置；超时失败后可重试，仍拒绝跨 connectorIds 范围的同名覆盖。",
       "complexity": "moderate",
       "tags": [
         "mcp",
@@ -37366,10 +37366,10 @@
       "name": "_reconcile_mcp_sources_locked",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1547,
-        1626
+        1557,
+        1638
       ],
-      "summary": "分别核对变更前后定义是否属于指定来源与连接器范围，撤销离开范围的旧连接且不激活范围外同名后备来源；并发重连新增、变更或上次失败的范围内服务。",
+      "summary": "按来源范围生成移除、禁用和重连操作并通过 gather 并发启动。内嵌 retire 与 reconnect 共享逐服务锁，撤销等待同名连接完成发布后关闭，保持其他服务独立，且不激活范围外同名后备来源。",
       "complexity": "moderate",
       "tags": [
         "mcp",
@@ -37548,13 +37548,30 @@
       "type": "document",
       "name": "CONNECTOR_RUNTIME_RESTORE.md",
       "filePath": "docs/CONNECTOR_RUNTIME_RESTORE.md",
-      "summary": "规定连接器凭证恢复顺序、局部来源更新和凭证所有权，禁止跨连接器同名覆盖并要求撤销旧连接后由后备来源自行对账。补充 eager/deferred 授权、子会话继承、撤销后调用及 utility 目录隔离要求和宿主验证边界。",
+      "summary": "规定 connector 凭证恢复、局部更新、撤销和授权边界；来源更新须持锁等待冷发现，就绪超时保持配置不变，移除与禁用等待同名连接发布后撤销。连接器授权只计算当前配置服务，忽略历史 tombstone，但当前服务缺失状态仍阻断授权，并保留 eager/deferred、继承与 utility 隔离要求。",
       "tags": [
         "documentation",
         "connectors",
         "restoration"
       ],
       "complexity": "simple"
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
+      "type": "function",
+      "name": "_mcp_startup_ready",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "summary": "在冷发现或首次加载尚未完成时有界等待目录就绪，覆盖 startup gate；仅有普通热重连时直接允许继续，由调用方持有来源锁并处理超时失败。",
+      "tags": [
+        "mcp",
+        "startup",
+        "lifecycle"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1470,
+        1477
+      ]
     }
   ],
   "edges": [
@@ -59376,7 +59393,8 @@
       "target": "file:box_agent/tools/mcp_tool_catalog.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "function:box_agent/session_assembly.py:prepare_tools",
@@ -59930,7 +59948,8 @@
       "target": "file:box_agent/tools/mcp_tool_catalog.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/tools/setup.py",
@@ -61990,7 +62009,8 @@
       "target": "file:box_agent/tools/mcp_tool_catalog.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/agent.py",
@@ -72646,13 +72666,6 @@
       "weight": 0.8
     },
     {
-      "source": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
-      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_timeout_config",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "function:box_agent/tools/mcp_loader.py:reconnect_mcp_server",
       "target": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
       "type": "calls",
@@ -72732,6 +72745,55 @@
     {
       "source": "function:box_agent/tools/skill_tool.py:create_skill_tools",
       "target": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_connector_server_names",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_timeout_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
+      "target": "function:box_agent/tools/mcp_tool_catalog.py:get_mcp_tool_catalog",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:replace_mcp_source",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_startup_ready",
       "type": "calls",
       "direction": "forward",
       "weight": 0.8

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -25,8 +25,8 @@
       "GitHub Actions"
     ],
     "description": "一个具备 Jupyter 沙箱、数据分析、MCP 工具、ACP 协议、多模型提供商支持和独立运行时打包能力的 AI Agent 框架。注意：该项目包含超过 100 个源文件；如需更快的分析，可考虑将范围限定到某个子目录。",
-    "analyzedAt": "2026-09-10T16:13:23.313Z",
-    "gitCommitHash": "ea99fc5ae17f19f2dd752b2264cd3134a36c07ae"
+    "analyzedAt": "2026-09-10T16:51:22.244Z",
+    "gitCommitHash": "affe4e2b57c0de58db749543333eae4b2e27aab1"
   },
   "nodes": [
     {
@@ -5922,7 +5922,7 @@
       "type": "file",
       "name": "sub_agent_capabilities.py",
       "filePath": "box_agent/tools/sub_agent_capabilities.py",
-      "summary": "解析委派能力规范，并解析子代理可获得的工具、Skill、预算与约束。",
+      "summary": "解析委派能力规范并对照父会话实时能力收紧工具、Skill、预算和约束；可用注入的会话访问过滤器检查必需 Skill 及其依赖。",
       "tags": [
         "子任务",
         "能力解析",
@@ -6154,9 +6154,9 @@
       "filePath": "box_agent/tools/sub_agent_capabilities.py",
       "lineRange": [
         533,
-        699
+        711
       ],
-      "summary": "对照父会话实时工具和 SkillLoader 解析能力，拒绝递归委派及约束冲突，并校验 Skill 缺失、禁用、损坏和依赖环。",
+      "summary": "对照父会话实时工具和 SkillLoader 解析能力，拒绝递归委派、约束冲突及缺失、禁用、损坏或成环的 Skill；注入会话过滤器时逐项检查请求及依赖 Skill，并在未获启用时返回结构化失败。",
       "tags": [
         "子任务",
         "能力解析",
@@ -6230,11 +6230,11 @@
       "type": "file",
       "name": "mcp_loader.py",
       "filePath": "box_agent/tools/mcp_loader.py",
-      "summary": "管理 MCP 服务器连接、动态认证、工具包装、状态目录和重连流程。",
+      "summary": "从 system、connector、user 来源组装 MCP 注册表，管理进程内凭据、连接等待、状态与热重连。来源更新串行化，独立服务并发连接；按来源或连接器作用域替换配置并保持逐服务指纹。",
       "tags": [
-        "python",
-        "runtime",
-        "mcp"
+        "mcp",
+        "connectors",
+        "lifecycle"
       ],
       "complexity": "complex"
     },
@@ -6244,15 +6244,16 @@
       "name": "_warn",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        76,
-        78
+        82,
+        84
       ],
-      "summary": "`_warn` 函数负责 warn 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "将 MCP 诊断输出到 stderr，避免污染 ACP stdout 协议流。",
       "tags": [
         "function",
         "python",
         "runtime",
-        "mcp"
+        "mcp",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6262,10 +6263,10 @@
       "name": "_public_mcp_tool_name",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        81,
-        95
+        87,
+        107
       ],
-      "summary": "`_public_mcp_tool_name` 函数负责 public、mcp、tool、name 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "保留浏览器工具的既有公开映射，为连接器工具增加服务命名空间，并用稳定哈希处理非法字符或过长名称。",
       "tags": [
         "function",
         "tools",
@@ -6281,15 +6282,16 @@
       "name": "_replace_server_catalog",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        98,
-        112
+        115,
+        129
       ],
-      "summary": "`_replace_server_catalog` 函数负责 replace、server、catalog 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "替换服务器工具目录并报告名称冲突，由目录隐藏冲突目标。",
       "tags": [
         "function",
         "python",
         "runtime",
-        "mcp"
+        "mcp",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6299,15 +6301,16 @@
       "name": "_structured_mcp_error_message",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        115,
-        134
+        132,
+        151
       ],
-      "summary": "`_structured_mcp_error_message` 函数负责 structured、mcp、error、message 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "从误缺 isError 标记的 JSON 错误封装中恢复可用错误信息。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6317,15 +6320,16 @@
       "name": "_walk_exception_tree",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        137,
-        161
+        154,
+        178
       ],
-      "summary": "`_walk_exception_tree` 函数负责 walk、exception、tree 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "按对象身份去重遍历异常组、cause 和 context，保留底层传输错误。",
       "tags": [
         "function",
         "python",
         "runtime",
-        "mcp"
+        "mcp",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6335,10 +6339,10 @@
       "name": "_http_statuses_from_exception",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        164,
-        176
+        181,
+        193
       ],
-      "summary": "`_http_statuses_from_exception` 函数负责 http、statuses、from、exception 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "从完整异常链提取有效 HTTP 状态码，兼容异常对象和其 response。",
       "tags": [
         "function",
         "status",
@@ -6354,10 +6358,10 @@
       "name": "_mcp_auth_status",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        179,
-        188
+        196,
+        205
       ],
-      "summary": "`_mcp_auth_status` 函数负责 mcp、auth、status 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "汇总异常链中的认证状态，优先识别 401，再识别 403。",
       "tags": [
         "function",
         "mcp",
@@ -6373,10 +6377,10 @@
       "name": "_is_mcp_authentication_error",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        191,
-        192
+        208,
+        209
       ],
-      "summary": "`_is_mcp_authentication_error` 函数负责 is、mcp、authentication、error 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "判断异常链是否包含 MCP 认证或授权失败状态。",
       "tags": [
         "function",
         "mcp",
@@ -6392,15 +6396,16 @@
       "name": "_mcp_connection_error_message",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        195,
-        216
+        212,
+        233
       ],
-      "summary": "`_mcp_connection_error_message` 函数负责 mcp、connection、error、message 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "优先报告真实 HTTP 认证失败或底层传输问题，避免清理产生的取消异常掩盖原因。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6410,10 +6415,10 @@
       "name": "_has_authorization_header",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        275,
-        276
+        292,
+        293
       ],
-      "summary": "`_has_authorization_header` 函数负责 has、authorization、header 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "以不区分大小写方式判断配置是否已包含 Authorization。",
       "tags": [
         "function",
         "authentication",
@@ -6429,10 +6434,10 @@
       "name": "_dynamic_bearer_auth_for_url",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        279,
-        287
+        296,
+        304
       ],
-      "summary": "`_dynamic_bearer_auth_for_url` 函数负责 dynamic、bearer、auth、for、url 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "仅为允许附加产品认证且未显式配置 Authorization 的 URL 建立动态 bearer hook。",
       "tags": [
         "function",
         "authentication",
@@ -6448,15 +6453,16 @@
       "name": "set_mcp_timeout_config",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        290,
-        308
+        307,
+        325
       ],
-      "summary": "`set_mcp_timeout_config` 函数负责 set、mcp、timeout、config 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "仅更新调用方显式提供的全局 MCP 超时值。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6466,15 +6472,16 @@
       "name": "get_mcp_timeout_config",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        311,
-        313
+        328,
+        330
       ],
-      "summary": "`get_mcp_timeout_config` 函数负责 get、mcp、timeout、config 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "返回当前 MCP 连接和执行默认超时配置。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6484,10 +6491,10 @@
       "name": "_current_mcp_auth_fingerprint",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        937,
-        942
+        987,
+        992
       ],
-      "summary": "`_current_mcp_auth_fingerprint` 函数负责 current、mcp、auth、fingerprint 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "计算当前产品登录认证指纹，以判断认证失败服务是否需要在 token 更新后重连。",
       "tags": [
         "function",
         "mcp",
@@ -6503,10 +6510,10 @@
       "name": "is_mcp_loading",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        945,
-        946
+        995,
+        996
       ],
-      "summary": "`is_mcp_loading` 函数负责 is、mcp、loading 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "报告 MCP 首次加载是否仍在进行。",
       "tags": [
         "function",
         "loading",
@@ -6522,10 +6529,10 @@
       "name": "get_mcp_config_path",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        949,
-        950
+        999,
+        1000
       ],
-      "summary": "`get_mcp_config_path` 函数负责 get、mcp、config、path 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "返回本轮 MCP 加载保存的主配置路径。",
       "tags": [
         "function",
         "mcp",
@@ -6541,10 +6548,10 @@
       "name": "get_mcp_tools_for_server",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        953,
-        956
+        1007,
+        1010
       ],
-      "summary": "`get_mcp_tools_for_server` 函数负责 get、mcp、tools、for、server 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "返回指定已连接服务当前持有的工具列表。",
       "tags": [
         "function",
         "tools",
@@ -6560,10 +6567,10 @@
       "name": "get_all_mcp_tools",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        959,
-        961
+        1013,
+        1015
       ],
-      "summary": "`get_all_mcp_tools` 函数负责 get、all、mcp、tools 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "汇总全部活动 MCP 连接的工具对象。",
       "tags": [
         "function",
         "tools",
@@ -6579,15 +6586,16 @@
       "name": "disconnect_mcp_server",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        964,
-        978
+        1018,
+        1032
       ],
-      "summary": "`disconnect_mcp_server` 函数负责 disconnect、mcp、server 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "关闭并移除指定服务的连接及工具目录，并同步其状态。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6597,10 +6605,10 @@
       "name": "_record_status",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        981,
-        999
+        1035,
+        1062
       ],
-      "summary": "`_record_status` 函数负责 record、status 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "记录服务状态与来源身份，规范认证状态，并保持状态载荷不含凭证 headers。",
       "tags": [
         "function",
         "status",
@@ -6616,10 +6624,10 @@
       "name": "get_mcp_status",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1002,
-        1014
+        1065,
+        1082
       ],
-      "summary": "`get_mcp_status` 函数负责 get、mcp、status 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "导出服务状态、owner/configId、连接器名称、sourcePath 和工具元数据。",
       "tags": [
         "function",
         "mcp",
@@ -6635,15 +6643,16 @@
       "name": "_determine_connection_type",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1017,
-        1025
+        1085,
+        1093
       ],
-      "summary": "`_determine_connection_type` 函数负责 determine、connection、type 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "从显式传输配置或 URL 推导服务连接类型，默认使用 stdio。",
       "tags": [
         "function",
         "python",
         "runtime",
-        "mcp"
+        "mcp",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6653,10 +6662,10 @@
       "name": "_resolve_mcp_config_path",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1028,
-        1056
+        1247,
+        1275
       ],
-      "summary": "`_resolve_mcp_config_path` 函数负责 resolve、mcp、config、path 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "按既有用户、工作目录和项目回退规则解析主 MCP 配置文件。",
       "tags": [
         "function",
         "resolution",
@@ -6672,10 +6681,10 @@
       "name": "load_mcp_tools_async",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1059,
-        1235
+        1278,
+        1432
       ],
-      "summary": "`load_mcp_tools_async` 函数负责 load、mcp、tools、async 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "解析多来源注册表并并发启动启用服务；有 credentialRef 但缺凭证时记录等待状态，不创建传输，再发布连接状态与工具目录。",
       "tags": [
         "function",
         "loading",
@@ -6691,15 +6700,16 @@
       "name": "cleanup_mcp_connections",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1238,
-        1245
+        1435,
+        1446
       ],
-      "summary": "`cleanup_mcp_connections` 函数负责 cleanup、mcp、connections 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "关闭连接并清空来源定义、内存来源覆盖、状态与工具目录；运行时凭证仍由进程内凭证接口管理。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6709,15 +6719,16 @@
       "name": "reconnect_mcp_server",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1248,
-        1252
+        1449,
+        1465
       ],
-      "summary": "`reconnect_mcp_server` 函数负责 reconnect、mcp、server 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "串行化同一服务的热重连，只刷新该服务定义的凭证与配置指纹，避免提前推进其他服务的版本状态。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6727,10 +6738,10 @@
       "name": "reconnect_auth_failed_mcp_servers_if_token_changed",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1255,
-        1282
+        1614,
+        1641
       ],
-      "summary": "`reconnect_auth_failed_mcp_servers_if_token_changed` 函数负责 reconnect、auth、failed、mcp、servers、if 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "在产品登录指纹变化后重连认证失败的 MCP 服务，保留逐服务重连锁。",
       "tags": [
         "function",
         "mcp",
@@ -6746,15 +6757,16 @@
       "name": "_reconnect_mcp_server_locked",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        1285,
-        1395
+        1644,
+        1718
       ],
-      "summary": "`_reconnect_mcp_server_locked` 函数负责 reconnect、mcp、server、locked 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "从已解析注册表重建单个服务连接；缺宿主凭证时只返回等待状态，连接成功后更新工具目录及来源状态。",
       "tags": [
         "function",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "moderate"
     },
@@ -6764,15 +6776,16 @@
       "name": "MCPTimeoutConfig",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        230,
-        235
+        247,
+        252
       ],
-      "summary": "`MCPTimeoutConfig` 类负责 MCPTimeoutConfig 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "保存连接、工具执行与 SSE 读取的全局默认超时。",
       "tags": [
         "class",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "simple"
     },
@@ -6782,10 +6795,10 @@
       "name": "DynamicBearerAuth",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        242,
-        272
+        259,
+        289
       ],
-      "summary": "`DynamicBearerAuth` 类负责 DynamicBearerAuth 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "在每次适用的 HTTP 请求时读取最新产品登录 token，保留已有 Authorization 并限制可附加认证的地址。",
       "tags": [
         "class",
         "authentication",
@@ -6801,10 +6814,10 @@
       "name": "MCPTool",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        316,
-        502
+        333,
+        531
       ],
-      "summary": "`MCPTool` 类负责 MCPTool 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "把远端 MCP 工具封装为本地 Tool，保留服务与连接器身份、参数、generation、常驻策略和并发限制，向真实会话提交调用。",
       "tags": [
         "class",
         "tools",
@@ -6820,15 +6833,16 @@
       "name": "MCPServerConnection",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        505,
-        907
+        534,
+        946
       ],
-      "summary": "`MCPServerConnection` 类负责 MCPServerConnection 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "管理 stdio、SSE 与 Streamable HTTP 连接、逐服务超时和生命周期；将连接器身份及所属服务加载策略传递给发现的工具。",
       "tags": [
         "class",
         "mcp",
         "python",
-        "runtime"
+        "runtime",
+        "connectors"
       ],
       "complexity": "complex"
     },
@@ -6838,10 +6852,10 @@
       "name": "McpServerStatus",
       "filePath": "box_agent/tools/mcp_loader.py",
       "lineRange": [
-        916,
-        923
+        956,
+        968
       ],
-      "summary": "`McpServerStatus` 类负责 McpServerStatus 相关逻辑，是 `box_agent/tools/mcp_loader.py` 职责的一部分。",
+      "summary": "保存服务连接状态、来源 owner/configId、连接器元数据及工具计数，不包含运行时凭证 headers。",
       "tags": [
         "class",
         "mcp",
@@ -9902,7 +9916,7 @@
       "type": "file",
       "name": "skill_tool.py",
       "filePath": "box_agent/tools/skill_tool.py",
-      "summary": "把 SkillLoader 封装为模型可调用的 Skill 读取工具集合。",
+      "summary": "把 SkillLoader 封装为按需读取 Skill 正文的工具，并支持在返回内容前应用会话级 Skill 访问过滤。",
       "tags": [
         "python",
         "runtime",
@@ -9916,10 +9930,10 @@
       "name": "create_skill_tools",
       "filePath": "box_agent/tools/skill_tool.py",
       "lineRange": [
-        130,
-        163
+        142,
+        175
       ],
-      "summary": "`create_skill_tools` 函数负责 create、skill、tools 相关逻辑，是 `box_agent/tools/skill_tool.py` 职责的一部分。",
+      "summary": "从单一目录或有优先级的 builtin、connector、user 来源创建 SkillLoader 和 get_skill 工具，支持把目录发现留给宿主后台任务。",
       "tags": [
         "function",
         "creation",
@@ -9936,9 +9950,9 @@
       "filePath": "box_agent/tools/skill_tool.py",
       "lineRange": [
         17,
-        127
+        139
       ],
-      "summary": "`GetSkillTool` 类负责 GetSkillTool 相关逻辑，是 `box_agent/tools/skill_tool.py` 职责的一部分。",
+      "summary": "按需刷新并读取 Skill，处理执行配置禁用、预载内容去重和损坏诊断；注入访问过滤器时拒绝返回当前会话未启用的 Skill 正文。",
       "tags": [
         "class",
         "skills",
@@ -10190,12 +10204,11 @@
       "type": "file",
       "name": "build_runtime.py",
       "filePath": "scripts/build_runtime.py",
-      "summary": "构建跨平台 PyInstaller 运行时，打包 Node/浏览器等组件并可安装到 OfficeV3。",
+      "summary": "构建跨平台独立 ACP 运行时及可迁移资源包，可安装至 OfficeV3；manifest 宣告 connector_skill_sources_version 与 mcp_multi_source_version 均为 1。",
       "tags": [
-        "python",
+        "packaging",
         "runtime",
-        "runtime-management",
-        "packaging"
+        "manifest"
       ],
       "complexity": "complex"
     },
@@ -10208,7 +10221,7 @@
         159,
         161
       ],
-      "summary": "`env_flag` 函数负责 env、flag 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "将环境变量的常见真值拼写转换为构建布尔开关。",
       "tags": [
         "function",
         "python",
@@ -10227,7 +10240,7 @@
         164,
         257
       ],
-      "summary": "`pyinstaller_hidden_imports` 函数负责 pyinstaller、hidden、imports 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "列出独立 ACP 运行时所需 PyInstaller 隐式导入，并适配外部 Python 沙箱模式。",
       "tags": [
         "function",
         "installation",
@@ -10246,7 +10259,7 @@
         260,
         280
       ],
-      "summary": "`pyinstaller_collect_args` 函数负责 pyinstaller、collect、args 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "生成打包运行时所需依赖资源的 PyInstaller collect 参数。",
       "tags": [
         "function",
         "installation",
@@ -10265,7 +10278,7 @@
         283,
         290
       ],
-      "summary": "`pyinstaller_exclude_args` 函数负责 pyinstaller、exclude、args 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "为外部 Python 沙箱构建生成明确的模块排除参数。",
       "tags": [
         "function",
         "installation",
@@ -10284,7 +10297,7 @@
         293,
         309
       ],
-      "summary": "`detect_platform` 函数负责 detect、platform 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "把当前 Python 进程的平台与架构规范化为 Electron 使用的标识。",
       "tags": [
         "function",
         "python",
@@ -10303,7 +10316,7 @@
         312,
         326
       ],
-      "summary": "`parse_target` 函数负责 parse、target 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "解析并校验目标平台与架构，缺省时使用当前进程平台。",
       "tags": [
         "function",
         "parsing",
@@ -10322,7 +10335,7 @@
         329,
         342
       ],
-      "summary": "`require_supported_build_process` 函数负责 require、supported、build、process 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "拒绝当前构建进程无法产出的平台组合，避免生成错误目标元数据。",
       "tags": [
         "function",
         "builder",
@@ -10341,7 +10354,7 @@
         345,
         381
       ],
-      "summary": "`verify_entry_binary_arch` 函数负责 verify、entry、binary、arch 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "检查已打包启动器的实际 CPU 架构是否符合声明目标。",
       "tags": [
         "function",
         "python",
@@ -10360,7 +10373,7 @@
         384,
         389
       ],
-      "summary": "`pyinstaller_target_arch_args` 函数负责 pyinstaller、target、arch、args 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "为 macOS 目标生成 PyInstaller 架构参数。",
       "tags": [
         "function",
         "installation",
@@ -10379,7 +10392,7 @@
         392,
         403
       ],
-      "summary": "`bundled_stable_runtime_components` 函数负责 bundled、stable、runtime、components 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "按目标平台和外部沙箱模式确定要随包携带的稳定运行时组件。",
       "tags": [
         "function",
         "runtime",
@@ -10396,9 +10409,9 @@
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
         406,
-        433
+        435
       ],
-      "summary": "`build_runtime_manifest` 函数负责 build、runtime、manifest 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "生成独立运行时入口与组件清单，宣告 connector_skill_sources_version=1 和 mcp_multi_source_version=1 两项能力版本。",
       "tags": [
         "function",
         "builder",
@@ -10414,10 +10427,10 @@
       "name": "resolve_officev3_dir",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        439,
-        463
+        441,
+        465
       ],
-      "summary": "`resolve_officev3_dir` 函数负责 resolve、officev3、dir 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "定位包含运行时安装器的 OfficeV3 checkout，支持显式参数与环境路径。",
       "tags": [
         "function",
         "resolution",
@@ -10433,10 +10446,10 @@
       "name": "install_runtime_into_officev3",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        466,
-        511
+        468,
+        513
       ],
-      "summary": "`install_runtime_into_officev3` 函数负责 install、runtime、into、officev3 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "调用 OfficeV3 安装器把已构建归档安装至 build-resources，并核对预期版本。",
       "tags": [
         "function",
         "installation",
@@ -10452,10 +10465,10 @@
       "name": "build_runtime",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        514,
-        697
+        516,
+        699
       ],
-      "summary": "`build_runtime` 函数负责 build、runtime 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "编排平台校验、PyInstaller 构建、资源收集、manifest 与归档输出，返回运行时包路径。",
       "tags": [
         "function",
         "builder",
@@ -10471,10 +10484,10 @@
       "name": "_install_bundled_node_runtime",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        700,
-        709
+        702,
+        711
       ],
-      "summary": "`_install_bundled_node_runtime` 函数负责 install、bundled、node、runtime 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "向 macOS 运行时包安装可迁移 Node 组件并清理下载缓存。",
       "tags": [
         "function",
         "installation",
@@ -10490,10 +10503,10 @@
       "name": "_install_bundled_win_runtimes",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        712,
-        731
+        714,
+        733
       ],
-      "summary": "`_install_bundled_win_runtimes` 函数负责 install、bundled、win、runtimes 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "向 Windows 包组合 PortableGit、独立 Python 与 Node，减少对系统工具的依赖。",
       "tags": [
         "function",
         "installation",
@@ -10509,10 +10522,10 @@
       "name": "_install_portable_git_win",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        734,
-        780
+        736,
+        782
       ],
-      "summary": "`_install_portable_git_win` 函数负责 install、portable、git、win 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "下载、校验并解包 Windows PortableGit 到运行时目录。",
       "tags": [
         "function",
         "installation",
@@ -10528,10 +10541,10 @@
       "name": "_install_portable_python_win",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        783,
-        845
+        785,
+        847
       ],
-      "summary": "`_install_portable_python_win` 函数负责 install、portable、python、win 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "下载、校验并安装 Windows 独立 Python，再补充沙箱依赖。",
       "tags": [
         "function",
         "installation",
@@ -10547,10 +10560,10 @@
       "name": "_install_sandbox_packages_win",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        857,
-        893
+        859,
+        895
       ],
-      "summary": "`_install_sandbox_packages_win` 函数负责 install、sandbox、packages、win 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "在随包便携 Python 中预装沙箱数据处理依赖，并隔离父进程虚拟环境标记。",
       "tags": [
         "function",
         "installation",
@@ -10566,10 +10579,10 @@
       "name": "_download_to",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        896,
-        905
+        898,
+        907
       ],
-      "summary": "`_download_to` 函数负责 download、to 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "把远端内容写入临时文件后原子替换目标下载文件。",
       "tags": [
         "function",
         "loading",
@@ -10585,10 +10598,10 @@
       "name": "_sha256_file",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        908,
-        913
+        910,
+        915
       ],
-      "summary": "`_sha256_file` 函数负责 sha256、file 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "分块计算文件 SHA-256，避免一次读入整份归档。",
       "tags": [
         "function",
         "python",
@@ -10604,10 +10617,10 @@
       "name": "_verify_sha256",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        916,
-        927
+        918,
+        929
       ],
-      "summary": "`_verify_sha256` 函数负责 verify、sha256 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "比较下载归档与固定 SHA-256，不匹配时中止构建。",
       "tags": [
         "function",
         "python",
@@ -10623,10 +10636,10 @@
       "name": "_relativize_node_manifest",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        930,
-        947
+        932,
+        949
       ],
-      "summary": "`_relativize_node_manifest` 函数负责 relativize、node、manifest 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "将 Node manifest 路径转换为相对 node_root 的形式，使归档可迁移。",
       "tags": [
         "function",
         "python",
@@ -10642,10 +10655,10 @@
       "name": "main",
       "filePath": "scripts/build_runtime.py",
       "lineRange": [
-        952,
-        1037
+        954,
+        1039
       ],
-      "summary": "`main` 函数负责 main 相关逻辑，是 `scripts/build_runtime.py` 职责的一部分。",
+      "summary": "解析独立运行时构建参数，执行构建并按请求安装到 OfficeV3。",
       "tags": [
         "function",
         "python",
@@ -23008,11 +23021,11 @@
       "type": "file",
       "name": "mcp_bootstrap.py",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
-      "summary": "初始化托管搜索和内置 Web Extract 的 MCP 配置，保留用户设置并向托管 stdio 服务传播当前 profile。",
+      "summary": "初始化托管搜索和内置 Web Extract 的 MCP 配置，保留受保护的用户设置；支持宿主指定的 system MCP 配置路径，未指定时保留旧用户路径。",
       "tags": [
         "mcp",
-        "配置初始化",
-        "托管服务"
+        "configuration",
+        "bootstrap"
       ],
       "complexity": "complex"
     },
@@ -23030,7 +23043,8 @@
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23041,14 +23055,15 @@
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
         56,
-        58
+        61
       ],
-      "summary": "定位当前 profile 的默认托管 MCP 配置文件。",
+      "summary": "优先返回 BOX_AGENT_MANAGED_MCP_CONFIG_PATH 指定的宿主 system MCP 来源，否则沿用当前 profile 的旧用户配置路径。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23058,15 +23073,16 @@
       "name": "_normalize_hosted_search_url",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        61,
-        77
+        64,
+        80
       ],
       "summary": "规范托管搜索地址，去除不合适的尾部格式。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23076,15 +23092,16 @@
       "name": "_is_official_hosted_search_url",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        80,
-        89
+        83,
+        92
       ],
       "summary": "识别内置托管搜索服务地址以控制自动配置覆盖范围。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23094,15 +23111,16 @@
       "name": "_resolve_hosted_search_server",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        92,
-        103
+        95,
+        106
       ],
       "summary": "依据配置和环境选择托管搜索 MCP 的传输与认证设置。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23112,15 +23130,16 @@
       "name": "_bundled_mcp_servers",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        106,
-        156
+        109,
+        159
       ],
       "summary": "收集打包运行时提供的内置 MCP 服务定义。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "moderate"
     },
@@ -23130,15 +23149,16 @@
       "name": "_web_extract_server",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        159,
-        171
+        162,
+        174
       ],
       "summary": "构造内置 Web Extract 的 stdio 启动项并绑定所需 profile 环境。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23148,15 +23168,16 @@
       "name": "_merge_managed_entry",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        174,
-        185
+        177,
+        188
       ],
       "summary": "更新托管服务的受控字段并保留不属于管理范围的用户配置。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23166,15 +23187,16 @@
       "name": "_merge_hosted_search_url",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        188,
-        209
+        191,
+        212
       ],
       "summary": "合并托管搜索 URL 的更新，保护显式自定义的服务地址。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23184,15 +23206,16 @@
       "name": "_atomic_write_json",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        212,
-        229
+        215,
+        232
       ],
       "summary": "先写临时文件再原子替换 MCP JSON，避免部分写入。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23202,15 +23225,16 @@
       "name": "bootstrap_managed_mcp_config",
       "filePath": "box_agent/tools/mcp_bootstrap.py",
       "lineRange": [
-        232,
-        315
+        235,
+        318
       ],
       "summary": "读取并合并托管 MCP 服务，必要时原子写回并返回变更结果。",
       "tags": [
         "工具函数",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "moderate"
     },
@@ -23228,7 +23252,8 @@
         "数据模型",
         "mcp",
         "配置初始化",
-        "托管服务"
+        "托管服务",
+        "configuration"
       ],
       "complexity": "simple"
     },
@@ -23237,7 +23262,7 @@
       "type": "file",
       "name": "mcp_config_tool.py",
       "filePath": "box_agent/tools/mcp_config_tool.py",
-      "summary": "通过工具接口查询和修改 MCP 服务配置，跟随 loader 实际路径并约束显式 profile 的写入边界。",
+      "summary": "通过工具接口查询和修改 MCP 服务配置；优先写入宿主指定的用户配置，未指定时跟随 loader 实际路径，并约束显式 profile 的写入边界。",
       "tags": [
         "mcp",
         "配置",
@@ -23251,8 +23276,8 @@
       "name": "_updated_server_config",
       "filePath": "box_agent/tools/mcp_config_tool.py",
       "lineRange": [
-        33,
-        81
+        34,
+        82
       ],
       "summary": "在现有 MCP 服务配置上应用用户请求的启用或字段更新。",
       "tags": [
@@ -23269,8 +23294,8 @@
       "name": "_browser_config_summary",
       "filePath": "box_agent/tools/mcp_config_tool.py",
       "lineRange": [
-        84,
-        128
+        85,
+        129
       ],
       "summary": "提取浏览器 MCP 配置的可读摘要并保留关键启用状态。",
       "tags": [
@@ -23287,10 +23312,10 @@
       "name": "_resolve_write_target",
       "filePath": "box_agent/tools/mcp_config_tool.py",
       "lineRange": [
-        131,
-        163
+        132,
+        169
       ],
-      "summary": "选择 loader 正在使用的 MCP 配置文件并校验写入不逃出显式 profile。",
+      "summary": "优先选择宿主指定的用户 MCP 配置，否则沿用 loader 与用户配置回退路径；通过 state_path 校验显式 profile 的写入范围。",
       "tags": [
         "工具函数",
         "mcp",
@@ -23305,8 +23330,8 @@
       "name": "McpConfigTool",
       "filePath": "box_agent/tools/mcp_config_tool.py",
       "lineRange": [
-        166,
-        370
+        172,
+        376
       ],
       "summary": "向模型提供 MCP 配置查看和更新能力，保存变更并刷新可用服务状态。",
       "tags": [
@@ -25747,8 +25772,8 @@
       "name": "trusted_runtime_executable_references",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        128,
-        153
+        129,
+        154
       ],
       "summary": "列出被信任的运行时可执行文件引用，供 Shell 安全分析识别。",
       "tags": [
@@ -25765,8 +25790,8 @@
       "name": "detect_dangerous_command",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        156,
-        198
+        157,
+        199
       ],
       "summary": "检测破坏性命令模式并返回需审批的风险原因。",
       "tags": [
@@ -25783,8 +25808,8 @@
       "name": "detect_invalid_runtime_executable_syntax",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        201,
-        213
+        202,
+        214
       ],
       "summary": "检测以错误 Shell 语法引用运行时可执行变量的命令。",
       "tags": [
@@ -25801,8 +25826,8 @@
       "name": "is_safe_scratch_cleanup",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        216,
-        289
+        217,
+        290
       ],
       "summary": "验证清理命令仅作用于当前受控 scratch 后代目录。",
       "tags": [
@@ -25819,8 +25844,8 @@
       "name": "_expand_scratch_reference",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        292,
-        303
+        293,
+        304
       ],
       "summary": "展开命令中的 scratch 路径变量以检查实际清理目标。",
       "tags": [
@@ -25837,8 +25862,8 @@
       "name": "_is_real_scratch_descendant",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        306,
-        325
+        307,
+        326
       ],
       "summary": "解析真实路径并确认其严格位于 scratch 根下，排除符号链接越界。",
       "tags": [
@@ -25855,8 +25880,8 @@
       "name": "_normalized_executable",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        328,
-        332
+        329,
+        333
       ],
       "summary": "规范命令可执行名称以匹配跨平台危险程序。",
       "tags": [
@@ -25873,8 +25898,8 @@
       "name": "_shell_reference_variable",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        335,
-        339
+        336,
+        340
       ],
       "summary": "提取 Shell 参数中的环境变量引用名。",
       "tags": [
@@ -25891,8 +25916,8 @@
       "name": "_shell_environment_mutations",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        342,
-        367
+        343,
+        368
       ],
       "summary": "识别命令对 PATH、HOME 等环境的赋值变化，避免被后续危险调用利用。",
       "tags": [
@@ -25909,8 +25934,8 @@
       "name": "_dangerous_invocation_reason",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        370,
-        390
+        371,
+        391
       ],
       "summary": "根据可执行文件及参数识别危险调用原因。",
       "tags": [
@@ -25927,8 +25952,8 @@
       "name": "_extract_path_token",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        393,
-        431
+        394,
+        432
       ],
       "summary": "从 Shell 词元中恢复用于范围检查的路径。",
       "tags": [
@@ -25945,8 +25970,8 @@
       "name": "_is_path_inside",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        447,
-        461
+        448,
+        462
       ],
       "summary": "判断规范化后的候选路径是否处于指定根目录内。",
       "tags": [
@@ -25963,8 +25988,8 @@
       "name": "_path_is_safe",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        464,
-        473
+        465,
+        474
       ],
       "summary": "按允许根目录集合判断路径是否安全。",
       "tags": [
@@ -25981,8 +26006,8 @@
       "name": "_command_has_unsafe_paths",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        476,
-        499
+        477,
+        500
       ],
       "summary": "检测命令参数中是否含有超出允许范围的路径。",
       "tags": [
@@ -25999,8 +26024,8 @@
       "name": "detect_scope_escape",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        502,
-        540
+        503,
+        541
       ],
       "summary": "分析命令是否通过目录切换、路径或解释器调用逃出工作区范围。",
       "tags": [
@@ -26017,8 +26042,8 @@
       "name": "ask_user_confirmation",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        543,
-        561
+        544,
+        562
       ],
       "summary": "在交互终端显示敏感操作说明并读取用户确认。",
       "tags": [
@@ -26035,8 +26060,8 @@
       "name": "validate_path_in_workspace",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        564,
-        586
+        565,
+        587
       ],
       "summary": "校验文件路径确实位于工作区，拒绝越界及不安全解析。",
       "tags": [
@@ -26053,8 +26078,8 @@
       "name": "backup_file",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        589,
-        615
+        590,
+        616
       ],
       "summary": "在破坏性改动前将文件备份到当前 profile 的 trash 区域。",
       "tags": [
@@ -26071,8 +26096,8 @@
       "name": "extract_rm_targets",
       "filePath": "box_agent/tools/safety.py",
       "lineRange": [
-        618,
-        653
+        619,
+        654
       ],
       "summary": "从删除命令中提取实际目标路径，供安全检查与备份使用。",
       "tags": [
@@ -26264,11 +26289,11 @@
       "type": "file",
       "name": "skill_loader.py",
       "filePath": "box_agent/tools/skill_loader.py",
-      "summary": "发现和缓存多来源 Skill，解析指令与元数据并按查询筛选；显式 profile 使用自己的用户 Skill 根和禁用设置。",
+      "summary": "发现与缓存 builtin、connector、user Skill，解析来源归属和禁用状态，并提供受过滤器约束的目录查询。会话选择器保留已匹配 Skill 的可见性，实际访问继续走独立授权过滤器。",
       "tags": [
-        "skill",
-        "发现",
-        "缓存"
+        "skills",
+        "connectors",
+        "discovery"
       ],
       "complexity": "complex"
     },
@@ -26286,7 +26311,8 @@
         "工具函数",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "simple"
     },
@@ -26304,7 +26330,8 @@
         "工具函数",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "simple"
     },
@@ -26322,7 +26349,8 @@
         "工具函数",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "simple"
     },
@@ -26340,7 +26368,8 @@
         "工具函数",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "simple"
     },
@@ -26351,14 +26380,15 @@
       "filePath": "box_agent/tools/skill_loader.py",
       "lineRange": [
         102,
-        182
+        186
       ],
-      "summary": "保存 Skill 指令、描述、路径、来源和可用状态，并生成提示及宿主元数据。",
+      "summary": "封装 Skill 正文、路径、builtin/connector/user 来源、ownerId 和禁用状态，生成提示与宿主目录元数据。",
       "tags": [
         "数据模型",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "moderate"
     },
@@ -26368,15 +26398,16 @@
       "name": "_SourceEntry",
       "filePath": "box_agent/tools/skill_loader.py",
       "lineRange": [
-        186,
-        198
+        190,
+        202
       ],
       "summary": "记录一个 Skill 来源的目录、名称和来源优先级信息。",
       "tags": [
         "数据模型",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "simple"
     },
@@ -26386,15 +26417,16 @@
       "name": "SkillLoader",
       "filePath": "box_agent/tools/skill_loader.py",
       "lineRange": [
-        201,
-        997
+        205,
+        1033
       ],
-      "summary": "从用户、内置及扩展来源加载 Skill，解析清单、检测变更、缓存结果并提供元数据查询。",
+      "summary": "加载与重载多来源 Skill，解析 connector 目录归属和 disable 标记，并在目录匹配及提示生成时应用可选 skill_filter。",
       "tags": [
         "数据模型",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "complex"
     },
@@ -26404,15 +26436,16 @@
       "name": "SkillSelector",
       "filePath": "box_agent/tools/skill_loader.py",
       "lineRange": [
-        1000,
-        1099
+        1036,
+        1151
       ],
-      "summary": "维护累计查询及匹配名称，按会话绑定和更新可见 Skill 集合。",
+      "summary": "按累计查询更新会话 Skill 目录并应用可见性过滤器，保留已匹配 Skill 的 sticky 名称集合；不替代独立的工具访问授权。",
       "tags": [
         "数据模型",
         "skill",
         "发现",
-        "缓存"
+        "缓存",
+        "skills"
       ],
       "complexity": "moderate"
     },
@@ -27471,12 +27504,11 @@
       "type": "file",
       "name": "session_assembly.py",
       "filePath": "box_agent/session_assembly.py",
-      "summary": "按插件初始化顺序预备模型、记忆、工具、提示与 Hook，复用显式宿主能力并登记自建资源清理。共享 cwd 提示和会话恢复逻辑供 CLI、ACP 与 Python 入口使用。",
+      "summary": "按共享插件初始化顺序装配模型、工具、提示与恢复状态，并转交宿主提供的 Skill 访问和目录过滤器；连接器可用性与授权策略仍由能力模块和宿主回调负责。",
       "tags": [
-        "session-assembly",
-        "plugin-runtime",
-        "resource-ownership",
-        "prompt-composition"
+        "session",
+        "composition",
+        "ownership"
       ],
       "complexity": "complex"
     },
@@ -27486,15 +27518,16 @@
       "name": "_prepared",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        41,
-        43
+        42,
+        44
       ],
       "summary": "判断宿主是否同时提供工具与系统提示，以保留旧的已预备资源入口。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27504,15 +27537,16 @@
       "name": "_stop_task",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        46,
-        52
+        47,
+        53
       ],
       "summary": "取消尚未完成的背景任务并等待结束，消费预期的取消异常。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27522,15 +27556,16 @@
       "name": "prepare_model",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        55,
-        82
+        56,
+        83
       ],
       "summary": "复用借用的 LLM 或按配置创建自有客户端，传递 reasoning_effort_when_disabled，并仅为自建客户端登记关闭回调。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27540,15 +27575,16 @@
       "name": "prepare_memory",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        85,
-        121
+        86,
+        122
       ],
       "summary": "在配置与会话类型允许时创建记忆管理和提取器，CLI 可导入 OpenClaw 并启动维护任务；utility 与已预备资源入口跳过自动初始化。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27558,15 +27594,16 @@
       "name": "prepare_tools",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        124,
-        222
+        125,
+        225
       ],
-      "summary": "复用显式工具或按配置装配基于会话 cwd 的基础和工作区能力，登记自建资源清理；utility 不自动注册工具。",
+      "summary": "装配 cwd 下工具并登记清理，向 GetSkillTool 和工作区工具传递 HostBindings.skill_access_filter；仅转交能力访问策略，utility 不自动注册工具。",
       "tags": [
         "session-assembly",
         "plugin-runtime",
         "resource-ownership",
-        "function"
+        "function",
+        "session"
       ],
       "complexity": "moderate"
     },
@@ -27576,15 +27613,16 @@
       "name": "prepare_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        225,
-        314
+        228,
+        317
       ],
       "summary": "按 CLI、ACP 或 Python profile 组合 cwd、模式、运行时与环境提示；utility 跳过自动记忆和生图，但 ACP 宿主附加提示仍可携带恢复信息。",
       "tags": [
         "session-assembly",
         "plugin-runtime",
         "resource-ownership",
-        "function"
+        "function",
+        "session"
       ],
       "complexity": "moderate"
     },
@@ -27594,15 +27632,16 @@
       "name": "prepare_hooks",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        317,
-        324
+        320,
+        327
       ],
       "summary": "优先借用宿主 Hook 列表，仅在适用的非 ACP、未预备入口按配置加载 Hook。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27612,15 +27651,16 @@
       "name": "finish_session",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        327,
-        371
+        330,
+        378
       ],
-      "summary": "在 Agent 拥有提示后恢复仍可用的持久 Skill，跳过无效或缺失条目，并为旧元数据补齐加载顺序，再绑定共享 SkillSelector。",
+      "summary": "恢复仍可用的持久 Skill 并为已恢复 connector Skill 补回会话 grant，再以 HostBindings.skill_catalog_filter 绑定 SkillSelector 的目录可见性。",
       "tags": [
         "session-assembly",
         "plugin-runtime",
         "resource-ownership",
-        "function"
+        "function",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27630,15 +27670,16 @@
       "name": "_workspace_layout_path",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        374,
-        395
+        381,
+        402
       ],
       "summary": "规范共享工作区布局中的目录值，用于提示路径约定。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27648,15 +27689,16 @@
       "name": "_workspace_layout_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        398,
-        427
+        405,
+        434
       ],
       "summary": "描述宿主选定工作区与稳定会话 cwd，明确工具相对路径、产物扫描和目录判空规则；不恢复旧输出根目录语义。",
       "tags": [
         "session-assembly",
         "plugin-runtime",
         "resource-ownership",
-        "function"
+        "function",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27666,15 +27708,16 @@
       "name": "_filesystem_access_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        430,
-        483
+        437,
+        490
       ],
       "summary": "根据能力策略与工作区生成可访问范围和目录授权提示。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "moderate"
     },
@@ -27684,15 +27727,16 @@
       "name": "_build_action_hints_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        486,
-        503
+        493,
+        515
       ],
-      "summary": "结合记忆稀疏和 Playwright 可用性构造当前会话的宿主引导提示。",
+      "summary": "结合记忆与 Playwright 可用性生成宿主引导提示，优先使用 BOX_AGENT_MCP_CONFIG_PATH 指向的 MCP 配置。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27702,15 +27746,16 @@
       "name": "build_acp_session_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        506,
-        600
+        518,
+        612
       ],
       "summary": "集中组合 ACP 模式、固定 cwd、访问策略、运行环境、专家和后续建议提示，并按显式开关加入通用任务目录组织规则。",
       "tags": [
         "session-assembly",
         "plugin-runtime",
         "resource-ownership",
-        "function"
+        "function",
+        "session"
       ],
       "complexity": "moderate"
     },
@@ -27720,15 +27765,16 @@
       "name": "create_application_runtime",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        603,
-        606
+        615,
+        618
       ],
       "summary": "创建应用级 PluginRuntime，避免宿主适配器直接依赖插件初始化细节。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27738,15 +27784,16 @@
       "name": "build_session_permission_policy",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        609,
-        621
+        621,
+        633
       ],
       "summary": "将配置能力与已规范的宿主文件系统上下文合并，在默认模式下重建会话工作区边界。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27756,15 +27803,16 @@
       "name": "close_owned_clients",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        624,
-        643
+        636,
+        655
       ],
       "summary": "按对象身份去重并逆序关闭进程拥有的模型客户端，继续尝试全部清理并保留原始异常。",
       "tags": [
         "工具函数",
         "会话组装",
         "配置",
-        "生命周期"
+        "生命周期",
+        "session"
       ],
       "complexity": "simple"
     },
@@ -27804,7 +27852,7 @@
       "type": "file",
       "name": "mcp_tool_catalog.py",
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
-      "summary": "维护可检索的 MCP 工具目录、冲突状态与 BM25 排序，支持给定候选集及工具别名，供本地/MCP 联合发现复用。",
+      "summary": "维护进程级 MCP 工具目录、发现就绪状态和名称冲突，保存 Connector 身份与远端原名，并为会话检索提供可过滤的精确匹配和 BM25 排序。",
       "tags": [
         "mcp",
         "工具目录",
@@ -27821,7 +27869,7 @@
         19,
         21
       ],
-      "summary": "`_normalize` 函数负责 normalize 相关逻辑，是 `box_agent/tools/mcp_tool_catalog.py` 职责的一部分。",
+      "summary": "统一搜索文本的大小写、下划线、连字符和连续空白，供工具名与元数据匹配复用。",
       "tags": [
         "function",
         "normalization",
@@ -27840,7 +27888,7 @@
         24,
         26
       ],
-      "summary": "`_tokenize` 函数负责 tokenize 相关逻辑，是 `box_agent/tools/mcp_tool_catalog.py` 职责的一部分。",
+      "summary": "把规范化搜索文本切分为支持 Unicode 的词项，用于工具元数据索引和查询。",
       "tags": [
         "function",
         "python",
@@ -27858,7 +27906,7 @@
         29,
         30
       ],
-      "summary": "`_prefix_term_frequency` 函数负责 prefix、term、frequency 相关逻辑，是 `box_agent/tools/mcp_tool_catalog.py` 职责的一部分。",
+      "summary": "统计字段词项中以查询词为前缀的数量，支持未写完的工具名和关键词匹配。",
       "tags": [
         "function",
         "python",
@@ -27876,7 +27924,7 @@
         33,
         56
       ],
-      "summary": "`_bm25_term_score` 函数负责 bm25、term、score 相关逻辑，是 `box_agent/tools/mcp_tool_catalog.py` 职责的一部分。",
+      "summary": "按词频、文档频率与字段长度计算单个 BM25 相关性分量，无有效命中时返回零。",
       "tags": [
         "function",
         "python",
@@ -27891,10 +27939,10 @@
       "name": "get_mcp_tool_catalog",
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
       "lineRange": [
-        445,
-        446
+        574,
+        575
       ],
-      "summary": "`get_mcp_tool_catalog` 函数负责 get、mcp、tool、catalog 相关逻辑，是 `box_agent/tools/mcp_tool_catalog.py` 职责的一部分。",
+      "summary": "返回进程内共享的 MCP 工具目录实例，供加载器和会话工具发现复用。",
       "tags": [
         "function",
         "tools",
@@ -27911,9 +27959,9 @@
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
       "lineRange": [
         60,
-        68
+        71
       ],
-      "summary": "`MCPToolEntry` 类负责 MCPToolEntry 相关逻辑，是 `box_agent/tools/mcp_tool_catalog.py` 职责的一部分。",
+      "summary": "保存工具身份、实例、代际、加载方式和冲突标记，并保留 Connector ID、显示名及远端原始名称。",
       "tags": [
         "class",
         "tools",
@@ -27929,10 +27977,10 @@
       "name": "MCPToolCatalog",
       "filePath": "box_agent/tools/mcp_tool_catalog.py",
       "lineRange": [
-        71,
-        439
+        74,
+        568
       ],
-      "summary": "维护工具注册快照与就绪状态，提供精确查找及多查询排名，并可对显式候选集按规范名和别名检索。",
+      "summary": "维护工具注册快照与就绪状态，以调用方提供的过滤器限制 Connector 身份解析、精确查找和多查询排名；检索同时覆盖规范名、别名、远端原名及 Connector 元数据。",
       "tags": [
         "class",
         "tools",
@@ -27947,7 +27995,7 @@
       "type": "file",
       "name": "mcp_tool_search.py",
       "filePath": "box_agent/tools/mcp_tool_search.py",
-      "summary": "统一允许的本地与 MCP 工具发现和会话激活；MCP 仍在加载时本地查询可返回结果，并分别报告两类目录数量。",
+      "summary": "统一允许的本地与 MCP 工具发现、会话激活和延迟暴露；支持 Connector 或服务器整组激活，并在提供会话授权查询器时过滤未启用的 Connector 工具。",
       "tags": [
         "mcp",
         "工具发现",
@@ -27998,9 +28046,9 @@
       "filePath": "box_agent/tools/mcp_tool_search.py",
       "lineRange": [
         36,
-        387
+        469
       ],
-      "summary": "检索并激活当前允许的本地/MCP 工具，隔离 server 范围、名称冲突和未就绪目录，返回独立的本地与 MCP 统计。",
+      "summary": "检索并激活当前允许的本地/MCP 工具，支持 Connector 身份、服务器范围、精确名称和关键词查询；注入授权查询器时先过滤 Connector，再计算目录统计、排名和伴随工具。",
       "tags": [
         "数据模型",
         "mcp",
@@ -28015,10 +28063,10 @@
       "name": "MCPToolExposureManager",
       "filePath": "box_agent/tools/mcp_tool_search.py",
       "lineRange": [
-        390,
-        494
+        472,
+        589
       ],
-      "summary": "结合本地延迟名称、已激活实例与 MCP 加载模式构建可见工具视图，保留允许的本地委派能力并检查远端代际变化。",
+      "summary": "结合本地延迟名称和已激活实例构建工具视图与子任务继承集合；延迟 MCP 模式下按注入的会话授权查询器过滤 Connector，并在调用前检查授权及工具代际。",
       "tags": [
         "数据模型",
         "mcp",
@@ -28032,7 +28080,7 @@
       "type": "file",
       "name": "setup.py",
       "filePath": "box_agent/tools/setup.py",
-      "summary": "按配置装配内置工具、Skill 和 MCP 并提供共享初始化与同步入口；工作区工具统一使用会话 cwd，每套工具拥有独立的 Skill scratch 清理范围。",
+      "summary": "按配置装配内置工具、Skill 和 MCP，共享入口接入用户、Connector 与内置 Skill 来源及宿主隔离 MCP 配置；工作区工具使用会话 cwd、独立 scratch，并向子任务传递会话 Skill 过滤器。",
       "tags": [
         "能力装配",
         "工具",
@@ -28046,8 +28094,8 @@
       "name": "render_system_prompt_template",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        65,
-        71
+        66,
+        72
       ],
       "summary": "替换系统提示中的运行时占位内容。",
       "tags": [
@@ -28063,8 +28111,8 @@
       "name": "_image_capable_llm",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        74,
-        108
+        75,
+        109
       ],
       "summary": "从已配置模型中选择具备图片理解能力的客户端。",
       "tags": [
@@ -28080,8 +28128,8 @@
       "name": "build_sandbox_info_prompt",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        111,
-        149
+        112,
+        150
       ],
       "summary": "生成基于会话 cwd 的 Python 沙箱说明，覆盖路径、附件定位、依赖和执行约束。",
       "tags": [
@@ -28097,8 +28145,8 @@
       "name": "build_file_delivery_prompt",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        152,
-        180
+        153,
+        181
       ],
       "summary": "生成统一 cwd 下的文件交付、附件定位、命名和本地 HTML 预览说明，不预设 output 子目录。",
       "tags": [
@@ -28114,8 +28162,8 @@
       "name": "image_generation_service_configured",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        183,
-        190
+        184,
+        191
       ],
       "summary": "检查生图端点及必要配置是否可用。",
       "tags": [
@@ -28131,8 +28179,8 @@
       "name": "build_image_generation_prompt",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        193,
-        214
+        194,
+        215
       ],
       "summary": "为已配置的生图服务生成模型使用说明。",
       "tags": [
@@ -28148,10 +28196,10 @@
       "name": "initialize_base_tools",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        233,
-        453
+        234,
+        488
       ],
-      "summary": "创建基础内置工具并发起 Skill 与 MCP 发现，返回供宿主继续组装的能力集合。",
+      "summary": "创建基础工具并发起 Skill 与 MCP 发现；Skill 来源保持 user→connector→builtin 优先级，宿主指定 MCP 来源时直接接入，普通启动继续执行托管配置引导。",
       "tags": [
         "能力装配",
         "工具",
@@ -28165,8 +28213,8 @@
       "name": "await_skill_discovery",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        456,
-        471
+        491,
+        506
       ],
       "summary": "等待异步 Skill 发现结束并返回 loader 与发现结果。",
       "tags": [
@@ -28182,8 +28230,8 @@
       "name": "await_mcp_tools",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        474,
-        485
+        509,
+        520
       ],
       "summary": "等待 MCP 加载任务并返回可用工具列表。",
       "tags": [
@@ -28199,8 +28247,8 @@
       "name": "register_mcp_tools",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        488,
-        496
+        523,
+        531
       ],
       "summary": "将加载到的 MCP 工具登记到目标工具映射。",
       "tags": [
@@ -28216,8 +28264,8 @@
       "name": "sync_mcp_tools",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        499,
-        521
+        534,
+        556
       ],
       "summary": "按来源更新工具映射，删除过期 MCP 项并恢复被覆盖的回退工具。",
       "tags": [
@@ -28233,8 +28281,8 @@
       "name": "merge_mcp_tools",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        524,
-        539
+        559,
+        574
       ],
       "summary": "合并基础与 MCP 工具，保持名称冲突处理规则一致。",
       "tags": [
@@ -28250,8 +28298,8 @@
       "name": "sync_mcp_tool_list",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        542,
-        550
+        577,
+        585
       ],
       "summary": "以列表形式同步 MCP 工具目录并保留列表身份和回退工具。",
       "tags": [
@@ -28267,10 +28315,10 @@
       "name": "add_workspace_tools",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        553,
-        795
+        588,
+        834
       ],
-      "summary": "依据工作区、权限、模型和环境装配文件、Bash、Jupyter、生图及委派能力，以稳定 cwd 解析相对路径并为每套工具分配独立 scratch。",
+      "summary": "依据工作区、权限、模型和环境装配文件、Bash、Jupyter、生图及委派能力，以稳定 cwd 解析路径并分配独立 scratch；将实时 Skill 目录、会话访问过滤器和能力状态接入子任务。",
       "tags": [
         "能力装配",
         "工具",
@@ -28284,8 +28332,8 @@
       "name": "Colors",
       "filePath": "box_agent/tools/setup.py",
       "lineRange": [
-        223,
-        230
+        224,
+        231
       ],
       "summary": "定义工具初始化过程使用的终端颜色常量。",
       "tags": [
@@ -28300,7 +28348,7 @@
       "type": "file",
       "name": "sub_agent_tool.py",
       "filePath": "box_agent/tools/sub_agent_tool.py",
-      "summary": "实现单任务及批量文件子 Agent 委派，继承运行能力并收紧写入范围，通过共享权限执行链和结果事件回传完成子任务。",
+      "summary": "实现单任务及批量文件子 Agent 委派，继承父会话能力、Skill 访问过滤器和权限链并收紧写入范围，通过结果与进度事件回传子任务状态。",
       "tags": [
         "子agent",
         "权限",
@@ -28366,9 +28414,9 @@
       "filePath": "box_agent/tools/sub_agent_tool.py",
       "lineRange": [
         244,
-        1409
+        1415
       ],
-      "summary": "使用父会话提供的工具、Skill、权限和模型启动普通或批量文件子任务，回传进度、结果和预算用量；以共享 cwd 约束写入范围及产物发现。",
+      "summary": "使用父会话提供的工具、Skill、权限和模型启动普通或批量文件子任务；启动子模型前将会话 Skill 访问过滤器交给 CapabilityResolver，执行中以共享 cwd 约束写入并回传进度、结果和预算用量。",
       "tags": [
         "子agent",
         "权限",
@@ -28381,7 +28429,7 @@
       "type": "file",
       "name": "__init__.py",
       "filePath": "box_agent/acp/__init__.py",
-      "summary": "实现 ACP 协议、宿主元数据和权限交互，通过共享 AgentSession 预备能力并管理资源关闭。会话 cwd 同时作为稳定执行根和产物扫描根，恢复受损日志时向模型说明历史与副作用核查要求。",
+      "summary": "实现 ACP 协议、宿主元数据和权限交互，通过共享 AgentSession 维护稳定 cwd、日志恢复与资源关闭。承接连接器选择、状态与会话 Skill 授权，并通过凭证更新、来源替换和对账扩展驱动 MCP 能力模块。",
       "tags": [
         "acp",
         "protocol-adapter",
@@ -28396,8 +28444,8 @@
       "name": "_artifact_envelope",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        259,
-        304
+        261,
+        306
       ],
       "summary": "将产物事件序列化为带稳定类型判别、会话/任务/轮次标识和修订谱系的 ACP 封装，不再注入 output_dir。",
       "tags": [
@@ -28414,8 +28462,8 @@
       "name": "_inject_item_text",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        307,
-        310
+        309,
+        312
       ],
       "summary": "从字符串或结构化注入项中提取用户文本。",
       "tags": [
@@ -28432,8 +28480,8 @@
       "name": "_inject_item_id",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        313,
-        317
+        315,
+        319
       ],
       "summary": "读取注入请求标识，供队列去重与事件确认使用。",
       "tags": [
@@ -28450,8 +28498,8 @@
       "name": "_text_stream_event_like",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        415,
-        428
+        417,
+        430
       ],
       "summary": "复制流事件的关联信息并替换文本内容，保持包装器输出兼容。",
       "tags": [
@@ -28468,8 +28516,8 @@
       "name": "_injected_marker",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        431,
-        434
+        433,
+        436
       ],
       "summary": "为已接收的注入项生成可识别的确认标记。",
       "tags": [
@@ -28486,8 +28534,8 @@
       "name": "_remove_inject_queue_item",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        437,
-        448
+        439,
+        450
       ],
       "summary": "移除注入队列中的目标请求，同时保留其他项顺序。",
       "tags": [
@@ -28504,8 +28552,8 @@
       "name": "_meta_bool",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        451,
-        454
+        453,
+        456
       ],
       "summary": "从宿主元数据读取布尔配置并应用默认值。",
       "tags": [
@@ -28522,8 +28570,8 @@
       "name": "_meta_string",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        457,
-        464
+        459,
+        466
       ],
       "summary": "清理元数据中的可选字符串，拒绝不符合约定的类型。",
       "tags": [
@@ -28540,8 +28588,8 @@
       "name": "_meta_string_list",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        467,
-        481
+        469,
+        483
       ],
       "summary": "从元数据提取去重后的非空字符串列表。",
       "tags": [
@@ -28558,8 +28606,8 @@
       "name": "_normalize_llm_binding",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        484,
-        553
+        486,
+        555
       ],
       "summary": "校验模型绑定身份、版本及能力字段，拒绝在绑定中夹带不允许的提供商配置。",
       "tags": [
@@ -28576,8 +28624,8 @@
       "name": "_plan_approval_from_meta",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        556,
-        569
+        558,
+        571
       ],
       "summary": "提取 ACP 元数据中待处理的计划审批载荷。",
       "tags": [
@@ -28594,8 +28642,8 @@
       "name": "_user_decision_response_from_meta",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        572,
-        603
+        574,
+        605
       ],
       "summary": "将宿主决策响应规范化为运行循环使用的审批数据。",
       "tags": [
@@ -28612,8 +28660,8 @@
       "name": "_plan_approval_is_approved",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        606,
-        620
+        608,
+        622
       ],
       "summary": "识别计划批准状态，供 ACP 的计划交互入口使用。",
       "tags": [
@@ -28630,8 +28678,8 @@
       "name": "_looks_like_plan_approval_text",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        623,
-        660
+        625,
+        662
       ],
       "summary": "判断用户短回复是否表达批准计划，避免把普通任务文本当作审批。",
       "tags": [
@@ -28648,8 +28696,8 @@
       "name": "_plan_approval_from_pending_text",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        663,
-        677
+        665,
+        679
       ],
       "summary": "将对待审批计划的文字回复映射为带计划身份的审批响应。",
       "tags": [
@@ -28666,8 +28714,8 @@
       "name": "_strip_history_text_prefix",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        692,
-        698
+        694,
+        700
       ],
       "summary": "剥离历史拼接标记以恢复用户原文。",
       "tags": [
@@ -28684,8 +28732,8 @@
       "name": "_latest_user_request_for_plan_detection",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        701,
-        751
+        703,
+        753
       ],
       "summary": "从本轮输入及历史文本中选择真正的最新用户请求供计划识别。",
       "tags": [
@@ -28702,8 +28750,8 @@
       "name": "_user_source_text_for_binding",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        754,
-        805
+        756,
+        807
       ],
       "summary": "为 Skill 来源绑定选择用户原始文本，排除宿主历史包装内容。",
       "tags": [
@@ -28720,8 +28768,8 @@
       "name": "_update_pending_plan_approval_from_raw",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        808,
-        828
+        810,
+        830
       ],
       "summary": "从工具结果更新待批准计划及审批状态。",
       "tags": [
@@ -28738,8 +28786,8 @@
       "name": "_normalize_workspace_layout",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        863,
-        877
+        865,
+        879
       ],
       "summary": "兼容工作区布局字段的 snake_case 与 camelCase 名称；规范值本身不改变会话 cwd。",
       "tags": [
@@ -28756,8 +28804,8 @@
       "name": "_workspace_layout_prompt",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        880,
-        883
+        882,
+        885
       ],
       "summary": "规范宿主布局字段后委托共享 session_assembly 生成工作区与稳定 cwd 提示。",
       "tags": [
@@ -28774,8 +28822,8 @@
       "name": "_goal_payload",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        886,
-        887
+        888,
+        889
       ],
       "summary": "复用公共目标序列化函数生成 ACP 返回载荷。",
       "tags": [
@@ -28792,8 +28840,8 @@
       "name": "_goal_request_from_meta",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        890,
-        907
+        892,
+        909
       ],
       "summary": "从 ACP 元数据提取创建或更新持久目标的请求。",
       "tags": [
@@ -28810,8 +28858,8 @@
       "name": "_tool_result_raw_output",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        910,
-        940
+        912,
+        942
       ],
       "summary": "为结构化工具结果补齐会话、任务、轮次和权限决策元数据，不再注入独立输出目录。",
       "tags": [
@@ -28828,8 +28876,8 @@
       "name": "_bind_user_source_text",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        973,
-        976
+        1157,
+        1160
       ],
       "summary": "委托共享 Skill 环境绑定器将用户原文写入会话工具执行上下文。",
       "tags": [
@@ -28846,8 +28894,8 @@
       "name": "run_acp_server",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5049,
-        5312
+        5384,
+        5647
       ],
       "summary": "装配应用级 runtime 与 ACP 服务，运行 stdio 协议，并在退出时按所有权关闭会话和模型客户端。",
       "tags": [
@@ -28864,8 +28912,8 @@
       "name": "main",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        5315,
-        5316
+        5650,
+        5651
       ],
       "summary": "启动 ACP 异步服务的命令行入口。",
       "tags": [
@@ -28882,8 +28930,8 @@
       "name": "_ActionHintNormalizingLLM",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        320,
-        359
+        322,
+        361
       ],
       "summary": "包装 LLM 的同步与流式结果，规范面向宿主的 action-hint 块。",
       "tags": [
@@ -28900,8 +28948,8 @@
       "name": "_FollowUpSuggestionsExtractingLLM",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        362,
-        412
+        364,
+        414
       ],
       "summary": "从模型输出提取后续建议并从用户可见文本中移除结构标记。",
       "tags": [
@@ -28918,10 +28966,10 @@
       "name": "SessionState",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        944,
-        966
+        946,
+        973
       ],
-      "summary": "继承受管 AgentSession，保存 ACP 会话标识、专家和宿主元数据，不复制共享生命周期策略。",
+      "summary": "继承受管 AgentSession 保存 ACP 宿主元数据，并记录会话选择的连接器、目录状态快照、内部 Skill 授权和 utility 标记，供每轮能力过滤与提示更新使用。",
       "tags": [
         "数据模型",
         "acp",
@@ -28936,10 +28984,10 @@
       "name": "BoxACPAgent",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        979,
-        4629
+        1163,
+        4964
       ],
-      "summary": "处理 ACP 会话和协议事件，将标准化选项与借用资源交给共享会话入口。会话 cwd 保持稳定，日志受损恢复时注入核查既有结果与副作用的提示。",
+      "summary": "处理 ACP 会话及协议扩展，把连接器选择、目录状态和内部 Skill 授权接入共享会话组装，并调用 MCP 凭证、来源替换与对账能力。宿主公开 Skill 列表排除连接器来源，会话生命周期、稳定 cwd 和日志恢复继续通过共享入口维护。",
       "tags": [
         "acp",
         "protocol-adapter",
@@ -28954,8 +29002,8 @@
       "name": "_PermissionNegotiator",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        4632,
-        4887
+        4967,
+        5222
       ],
       "summary": "串行化和去重宿主权限请求，把审批结果转换为工具授权与目录授权。",
       "tags": [
@@ -28972,8 +29020,8 @@
       "name": "_MemoryProposalNegotiator",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        4890,
-        5046
+        5225,
+        5381
       ],
       "summary": "向宿主发出记忆提升提案并将用户响应交回共享记忆流程。",
       "tags": [
@@ -29287,7 +29335,7 @@
       "type": "file",
       "name": "agent.py",
       "filePath": "box_agent/agent.py",
-      "summary": "提供 Agent 公共 API、运行选项和目标状态，协调 SessionLog、Skill 状态与稳定循环。相对工具路径和产物扫描统一基于会话 cwd，旧 artifact_root_dir 参数仅保留兼容接收。",
+      "summary": "提供 Agent 公共 API、运行选项和目标状态，协调 SessionLog、Skill 状态与稳定循环。保持会话 cwd 路径合同，并把连接器许可回调交给 MCP 工具搜索和可见性管理。",
       "tags": [
         "agent-runtime",
         "public-api",
@@ -29537,9 +29585,9 @@
       "filePath": "box_agent/agent.py",
       "lineRange": [
         436,
-        1289
+        1295
       ],
-      "summary": "维护消息、目标与 Skill 公共接口，将有效能力传入稳定循环并管理模型可见工具。工具相对路径遵循会话 cwd，旧产物根参数只触发一次兼容提示。",
+      "summary": "维护消息、目标与 Skill 公共接口，把有效能力传入稳定循环并管理模型可见工具。将宿主连接器许可回调传给 MCPToolExposureManager 和 ToolSearchTool，同时提示模型使用本轮最新连接器状态。",
       "tags": [
         "agent-runtime",
         "public-api",
@@ -29553,7 +29601,7 @@
       "type": "file",
       "name": "agent_runtime.py",
       "filePath": "box_agent/agent_runtime.py",
-      "summary": "集中构造 LLM、Agent、权限和记忆对象，保留可注入工厂；传递可选推理强度与内置工具开关，使共享会话路径和宿主入口行为一致。",
+      "summary": "集中构造 LLM、Agent、权限和记忆对象，保留可注入工厂与兼容参数转发；把连接器许可回调传入 Agent，使共享会话和宿主入口使用同一能力过滤入口。",
       "tags": [
         "runtime",
         "依赖注入",
@@ -29586,9 +29634,9 @@
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
         73,
-        136
+        138
       ],
-      "summary": "集中转发 Agent 配置与能力，并仅在显式提供时传递内置工具开关，保留已有工厂替换点。",
+      "summary": "通过可替换工厂构造 Agent，集中转发运行参数、SessionLog 和内置工具选项，并将宿主提供的连接器许可回调传给 Agent。",
       "tags": [
         "工具函数",
         "runtime",
@@ -29603,8 +29651,8 @@
       "name": "build_permission_engine",
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
-        139,
-        153
+        141,
+        155
       ],
       "summary": "使用宿主解析的策略、工作目录和授权存储创建共享权限引擎。",
       "tags": [
@@ -29621,8 +29669,8 @@
       "name": "build_memory_manager",
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
-        156,
-        167
+        158,
+        169
       ],
       "summary": "根据显式记忆配置创建共享 MemoryManager，保留可注入构造工厂。",
       "tags": [
@@ -29639,8 +29687,8 @@
       "name": "build_memory_extractor",
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
-        170,
-        192
+        172,
+        194
       ],
       "summary": "为记忆管理器绑定 LLM、冷却时间与步骤间隔，创建共享提取器。",
       "tags": [
@@ -29656,7 +29704,7 @@
       "type": "file",
       "name": "agent_session.py",
       "filePath": "box_agent/agent_session.py",
-      "summary": "统一活跃会话状态和配置引用，通过 PluginRuntime 预备能力，为每轮绑定受管 KernelServices，并按 run、session、拥有的 runtime 顺序释放资源。会话仅使用工作区 cwd，不再保存独立产物目录或模式。",
+      "summary": "统一活跃会话状态和配置引用，通过 PluginRuntime 预备能力、为每轮绑定 KernelServices，并按所有权释放资源。显式接收连接器许可回调并经 Agent 工厂转发，继续使用会话 cwd。",
       "tags": [
         "session-lifecycle",
         "plugin-runtime",
@@ -29671,9 +29719,9 @@
       "filePath": "box_agent/agent_session.py",
       "lineRange": [
         32,
-        404
+        406
       ],
-      "summary": "管理显式配置、运行选项和受管插件会话；禁止并发轮次与外部覆盖受管服务，协调取消、暂停在 yield 的流关闭和按所有权释放资源。",
+      "summary": "管理显式配置、运行选项和受管插件会话，协调取消、流关闭和按所有权释放资源。创建会话时将连接器许可回调传入 Agent 工厂，保留禁止并发轮次及外部覆盖受管服务的约束。",
       "tags": [
         "数据模型",
         "会话",
@@ -35371,7 +35419,7 @@
       "type": "file",
       "name": "session_context.py",
       "filePath": "box_agent/session_context.py",
-      "summary": "用显式数据对象分离配置、会话选项、宿主借用能力和本轮执行输入，诊断输出避免暴露 Config。工作区 cwd 是会话选项中的目录边界，不再另存 artifact root 或 artifact mode。",
+      "summary": "用显式数据对象分离配置、会话选项、宿主借用能力与本轮输入，诊断输出避免暴露 Config。HostBindings 允许宿主提供 Skill 访问和目录过滤回调，供共享能力组装接入策略。",
       "tags": [
         "data-model",
         "host-bindings",
@@ -35404,9 +35452,9 @@
       "filePath": "box_agent/session_context.py",
       "lineRange": [
         38,
-        64
+        66
       ],
-      "summary": "声明宿主回调及借用的模型、工具、记忆、Hook、SessionLog 和异步任务，区分已预备与待组装入口。",
+      "summary": "声明宿主借用的模型、工具、记忆、Hook、SessionLog、异步任务与组装回调，并提供可选 Skill 访问和目录过滤函数，供共享会话预备阶段使用。",
       "tags": [
         "数据模型",
         "会话",
@@ -35421,8 +35469,8 @@
       "name": "SessionContext",
       "filePath": "box_agent/session_context.py",
       "lineRange": [
-        68,
-        84
+        70,
+        86
       ],
       "summary": "绑定 Config、SessionOptions、HostBindings 与唯一会话键，解析工作区并发送不会改变模型行为的诊断事件。",
       "tags": [
@@ -35439,8 +35487,8 @@
       "name": "RunContext",
       "filePath": "box_agent/session_context.py",
       "lineRange": [
-        88,
-        92
+        90,
+        94
       ],
       "summary": "把当前会话、Agent、有效运行选项和唯一轮次 ID 绑定为 run scope 工厂输入。",
       "tags": [
@@ -36809,8 +36857,8 @@
       "name": "_deprecated_artifact_fields",
       "filePath": "box_agent/acp/__init__.py",
       "lineRange": [
-        831,
-        860
+        833,
+        862
       ],
       "summary": "列出宿主元数据及 workspace_layout 中已废弃、仅接受但忽略的产物路径字段，供诊断日志记录。",
       "tags": [
@@ -36978,6 +37026,533 @@
         "命令校验",
         "路径安全",
         "自检"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_ids_from_meta",
+      "type": "function",
+      "name": "_connector_ids_from_meta",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        983,
+        1000
+      ],
+      "summary": "读取宿主每会话的连接器选择，校验数组和 ID 格式，规范大小写并去重；缺失字段保留为未提供选择。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_statuses_from_meta",
+      "type": "function",
+      "name": "_connector_statuses_from_meta",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1003,
+        1043
+      ],
+      "summary": "校验宿主提供的完整连接器目录快照，限制条目数并验证唯一 ID、名称及 connected/disconnected 状态，返回不可变记录。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_status_unavailable_from_meta",
+      "type": "function",
+      "name": "_connector_status_unavailable_from_meta",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1046,
+        1057
+      ],
+      "summary": "读取并严格校验宿主的连接器状态刷新失败标记，区分未提供字段与显式布尔值。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "type": "function",
+      "name": "_connector_server_statuses",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1060,
+        1078
+      ],
+      "summary": "从 MCP 运行时状态中筛选 connector 所有者的服务器，并按规范连接器 ID 汇总服务器名称、连接器名称和连接状态。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "type": "function",
+      "name": "_connected_connector_ids",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1081,
+        1091
+      ],
+      "summary": "只返回会话已选择且预期服务器集合完整匹配、所有服务器均 connected 的连接器 ID。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_skill_is_available",
+      "type": "function",
+      "name": "_connector_skill_is_available",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1094,
+        1100
+      ],
+      "summary": "对连接器来源 Skill 的新识别要求所属连接器已选中且运行时完整连接，其他来源直接允许；不移除已经加载的指导。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_skill_is_granted",
+      "type": "function",
+      "name": "_connector_skill_is_granted",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1103,
+        1107
+      ],
+      "summary": "访问连接器 Skill 时要求其名称已获本会话内部选择器授权，其他来源 Skill 保持可用。"
+    },
+    {
+      "id": "function:box_agent/acp/__init__.py:_connector_status_context",
+      "type": "function",
+      "name": "_connector_status_context",
+      "filePath": "box_agent/acp/__init__.py",
+      "tags": [
+        "connector",
+        "session-policy",
+        "validation",
+        "utility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        1110,
+        1154
+      ],
+      "summary": "生成连接器级状态提示，优先使用宿主完整快照，缺失时聚合已选连接器的运行时状态；刷新失败时明确禁止沿用旧状态。"
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_mcp_tool_always_load",
+      "type": "function",
+      "name": "_mcp_tool_always_load",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        110,
+        112
+      ],
+      "summary": "使用工具所属服务器的 alwaysLoad 设置决定常驻或延迟加载，不由远端工具覆盖该策略。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:get_mcp_config_paths",
+      "type": "function",
+      "name": "get_mcp_config_paths",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1003,
+        1004
+      ],
+      "summary": "按 owner 返回已注册的 MCP 配置来源路径，不返回凭证内容。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:set_mcp_runtime_credential",
+      "type": "function",
+      "name": "set_mcp_runtime_credential",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1096,
+        1121
+      ],
+      "summary": "校验 credentialRef 与 headers 后仅写入进程内存，递增该引用的凭证版本并返回受影响服务名；不写配置文件。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:get_mcp_connector_server_names",
+      "type": "function",
+      "name": "get_mcp_connector_server_names",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1124,
+        1134
+      ],
+      "summary": "从全部已配置定义按 connector_id 汇总预期服务名，供完整连接器状态判断。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:clear_mcp_runtime_credential",
+      "type": "function",
+      "name": "clear_mcp_runtime_credential",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1137,
+        1147
+      ],
+      "summary": "从进程内存移除指定凭证并递增版本，返回需重新核对连接的服务名。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_materialize_server_config",
+      "type": "function",
+      "name": "_materialize_server_config",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1150,
+        1162
+      ],
+      "summary": "复制服务定义并移除来源标记，把 credentialRef 对应的最新内存 headers 合入连接配置。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_waiting_for_credential",
+      "type": "function",
+      "name": "_waiting_for_credential",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1165,
+        1167
+      ],
+      "summary": "检查声明了 credentialRef 的服务是否仍缺少宿主恢复的内存凭证。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "type": "function",
+      "name": "_build_connection",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1170,
+        1206
+      ],
+      "summary": "用已解析定义和最新内存凭证统一构造连接，复用冷启动与重连的认证、超时、连接器身份及加载策略。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "type": "function",
+      "name": "_resolve_registered_sources",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1209,
+        1244
+      ],
+      "summary": "组合环境来源与内存 connector 覆盖，解析受保护服务名，调用来源解析器并报告冲突；不提交其他服务已使用新凭证的假状态。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "type": "function",
+      "name": "reconcile_mcp_sources",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1468,
+        1476
+      ],
+      "summary": "等待首次加载就绪后取得来源更新锁，按可选来源作用域对账并调整连接。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:replace_mcp_source",
+      "type": "function",
+      "name": "replace_mcp_source",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1479,
+        1537
+      ],
+      "summary": "校验并在内存替换 connector 来源；connectorIds 可限定替换和删除范围，保留其他连接器及 system/user 来源，再执行串行对账。",
+      "complexity": "moderate",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "type": "function",
+      "name": "_reconcile_mcp_sources_locked",
+      "filePath": "box_agent/tools/mcp_loader.py",
+      "lineRange": [
+        1540,
+        1611
+      ],
+      "summary": "比较作用域内服务的新旧定义与指纹，处理移除和禁用，并并发重连新增、变更或上次失败的服务；健康及仍加载的未变化服务保持原连接。",
+      "complexity": "moderate",
+      "tags": [
+        "mcp",
+        "connectors",
+        "lifecycle"
+      ]
+    },
+    {
+      "id": "file:box_agent/tools/mcp_sources.py",
+      "type": "file",
+      "name": "mcp_sources.py",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "summary": "把按优先级隔离的 MCP 配置来源解析为统一服务定义，校验连接器身份、受保护名称与冲突，并将配置内容和凭证版本纳入指纹；不建立连接或持久化凭证。",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:box_agent/tools/mcp_sources.py:McpConfigSource",
+      "type": "class",
+      "name": "McpConfigSource",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        19,
+        21
+      ],
+      "summary": "以不可变数据类保存 MCP 来源的 owner 与配置文件路径。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "class:box_agent/tools/mcp_sources.py:ResolvedMcpServer",
+      "type": "class",
+      "name": "ResolvedMcpServer",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        25,
+        33
+      ],
+      "summary": "保存服务配置、来源归属、config_id、连接器身份、source_path 及版本化配置指纹，供 loader 调整连接。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "class:box_agent/tools/mcp_sources.py:ResolvedMcpSources",
+      "type": "class",
+      "name": "ResolvedMcpSources",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        37,
+        40
+      ],
+      "summary": "封装本次解析使用的来源列表、有效服务字典及被跳过的命名冲突。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_sources.py:configured_mcp_sources",
+      "type": "function",
+      "name": "configured_mcp_sources",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        43,
+        63
+      ],
+      "summary": "依据显式环境路径按 system、connector、user 顺序列出配置来源；宿主未启用隔离时保留单个 user 配置文件行为。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_sources.py:_read_servers",
+      "type": "function",
+      "name": "_read_servers",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        66,
+        81
+      ],
+      "summary": "读取来源文件并验证 mcpServers 对象及每个服务条目；缺失文件视为空来源，格式错误明确失败。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_sources.py:_copy_servers",
+      "type": "function",
+      "name": "_copy_servers",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        84,
+        92
+      ],
+      "summary": "验证内存来源覆盖的 mcpServers 字典并复制条目，避免直接复用输入容器。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_sources.py:_server_identity",
+      "type": "function",
+      "name": "_server_identity",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        95,
+        120
+      ],
+      "summary": "按 owner 生成 system、connector 或 custom-mcp 身份，严格规范连接器 ID，并给缺失展示名使用 ID 回退。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_sources.py:_fingerprint",
+      "type": "function",
+      "name": "_fingerprint",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        123,
+        140
+      ],
+      "summary": "将来源、configId、配置内容和独立凭证版本组合为 SHA-256，供 loader 识别需重新连接的服务。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "type": "function",
+      "name": "resolve_mcp_sources",
+      "filePath": "box_agent/tools/mcp_sources.py",
+      "lineRange": [
+        143,
+        189
+      ],
+      "summary": "按来源优先级解析文件或内存覆盖，阻止用户使用受保护名称及后续来源覆盖同名服务，返回带凭证版本指纹的定义与冲突列表。",
+      "complexity": "simple",
+      "tags": [
+        "mcp",
+        "source-isolation",
+        "configuration"
+      ]
+    },
+    {
+      "id": "document:docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "type": "document",
+      "name": "CONNECTOR_RUNTIME_RESTORE.md",
+      "filePath": "docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "summary": "规定宿主在每次 ACP 进程初始化后先恢复进程内凭证、再发布连接器来源，并按 connectorIds 作用域更新。说明缺凭证等待、逐服务指纹与失败重试，以及打包宿主验证边界。",
+      "tags": [
+        "documentation",
+        "connectors",
+        "restoration"
       ],
       "complexity": "simple"
     }
@@ -41356,7 +41931,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_warn",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41370,7 +41945,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_public_mcp_tool_name",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41384,7 +41959,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_replace_server_catalog",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41398,7 +41973,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_structured_mcp_error_message",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41412,7 +41987,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_walk_exception_tree",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41426,7 +42001,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_http_statuses_from_exception",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41440,7 +42015,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_mcp_auth_status",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41454,7 +42029,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_is_mcp_authentication_error",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41468,7 +42043,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_mcp_connection_error_message",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41482,7 +42057,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_has_authorization_header",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41496,7 +42071,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_dynamic_bearer_auth_for_url",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41510,7 +42085,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:set_mcp_timeout_config",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41524,7 +42099,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:get_mcp_timeout_config",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41538,7 +42113,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_current_mcp_auth_fingerprint",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41552,7 +42127,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:is_mcp_loading",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41566,7 +42141,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:get_mcp_config_path",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41580,7 +42155,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:get_mcp_tools_for_server",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41594,7 +42169,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:get_all_mcp_tools",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41608,7 +42183,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:disconnect_mcp_server",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41622,7 +42197,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_record_status",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41636,7 +42211,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:get_mcp_status",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41650,7 +42225,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_determine_connection_type",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41664,7 +42239,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_resolve_mcp_config_path",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41678,7 +42253,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41692,7 +42267,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:cleanup_mcp_connections",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41706,7 +42281,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:reconnect_mcp_server",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41720,7 +42295,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:reconnect_auth_failed_mcp_servers_if_token_changed",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41734,7 +42309,7 @@
       "target": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41748,7 +42323,7 @@
       "target": "class:box_agent/tools/mcp_loader.py:MCPTimeoutConfig",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41762,7 +42337,7 @@
       "target": "class:box_agent/tools/mcp_loader.py:DynamicBearerAuth",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41776,7 +42351,7 @@
       "target": "class:box_agent/tools/mcp_loader.py:MCPTool",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41790,7 +42365,7 @@
       "target": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41804,7 +42379,7 @@
       "target": "class:box_agent/tools/mcp_loader.py:McpServerStatus",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
@@ -41955,20 +42530,6 @@
     },
     {
       "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
-      "target": "function:box_agent/tools/mcp_loader.py:_dynamic_bearer_auth_for_url",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
-      "target": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
       "target": "function:box_agent/tools/mcp_loader.py:_mcp_auth_status",
       "type": "calls",
       "direction": "forward",
@@ -42005,27 +42566,6 @@
     {
       "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
       "target": "function:box_agent/tools/mcp_loader.py:_record_status",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
-      "target": "function:box_agent/tools/mcp_loader.py:_determine_connection_type",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
-      "target": "function:box_agent/tools/mcp_loader.py:_dynamic_bearer_auth_for_url",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
-      "target": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
       "type": "calls",
       "direction": "forward",
       "weight": 0.8
@@ -44825,7 +45365,7 @@
       "target": "function:box_agent/tools/skill_tool.py:create_skill_tools",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_tool.py",
@@ -44839,7 +45379,7 @@
       "target": "class:box_agent/tools/skill_tool.py:GetSkillTool",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_tool.py",
@@ -45085,7 +45625,7 @@
       "target": "function:scripts/build_runtime.py:env_flag",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45099,7 +45639,7 @@
       "target": "function:scripts/build_runtime.py:pyinstaller_hidden_imports",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45113,7 +45653,7 @@
       "target": "function:scripts/build_runtime.py:pyinstaller_collect_args",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45127,7 +45667,7 @@
       "target": "function:scripts/build_runtime.py:pyinstaller_exclude_args",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45141,7 +45681,7 @@
       "target": "function:scripts/build_runtime.py:detect_platform",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45155,7 +45695,7 @@
       "target": "function:scripts/build_runtime.py:parse_target",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45169,7 +45709,7 @@
       "target": "function:scripts/build_runtime.py:require_supported_build_process",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45183,7 +45723,7 @@
       "target": "function:scripts/build_runtime.py:verify_entry_binary_arch",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45197,7 +45737,7 @@
       "target": "function:scripts/build_runtime.py:pyinstaller_target_arch_args",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45211,7 +45751,7 @@
       "target": "function:scripts/build_runtime.py:bundled_stable_runtime_components",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45225,7 +45765,7 @@
       "target": "function:scripts/build_runtime.py:build_runtime_manifest",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45239,7 +45779,7 @@
       "target": "function:scripts/build_runtime.py:resolve_officev3_dir",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45253,7 +45793,7 @@
       "target": "function:scripts/build_runtime.py:install_runtime_into_officev3",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45267,7 +45807,7 @@
       "target": "function:scripts/build_runtime.py:build_runtime",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45281,7 +45821,7 @@
       "target": "function:scripts/build_runtime.py:_install_bundled_node_runtime",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45295,7 +45835,7 @@
       "target": "function:scripts/build_runtime.py:_install_bundled_win_runtimes",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45309,7 +45849,7 @@
       "target": "function:scripts/build_runtime.py:_install_portable_git_win",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45323,7 +45863,7 @@
       "target": "function:scripts/build_runtime.py:_install_portable_python_win",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45337,7 +45877,7 @@
       "target": "function:scripts/build_runtime.py:_install_sandbox_packages_win",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45351,7 +45891,7 @@
       "target": "function:scripts/build_runtime.py:_download_to",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45365,7 +45905,7 @@
       "target": "function:scripts/build_runtime.py:_sha256_file",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45379,7 +45919,7 @@
       "target": "function:scripts/build_runtime.py:_verify_sha256",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45393,7 +45933,7 @@
       "target": "function:scripts/build_runtime.py:_relativize_node_manifest",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -45407,7 +45947,7 @@
       "target": "function:scripts/build_runtime.py:main",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:scripts/build_runtime.py",
@@ -54238,7 +54778,8 @@
       "target": "file:box_agent/tools/safety.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/tools/bash_tool.py",
@@ -54434,7 +54975,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_runtime_root",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54448,7 +54989,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:default_managed_mcp_config_path",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54462,7 +55003,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_normalize_hosted_search_url",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54476,7 +55017,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_is_official_hosted_search_url",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54490,7 +55031,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_resolve_hosted_search_server",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54504,7 +55045,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_bundled_mcp_servers",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54518,7 +55059,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_web_extract_server",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54532,7 +55073,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_merge_managed_entry",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54546,7 +55087,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_merge_hosted_search_url",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54560,7 +55101,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:_atomic_write_json",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54574,7 +55115,7 @@
       "target": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54588,7 +55129,7 @@
       "target": "class:box_agent/tools/mcp_bootstrap.py:McpBootstrapResult",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_bootstrap.py",
@@ -54609,7 +55150,7 @@
       "target": "function:box_agent/tools/mcp_config_tool.py:_updated_server_config",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_config_tool.py",
@@ -54623,7 +55164,7 @@
       "target": "function:box_agent/tools/mcp_config_tool.py:_browser_config_summary",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_config_tool.py",
@@ -54637,7 +55178,7 @@
       "target": "function:box_agent/tools/mcp_config_tool.py:_resolve_write_target",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_config_tool.py",
@@ -54651,7 +55192,7 @@
       "target": "class:box_agent/tools/mcp_config_tool.py:McpConfigTool",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_config_tool.py",
@@ -55589,7 +56130,8 @@
       "target": "file:box_agent/tools/skill_loader.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/skill_runtime.py",
@@ -56598,7 +57140,7 @@
       "target": "function:box_agent/tools/safety.py:trusted_runtime_executable_references",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56612,7 +57154,7 @@
       "target": "function:box_agent/tools/safety.py:detect_dangerous_command",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56626,7 +57168,7 @@
       "target": "function:box_agent/tools/safety.py:detect_invalid_runtime_executable_syntax",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56640,7 +57182,7 @@
       "target": "function:box_agent/tools/safety.py:is_safe_scratch_cleanup",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56654,7 +57196,7 @@
       "target": "function:box_agent/tools/safety.py:_expand_scratch_reference",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56668,7 +57210,7 @@
       "target": "function:box_agent/tools/safety.py:_is_real_scratch_descendant",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56682,7 +57224,7 @@
       "target": "function:box_agent/tools/safety.py:_normalized_executable",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56696,7 +57238,7 @@
       "target": "function:box_agent/tools/safety.py:_shell_reference_variable",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56710,7 +57252,7 @@
       "target": "function:box_agent/tools/safety.py:_shell_environment_mutations",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56724,7 +57266,7 @@
       "target": "function:box_agent/tools/safety.py:_dangerous_invocation_reason",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56738,7 +57280,7 @@
       "target": "function:box_agent/tools/safety.py:_extract_path_token",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56752,7 +57294,7 @@
       "target": "function:box_agent/tools/safety.py:_is_path_inside",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56766,7 +57308,7 @@
       "target": "function:box_agent/tools/safety.py:_path_is_safe",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56780,7 +57322,7 @@
       "target": "function:box_agent/tools/safety.py:_command_has_unsafe_paths",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56794,7 +57336,7 @@
       "target": "function:box_agent/tools/safety.py:detect_scope_escape",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56808,7 +57350,7 @@
       "target": "function:box_agent/tools/safety.py:ask_user_confirmation",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56822,7 +57364,7 @@
       "target": "function:box_agent/tools/safety.py:validate_path_in_workspace",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56836,7 +57378,7 @@
       "target": "function:box_agent/tools/safety.py:backup_file",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -56850,7 +57392,7 @@
       "target": "function:box_agent/tools/safety.py:extract_rm_targets",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/safety.py",
@@ -57102,7 +57644,7 @@
       "target": "function:box_agent/tools/skill_loader.py:_warn",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57116,7 +57658,7 @@
       "target": "function:box_agent/tools/skill_loader.py:_tokenize",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57130,7 +57672,7 @@
       "target": "function:box_agent/tools/skill_loader.py:move_skill_slot_to_end",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57144,7 +57686,7 @@
       "target": "function:box_agent/tools/skill_loader.py:_read_disabled_skill_names",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57158,7 +57700,7 @@
       "target": "class:box_agent/tools/skill_loader.py:Skill",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57172,7 +57714,7 @@
       "target": "class:box_agent/tools/skill_loader.py:_SourceEntry",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57186,7 +57728,7 @@
       "target": "class:box_agent/tools/skill_loader.py:SkillLoader",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -57200,7 +57742,7 @@
       "target": "class:box_agent/tools/skill_loader.py:SkillSelector",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/skill_loader.py",
@@ -58253,7 +58795,8 @@
       "target": "file:box_agent/tools/safety.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/tools/image_generation_tool.py",
@@ -58267,22 +58810,23 @@
       "target": "file:box_agent/tools/safety.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/tools/image_inspection_tool.py",
       "target": "file:box_agent/tools/safety.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
       "target": "file:box_agent/auth.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/tools/skill_preload.py",
@@ -58297,8 +58841,7 @@
       "target": "file:box_agent/tools/skill_loader.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/tools/skillhub_install_tool.py",
@@ -58321,24 +58864,21 @@
       "target": "file:box_agent/tools/jupyter_tool.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:scripts/build_runtime.py",
       "target": "file:box_agent/tools/mcp_bootstrap.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:scripts/build_runtime.py",
       "target": "file:box_agent/tools/runtime.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/session_assembly.py",
@@ -58668,7 +59208,7 @@
       "target": "function:box_agent/tools/mcp_tool_catalog.py:_normalize",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58682,7 +59222,7 @@
       "target": "function:box_agent/tools/mcp_tool_catalog.py:_tokenize",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58696,7 +59236,7 @@
       "target": "function:box_agent/tools/mcp_tool_catalog.py:_prefix_term_frequency",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58710,7 +59250,7 @@
       "target": "function:box_agent/tools/mcp_tool_catalog.py:_bm25_term_score",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58724,7 +59264,7 @@
       "target": "function:box_agent/tools/mcp_tool_catalog.py:get_mcp_tool_catalog",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58738,7 +59278,7 @@
       "target": "class:box_agent/tools/mcp_tool_catalog.py:MCPToolEntry",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58752,7 +59292,7 @@
       "target": "class:box_agent/tools/mcp_tool_catalog.py:MCPToolCatalog",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_catalog.py",
@@ -58773,7 +59313,7 @@
       "target": "class:box_agent/tools/mcp_tool_search.py:ActivatedMCPTool",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_search.py",
@@ -58787,7 +59327,7 @@
       "target": "class:box_agent/tools/mcp_tool_search.py:ToolExposure",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_search.py",
@@ -58801,7 +59341,7 @@
       "target": "class:box_agent/tools/mcp_tool_search.py:ToolSearchTool",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_search.py",
@@ -58815,7 +59355,7 @@
       "target": "class:box_agent/tools/mcp_tool_search.py:MCPToolExposureManager",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/tools/mcp_tool_search.py",
@@ -61596,7 +62136,7 @@
       "target": "function:box_agent/agent_runtime.py:build_llm_client",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/agent_runtime.py",
@@ -61610,7 +62150,7 @@
       "target": "function:box_agent/agent_runtime.py:build_agent",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/agent_runtime.py",
@@ -61624,7 +62164,7 @@
       "target": "function:box_agent/agent_runtime.py:build_permission_engine",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/agent_runtime.py",
@@ -61638,7 +62178,7 @@
       "target": "function:box_agent/agent_runtime.py:build_memory_manager",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/agent_runtime.py",
@@ -61652,7 +62192,7 @@
       "target": "function:box_agent/agent_runtime.py:build_memory_extractor",
       "type": "contains",
       "direction": "forward",
-      "weight": 1
+      "weight": 1.0
     },
     {
       "source": "file:box_agent/agent_runtime.py",
@@ -61666,8 +62206,7 @@
       "target": "file:box_agent/agent.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/agent_runtime.py",
@@ -62633,21 +63172,24 @@
       "target": "file:box_agent/agent.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/cli.py",
       "target": "file:box_agent/agent_runtime.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/cli.py",
       "target": "file:box_agent/agent_session.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/cli.py",
@@ -62710,7 +63252,8 @@
       "target": "file:box_agent/session_context.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/cli.py",
@@ -62745,7 +63288,8 @@
       "target": "file:box_agent/tools/mcp_loader.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/cli.py",
@@ -62759,7 +63303,8 @@
       "target": "file:box_agent/tools/setup.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/cli.py",
@@ -70097,14 +70642,16 @@
       "target": "file:box_agent/agent.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/agent_service.py",
       "target": "file:box_agent/agent_runtime.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     },
     {
       "source": "file:box_agent/kernel/__init__.py",
@@ -70166,24 +70713,21 @@
       "target": "file:box_agent/config.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
       "target": "file:box_agent/config.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/tools/mcp_loader.py",
       "target": "file:box_agent/tools/mcp_tool_catalog.py",
       "type": "imports",
       "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
+      "weight": 0.7
     },
     {
       "source": "file:box_agent/tools/skill_preload.py",
@@ -71020,13 +71564,1182 @@
       "type": "documents",
       "direction": "forward",
       "weight": 0.5
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connector_ids_from_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connector_skill_is_available",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connector_skill_is_granted",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connector_status_context",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connector_status_unavailable_from_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/acp/__init__.py:_connector_statuses_from_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:clear_mcp_runtime_credential",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:get_all_mcp_tools",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_config_paths",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_tools_for_server",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:replace_mcp_source",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/acp/__init__.py:BoxACPAgent",
+      "target": "function:box_agent/tools/mcp_loader.py:set_mcp_runtime_credential",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_config_tool.py:McpConfigTool",
+      "target": "class:box_agent/tools/base.py:Tool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "class:box_agent/tools/mcp_loader.py:MCPTool",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "function:box_agent/tools/mcp_loader.py:_is_mcp_authentication_error",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_auth_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_connection_error_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_tool_always_load",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "function:box_agent/tools/mcp_loader.py:_public_mcp_tool_name",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "target": "function:box_agent/tools/mcp_loader.py:_warn",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPTool",
+      "target": "function:box_agent/tools/mcp_loader.py:_structured_mcp_error_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_loader.py:MCPTool",
+      "target": "class:box_agent/tools/base.py:Tool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/tools/mcp_tool_search.py:MCPToolExposureManager",
+      "target": "class:box_agent/tools/mcp_tool_catalog.py:MCPToolCatalog",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_tool_search.py:ToolSearchTool",
+      "target": "class:box_agent/tools/mcp_tool_catalog.py:MCPToolCatalog",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/mcp_tool_search.py:ToolSearchTool",
+      "target": "class:box_agent/tools/base.py:Tool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "target": "class:box_agent/tools/skill_loader.py:Skill",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "target": "class:box_agent/tools/skill_loader.py:_SourceEntry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "target": "function:box_agent/tools/skill_loader.py:_read_disabled_skill_names",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "target": "function:box_agent/tools/skill_loader.py:_tokenize",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "target": "function:box_agent/tools/skill_loader.py:_warn",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/skill_tool.py:GetSkillTool",
+      "target": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/skill_tool.py:GetSkillTool",
+      "target": "class:box_agent/tools/base.py:Tool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/tools/sub_agent_tool.py:SubAgentTool",
+      "target": "class:box_agent/tools/sub_agent_capabilities.py:CapabilityResolver",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/sub_agent_tool.py:SubAgentTool",
+      "target": "function:box_agent/tools/sub_agent_capabilities.py:parse_delegation_spec",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/tools/sub_agent_tool.py:SubAgentTool",
+      "target": "class:box_agent/tools/base.py:EventEmittingTool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/tools/sub_agent_tool.py:_PermissionGatedBashTool",
+      "target": "class:box_agent/tools/base.py:Tool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/tools/sub_agent_tool.py:_WriteScopedTool",
+      "target": "class:box_agent/tools/base.py:Tool",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "document:docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "target": "file:box_agent/acp/__init__.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "target": "file:box_agent/tools/mcp_loader.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "target": "file:box_agent/tools/mcp_sources.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONNECTOR_RUNTIME_RESTORE.md",
+      "target": "file:scripts/build_runtime.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_ids_from_meta",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_skill_is_available",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_skill_is_granted",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_status_context",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_status_unavailable_from_meta",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_statuses_from_meta",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_ids_from_meta",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_skill_is_available",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_skill_is_granted",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_status_context",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_status_unavailable_from_meta",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "function:box_agent/acp/__init__.py:_connector_statuses_from_meta",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/acp/__init__.py",
+      "target": "file:box_agent/tools/mcp_loader.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/session_assembly.py",
+      "target": "file:box_agent/session_context.py",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_materialize_server_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_tool_always_load",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_waiting_for_credential",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:clear_mcp_runtime_credential",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_config_paths",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_connector_server_names",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:replace_mcp_source",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:set_mcp_runtime_credential",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_materialize_server_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_mcp_tool_always_load",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:_waiting_for_credential",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:clear_mcp_runtime_credential",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_config_paths",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_connector_server_names",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:replace_mcp_source",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "function:box_agent/tools/mcp_loader.py:set_mcp_runtime_credential",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_loader.py",
+      "target": "file:box_agent/tools/mcp_sources.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "class:box_agent/tools/mcp_sources.py:McpConfigSource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "class:box_agent/tools/mcp_sources.py:ResolvedMcpServer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "class:box_agent/tools/mcp_sources.py:ResolvedMcpSources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_copy_servers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_fingerprint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_read_servers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_server_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:configured_mcp_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "class:box_agent/tools/mcp_sources.py:McpConfigSource",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "class:box_agent/tools/mcp_sources.py:ResolvedMcpServer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "class:box_agent/tools/mcp_sources.py:ResolvedMcpSources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_copy_servers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_fingerprint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_read_servers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:_server_identity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:configured_mcp_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/tools/mcp_sources.py",
+      "target": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "target": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_connector_server_names",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connector_skill_is_available",
+      "target": "function:box_agent/acp/__init__.py:_connected_connector_ids",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connector_status_context",
+      "target": "function:box_agent/acp/__init__.py:_connector_server_statuses",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/acp/__init__.py:_connector_status_context",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_connector_server_names",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:_workspace_layout_prompt",
+      "target": "function:box_agent/session_assembly.py:_workspace_layout_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:build_acp_session_prompt",
+      "target": "function:box_agent/session_assembly.py:_build_action_hints_prompt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:build_acp_session_prompt",
+      "target": "function:box_agent/session_assembly.py:_filesystem_access_prompt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:build_acp_session_prompt",
+      "target": "function:box_agent/session_assembly.py:_workspace_layout_prompt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:finish_session",
+      "target": "class:box_agent/tools/skill_loader.py:SkillSelector",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:finish_session",
+      "target": "function:box_agent/session_assembly.py:_prepared",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:prepare_hooks",
+      "target": "function:box_agent/session_assembly.py:_prepared",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:prepare_memory",
+      "target": "function:box_agent/session_assembly.py:_prepared",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:prepare_prompt",
+      "target": "function:box_agent/session_assembly.py:_prepared",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:prepare_prompt",
+      "target": "function:box_agent/session_assembly.py:build_acp_session_prompt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:prepare_tools",
+      "target": "class:box_agent/tools/skill_tool.py:GetSkillTool",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:_merge_hosted_search_url",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_is_official_hosted_search_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:_resolve_hosted_search_server",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_normalize_hosted_search_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "class:box_agent/tools/mcp_bootstrap.py:McpBootstrapResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_atomic_write_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_bundled_mcp_servers",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_merge_hosted_search_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_merge_managed_entry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_resolve_hosted_search_server",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_runtime_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_bootstrap.py:bootstrap_managed_mcp_config",
+      "target": "function:box_agent/tools/mcp_bootstrap.py:_web_extract_server",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "target": "class:box_agent/tools/mcp_loader.py:MCPServerConnection",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "target": "function:box_agent/auth.py:request_auth_headers",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "target": "function:box_agent/tools/mcp_loader.py:_determine_connection_type",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "target": "function:box_agent/tools/mcp_loader.py:_dynamic_bearer_auth_for_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "target": "function:box_agent/tools/mcp_loader.py:_materialize_server_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:_record_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:disconnect_mcp_server",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_config_paths",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:reconnect_mcp_server",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:_materialize_server_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_reconnect_mcp_server_locked",
+      "target": "function:box_agent/tools/mcp_loader.py:_waiting_for_credential",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "target": "class:box_agent/tools/mcp_sources.py:McpConfigSource",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "target": "function:box_agent/tools/mcp_loader.py:_warn",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "target": "function:box_agent/tools/mcp_sources.py:configured_mcp_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "target": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
+      "target": "function:box_agent/tools/mcp_loader.py:_build_connection",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
+      "target": "function:box_agent/tools/mcp_loader.py:_materialize_server_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
+      "target": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:load_mcp_tools_async",
+      "target": "function:box_agent/tools/mcp_loader.py:_waiting_for_credential",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "target": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:reconcile_mcp_sources",
+      "target": "function:box_agent/tools/mcp_loader.py:get_mcp_timeout_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:reconnect_mcp_server",
+      "target": "function:box_agent/tools/mcp_loader.py:_resolve_registered_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_loader.py:replace_mcp_source",
+      "target": "function:box_agent/tools/mcp_loader.py:_reconcile_mcp_sources_locked",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:configured_mcp_sources",
+      "target": "class:box_agent/tools/mcp_sources.py:McpConfigSource",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "target": "class:box_agent/tools/mcp_sources.py:ResolvedMcpServer",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "target": "class:box_agent/tools/mcp_sources.py:ResolvedMcpSources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "target": "function:box_agent/tools/mcp_sources.py:_copy_servers",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "target": "function:box_agent/tools/mcp_sources.py:_fingerprint",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "target": "function:box_agent/tools/mcp_sources.py:_read_servers",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/mcp_sources.py:resolve_mcp_sources",
+      "target": "function:box_agent/tools/mcp_sources.py:_server_identity",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/setup.py:add_workspace_tools",
+      "target": "class:box_agent/tools/sub_agent_tool.py:SubAgentTool",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/setup.py:initialize_base_tools",
+      "target": "function:box_agent/tools/skill_tool.py:create_skill_tools",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/tools/skill_tool.py:create_skill_tools",
+      "target": "class:box_agent/tools/skill_loader.py:SkillLoader",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
     }
   ],
   "layers": [
     {
       "id": "layer:core-agent-runtime",
       "name": "核心 Agent 与 Kernel 运行层",
-      "description": "承载共享 AgentSession、会话上下文与能力装配、Agent 运行入口、稳定 Kernel 循环与端口、唯一工具消息提交、SessionLog 及事件契约，使 CLI 与 ACP 在稳定 cwd 下复用配置门控、日志恢复、取消、流恢复和会话生命周期。",
+      "description": "承载共享 AgentSession、会话上下文与能力装配、Agent 运行入口、稳定 Kernel 循环与端口、唯一工具消息提交、SessionLog 及事件契约，使 CLI 与 ACP 在稳定 cwd 下复用配置门控、日志恢复、取消、流恢复和会话生命周期。共享会话装配接入宿主提供的 Skill 访问与识别过滤回调。",
       "nodeIds": [
         "file:box_agent/__init__.py",
         "file:box_agent/agent.py",
@@ -71084,7 +72797,7 @@
     {
       "id": "layer:acp-host-integration",
       "name": "ACP 宿主集成层",
-      "description": "实现 ACP 会话与 stdio 入口、宿主元数据、权限协商、action hint、后续建议及调试日志；通过共享 AgentSession 管理活跃状态，以稳定会话 cwd 承接宿主工作区和产物路径，并保留环境与项目上下文兼容入口。",
+      "description": "实现 ACP 会话与 stdio 入口、宿主元数据、权限协商、action hint、后续建议及调试日志；通过共享 AgentSession 管理活跃状态，以稳定会话 cwd 承接宿主工作区和产物路径，并保留环境与项目上下文兼容入口。承接连接器选择和状态快照、会话 grant 与凭证及来源恢复请求，将来源策略交给 MCP 能力模块。",
       "nodeIds": [
         "file:box_agent/acp/__init__.py",
         "file:box_agent/acp/action_hints.py",
@@ -71125,7 +72838,7 @@
     {
       "id": "layer:tools-sandbox",
       "name": "工具、MCP 与沙箱层",
-      "description": "提供工具、MCP 与沙箱能力，由 tools/engine 借用调用方能力统一冻结定义、权限继续、预算调度和结果适配，统一 cwd 相对路径、有界产物扫描及工具集独立 scratch，并结合文件与 Shell 安全、网页搜索和媒体处理执行实际动作。",
+      "description": "提供工具、MCP 与沙箱能力，由 tools/engine 借用调用方能力统一冻结定义、权限继续、预算调度和结果适配，统一 cwd 相对路径、有界产物扫描及工具集独立 scratch，并结合文件与 Shell 安全、网页搜索和媒体处理执行实际动作。MCP 配置按 system、connector、user 来源隔离；运行时凭证扩展只维护进程内 headers 和版本，来源替换只更新内存快照。宿主注入的过滤器约束连接器能力，未提供过滤器时保持兼容行为。",
       "nodeIds": [
         "file:box_agent/mcp_servers/__init__.py",
         "file:box_agent/mcp_servers/web_extract_server.py",
@@ -71186,7 +72899,8 @@
         "file:box_agent/tools/skill_result_adapter.py",
         "file:box_agent/tools/web_search_policy.py",
         "file:box_agent/tools/web_search_runtime.py",
-        "file:box_agent/tools/engine/__init__.py"
+        "file:box_agent/tools/engine/__init__.py",
+        "file:box_agent/tools/mcp_sources.py"
       ]
     },
     {
@@ -71204,7 +72918,7 @@
     {
       "id": "layer:skills-experts",
       "name": "Skills、插件与委派层",
-      "description": "统一插件描述符、依赖排序和能力注册表，由 PluginRuntime、PluginSession 与内置初始化器管理 process/session/run 资源所有权，并负责 Skills 发现安装、专家配置和受能力、cwd 相对写入范围及预算约束的委派。 失败 Run 激活的中断回滚归属于相应会话，关闭时先重试 Run 再释放 Session 依赖，并阻止未完成清理的会话再次激活。",
+      "description": "统一插件描述符、依赖排序和能力注册表，由 PluginRuntime、PluginSession 与内置初始化器管理 process/session/run 资源所有权，并负责 Skills 发现安装、专家配置和受能力、cwd 相对写入范围及预算约束的委派。 失败 Run 激活的中断回滚归属于相应会话，关闭时先重试 Run 再释放 Session 依赖，并阻止未完成清理的会话再次激活。宿主可注入独立的 Skill 识别与访问过滤器，连接器 Skill 的会话授权和子 Agent 授权快照在能力入口生效。",
       "nodeIds": [
         "file:.gitmodules",
         "file:box_agent/experts.py",
@@ -71436,7 +73150,8 @@
         "document:docs/design/tool-refactor/runtime.md",
         "document:docs/design/tool-refactor/testing.md",
         "document:docs/design/tool-refactor/verification.md",
-        "document:docs/reasoning-configuration.md"
+        "document:docs/reasoning-configuration.md",
+        "document:docs/CONNECTOR_RUNTIME_RESTORE.md"
       ]
     },
     {
@@ -71543,7 +73258,7 @@
     {
       "order": 4,
       "title": "共享运行入口",
-      "description": "两个宿主通过 AgentSession.open 进入受管会话，原有同步 create 与 AgentService 构造入口继续兼容。SessionContext 显式区分配置、选项、宿主借用能力与本轮输入，session_assembly 按插件顺序准备模型、记忆、工具、提示和 Hook，并统一 utility 配置门控、cwd 提示和会话恢复。AgentSession 为每轮绑定 KernelServices，经 Agent 与 composition 驱动稳定循环，退出时依次释放 run、session 和自身拥有的 runtime。",
+      "description": "两个宿主通过 AgentSession.open 进入受管会话，原有同步 create 与 AgentService 构造入口继续兼容。SessionContext 显式区分配置、选项、宿主借用能力与本轮输入，session_assembly 按插件顺序准备模型、记忆、工具、提示和 Hook，接入宿主的 Skill 访问与识别过滤回调，并统一 utility 配置门控、cwd 提示和会话恢复。AgentSession 为每轮绑定 KernelServices，经 Agent 与 composition 驱动稳定循环，退出时依次释放 run、session 和自身拥有的 runtime。",
       "nodeIds": [
         "file:box_agent/agent_session.py",
         "file:box_agent/session_context.py",
@@ -71604,7 +73319,7 @@
     {
       "order": 9,
       "title": "MCP 动态能力",
-      "description": "MCP 启动配置先声明托管服务，loader 再处理连接、认证、工具包装和重连。工具目录与按需搜索限制每轮暴露给模型的能力集合，而网页抽取服务把 SSRF 防护和重定向校验放在外部内容进入模型之前。",
+      "description": "MCP 配置按 system、connector、user 来源隔离，mcp_sources 统一服务身份与指纹，loader 负责连接和认证恢复。运行时凭证扩展只保存进程内 headers 与版本；ACP 进程重建后，宿主必须先恢复凭证，再发布连接器来源快照。重连时只推进被选中服务的指纹，失败状态允许同配置重试；工具目录和按需搜索在宿主提供过滤器时按当前会话授权限制可调用能力。网页抽取服务继续在外部内容入模前执行 SSRF 与重定向校验。",
       "nodeIds": [
         "file:box_agent/tools/mcp_bootstrap.py",
         "file:box_agent/tools/mcp_loader.py",
@@ -71639,7 +73354,7 @@
     {
       "order": 12,
       "title": "Skills 与委派",
-      "description": "SkillLoader 发现并筛选多来源技能，SkillHub 工具把检索与经授权安装拆成明确步骤。专家配置与子 Agent 工具共同描述角色、能力、写入范围和预算，让并行委派仍受父 Agent 的契约与验收边界控制。文件写入范围相对会话 cwd 声明，平行子任务仍需使用互不重叠的范围。",
+      "description": "SkillLoader 发现并筛选多来源技能，SkillHub 工具把检索与经授权安装拆成明确步骤。专家配置与子 Agent 工具共同描述角色、能力、写入范围和预算，让并行委派仍受父 Agent 的契约与验收边界控制。文件写入范围相对会话 cwd 声明，平行子任务仍需使用互不重叠的范围。连接器 Skill 经宿主识别与访问回调过滤，子 Agent 继续使用受父会话约束的连接器授权快照。",
       "nodeIds": [
         "file:box_agent/tools/skill_loader.py",
         "file:box_agent/tools/skillhub_search_tool.py",

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-09-10T16:51:22.244Z",
-  "gitCommitHash": "affe4e2b57c0de58db749543333eae4b2e27aab1",
+  "lastAnalyzedAt": "2026-09-10T17:29:11.102Z",
+  "gitCommitHash": "9f1bb264f5b9356a5b9f4b5c49026612301cc03d",
   "version": "1.0.0",
   "analyzedFiles": 410
 }

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-09-10T17:29:11.102Z",
-  "gitCommitHash": "9f1bb264f5b9356a5b9f4b5c49026612301cc03d",
+  "lastAnalyzedAt": "2026-09-10T18:06:25.517Z",
+  "gitCommitHash": "be3c151a0d056623795b6c799a298919e6ed6ae0",
   "version": "1.0.0",
   "analyzedFiles": 410
 }

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-09-10T16:13:23.313Z",
-  "gitCommitHash": "ea99fc5ae17f19f2dd752b2264cd3134a36c07ae",
+  "lastAnalyzedAt": "2026-09-10T16:51:22.244Z",
+  "gitCommitHash": "affe4e2b57c0de58db749543333eae4b2e27aab1",
   "version": "1.0.0",
-  "analyzedFiles": 408
+  "analyzedFiles": 410
 }

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -3320,7 +3320,11 @@ class BoxACPAgent:
                 config = params.get("config")
                 if not isinstance(source, str) or not isinstance(config, dict):
                     return {"success": False, "error": "source and config are required"}
-                result = await replace_mcp_source(source, config)
+                connector_ids = params.get("connectorIds")
+                if connector_ids is not None:
+                    result = await replace_mcp_source(source, config, connector_ids)
+                else:
+                    result = await replace_mcp_source(source, config)
             else:
                 result = await reconcile_mcp_sources(source)
             if not self._config.tools.mcp.deferred_loading_enabled:

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1201,6 +1201,7 @@ class BoxACPAgent:
             session_registries=lambda: (
                 (state.agent.tools, state.mcp_fallback_tools)
                 for state in self._sessions.values()
+                if not state.utility_session
             ),
         )
         self._mcp_task = mcp_task  # background MCP discovery; awaited on first prompt
@@ -3332,18 +3333,7 @@ class BoxACPAgent:
             else:
                 result = await reconcile_mcp_sources(source)
             if not self._config.tools.mcp.deferred_loading_enabled:
-                all_mcp_tools = get_all_mcp_tools()
-                sync_mcp_tool_list(
-                    self._base_tools,
-                    all_mcp_tools,
-                    self._base_mcp_fallback_tools,
-                )
-                for session_state in self._sessions.values():
-                    sync_mcp_tools(
-                        session_state.agent.tools,
-                        all_mcp_tools,
-                        session_state.mcp_fallback_tools,
-                    )
+                self._sync_mcp_registries(get_all_mcp_tools())
             injected = 0
             for item in result.get("results", []):
                 name = item.get("name", "")

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -954,6 +954,7 @@ class SessionState(AgentSession):
     selected_connector_ids: set[str] = field(default_factory=set)
     connector_statuses: tuple[tuple[str, str, str], ...] | None = None
     connector_status_unavailable: bool = False
+    utility_session: bool = False
     expert_context: ExpertSessionContext | None = None
     upstream_session_id: str = ""
     current_task_id: str = ""
@@ -2048,6 +2049,7 @@ class BoxACPAgent:
                 selected_connector_ids=selected_connector_ids,
                 connector_statuses=connector_statuses,
                 connector_status_unavailable=connector_status_unavailable,
+                utility_session=utility,
                 session_llm=session_llm,
                 summary_llm=summary_llm,
                 session_mode=session_mode,
@@ -2360,22 +2362,23 @@ class BoxACPAgent:
         )
         _bind_user_source_text(state, source_binding_text)
         prompt_meta = getattr(params, "field_meta", None) or {}
-        selected_connector_ids = _connector_ids_from_meta(prompt_meta)
-        if selected_connector_ids is not None:
-            state.selected_connector_ids.clear()
-            state.selected_connector_ids.update(selected_connector_ids)
-        connector_statuses = _connector_statuses_from_meta(prompt_meta)
-        if connector_statuses is not None:
-            state.connector_statuses = connector_statuses
-            state.connector_status_unavailable = False
-        else:
-            connector_status_unavailable = _connector_status_unavailable_from_meta(
-                prompt_meta
-            )
-            if connector_status_unavailable is not None:
-                state.connector_status_unavailable = connector_status_unavailable
-                if connector_status_unavailable:
-                    state.connector_statuses = None
+        if not state.utility_session:
+            selected_connector_ids = _connector_ids_from_meta(prompt_meta)
+            if selected_connector_ids is not None:
+                state.selected_connector_ids.clear()
+                state.selected_connector_ids.update(selected_connector_ids)
+            connector_statuses = _connector_statuses_from_meta(prompt_meta)
+            if connector_statuses is not None:
+                state.connector_statuses = connector_statuses
+                state.connector_status_unavailable = False
+            else:
+                connector_status_unavailable = _connector_status_unavailable_from_meta(
+                    prompt_meta
+                )
+                if connector_status_unavailable is not None:
+                    state.connector_status_unavailable = connector_status_unavailable
+                    if connector_status_unavailable:
+                        state.connector_statuses = None
         user_decision_response = _user_decision_response_from_meta(prompt_meta)
         if user_decision_response is not None:
             user_text = (
@@ -2395,12 +2398,13 @@ class BoxACPAgent:
                 "explicitly requests another language.]\n\n"
                 f"{user_text}"
             )
-        connector_status = _connector_status_context(
-            state.selected_connector_ids,
-            state.connector_statuses,
-            state.connector_status_unavailable,
-        )
-        user_text = f"{user_text.rstrip()}\n\n{connector_status}"
+        if not state.utility_session:
+            connector_status = _connector_status_context(
+                state.selected_connector_ids,
+                state.connector_statuses,
+                state.connector_status_unavailable,
+            )
+            user_text = f"{user_text.rstrip()}\n\n{connector_status}"
         requested_llm_binding = _normalize_llm_binding(prompt_meta)
         if requested_llm_binding is not None and requested_llm_binding != state.llm_binding:
             if state.turn_active:

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -30,6 +30,7 @@ import asyncio
 import json as _json
 import logging
 import platform
+import re
 import signal
 import sys
 from contextlib import AsyncExitStack, aclosing
@@ -211,6 +212,7 @@ from box_agent.retry import RetryConfig as RetryConfigBase
 from box_agent.retry import StreamInterrupted
 from box_agent.schema import LLMProvider, Message
 from box_agent.tools.permissions import CapabilityPolicy, GrantStore, PermissionEngine
+from box_agent.tools.mcp_loader import get_mcp_connector_server_names, get_mcp_status
 from box_agent.tools.runtime import (
     SkillRuntimeContext,
     build_skill_runtime_context,
@@ -948,6 +950,10 @@ class SessionState(AgentSession):
     session_mode: str | None = None
     llm_binding: dict[str, Any] | None = None
     seen_injection_ids: set[str] = field(default_factory=set)
+    connector_skill_grants: set[str] = field(default_factory=set)
+    selected_connector_ids: set[str] = field(default_factory=set)
+    connector_statuses: tuple[tuple[str, str, str], ...] | None = None
+    connector_status_unavailable: bool = False
     expert_context: ExpertSessionContext | None = None
     upstream_session_id: str = ""
     current_task_id: str = ""
@@ -968,6 +974,183 @@ class SessionState(AgentSession):
 
 _CONTEXT_SUMMARY_MAX_OUTPUT_TOKENS = 4_096
 _TITLE_MAX_OUTPUT_TOKENS = 8_000
+_CONNECTOR_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_CONNECTOR_STATUS_VALUES = frozenset({"connected", "disconnected"})
+_MAX_CONNECTOR_STATUSES = 256
+
+
+def _connector_ids_from_meta(meta: Any) -> set[str] | None:
+    """Read the host's per-conversation connector selection without guessing IDs."""
+    if not isinstance(meta, dict):
+        return None
+    marker = meta.get("selected_connector_ids", meta.get("selectedConnectorIds"))
+    if marker is None:
+        return None
+    if not isinstance(marker, list):
+        raise ValueError("selected_connector_ids must be an array")
+    selected: set[str] = set()
+    for raw in marker:
+        if not isinstance(raw, str):
+            raise ValueError("selected_connector_ids must contain strings")
+        connector_id = raw.strip().lower()
+        if not _CONNECTOR_ID_PATTERN.fullmatch(connector_id):
+            raise ValueError("selected_connector_ids contains an invalid connector id")
+        selected.add(connector_id)
+    return selected
+
+
+def _connector_statuses_from_meta(
+    meta: Any,
+) -> tuple[tuple[str, str, str], ...] | None:
+    """Read the host's complete connector catalog snapshot for one turn."""
+    if not isinstance(meta, dict):
+        return None
+    marker = meta.get("connector_statuses", meta.get("connectorStatuses"))
+    if marker is None:
+        return None
+    if not isinstance(marker, list):
+        raise ValueError("connector_statuses must be an array")
+    if len(marker) > _MAX_CONNECTOR_STATUSES:
+        raise ValueError("connector_statuses contains too many entries")
+
+    statuses: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    for raw in marker:
+        if not isinstance(raw, dict):
+            raise ValueError("connector_statuses entries must be objects")
+        raw_id = raw.get("id")
+        raw_name = raw.get("name")
+        raw_status = raw.get("status")
+        if not isinstance(raw_id, str):
+            raise ValueError("connector_statuses id must be a string")
+        connector_id = raw_id.strip().lower()
+        if not _CONNECTOR_ID_PATTERN.fullmatch(connector_id):
+            raise ValueError("connector_statuses contains an invalid connector id")
+        if connector_id in seen:
+            raise ValueError("connector_statuses contains a duplicate connector id")
+        if (
+            not isinstance(raw_name, str)
+            or not raw_name.strip()
+            or len(raw_name.strip()) > 128
+            or any(character in raw_name for character in "\r\n")
+        ):
+            raise ValueError("connector_statuses contains an invalid connector name")
+        if not isinstance(raw_status, str) or raw_status not in _CONNECTOR_STATUS_VALUES:
+            raise ValueError("connector_statuses contains an invalid status")
+        seen.add(connector_id)
+        statuses.append((connector_id, raw_name.strip(), raw_status))
+    return tuple(statuses)
+
+
+def _connector_status_unavailable_from_meta(meta: Any) -> bool | None:
+    """Read the host signal that the connector snapshot could not be refreshed."""
+    if not isinstance(meta, dict):
+        return None
+    marker = meta.get(
+        "connector_status_unavailable", meta.get("connectorStatusUnavailable")
+    )
+    if marker is None:
+        return None
+    if not isinstance(marker, bool):
+        raise ValueError("connector_status_unavailable must be a boolean")
+    return marker
+
+
+def _connector_server_statuses() -> dict[str, list[tuple[str, str, str]]]:
+    """Return the current connector runtime state keyed by canonical connector ID."""
+    statuses_by_connector: dict[str, list[tuple[str, str, str]]] = {}
+    for status in get_mcp_status():
+        if status.get("owner") != "connector":
+            continue
+        connector_id = status.get("connectorId")
+        if isinstance(connector_id, str) and connector_id:
+            connector_name = status.get("connectorName")
+            statuses_by_connector.setdefault(connector_id, []).append(
+                (
+                    str(status.get("name") or connector_id),
+                    connector_name.strip()
+                    if isinstance(connector_name, str) and connector_name.strip()
+                    else connector_id,
+                    str(status.get("state") or "disconnected"),
+                )
+            )
+    return statuses_by_connector
+
+
+def _connected_connector_ids(selected_connector_ids: set[str]) -> frozenset[str]:
+    statuses_by_connector = _connector_server_statuses()
+    expected_by_connector = get_mcp_connector_server_names()
+    return frozenset(
+        connector_id
+        for connector_id in selected_connector_ids
+        if (expected := expected_by_connector.get(connector_id))
+        and (statuses := statuses_by_connector.get(connector_id))
+        and expected == {server_name for server_name, _, _ in statuses}
+        and all(state == "connected" for _, _, state in statuses)
+    )
+
+
+def _connector_skill_is_available(skill: Any, selected_connector_ids: set[str]) -> bool:
+    """Gate new connector-Skill recognition without removing already loaded guidance."""
+    if getattr(skill, "source", None) != "connector":
+        return True
+    return getattr(skill, "owner_id", None) in _connected_connector_ids(
+        selected_connector_ids
+    )
+
+
+def _connector_skill_is_granted(skill: Any, connector_skill_grants: set[str]) -> bool:
+    """Allow connector Skills only after this conversation's internal selector grants them."""
+    return getattr(skill, "source", None) != "connector" or getattr(
+        skill, "name", None
+    ) in connector_skill_grants
+
+
+def _connector_status_context(
+    selected_connector_ids: set[str],
+    connector_statuses: tuple[tuple[str, str, str], ...] | None = None,
+    connector_status_unavailable: bool = False,
+) -> str:
+    """Render connector-level state; individual MCP server health stays internal."""
+    if connector_status_unavailable:
+        return (
+            "<connector-status>\n"
+            "status: unavailable\n"
+            "连接器状态读取失败，请勿沿用之前轮次的连接状态。\n"
+            "</connector-status>"
+        )
+    if connector_statuses is not None:
+        lines = ["<connector-status>"]
+        lines.extend(
+            f"{connector_id} {connector_name}: {status}"
+            for connector_id, connector_name, status in connector_statuses
+        )
+        lines.append("</connector-status>")
+        return "\n".join(lines)
+
+    statuses_by_connector = _connector_server_statuses()
+    expected_by_connector = get_mcp_connector_server_names()
+
+    lines = ["<connector-status>"]
+    for connector_id in sorted(selected_connector_ids):
+        statuses = statuses_by_connector.get(connector_id, [])
+        if not statuses:
+            lines.append(f"{connector_id}: disconnected")
+            continue
+        connector_name = sorted(statuses)[0][1]
+        expected = expected_by_connector.get(connector_id, frozenset())
+        overall_state = (
+            "connected"
+            if expected
+            and expected == {server_name for server_name, _, _ in statuses}
+            and all(state == "connected" for _, _, state in statuses)
+            else "disconnected"
+        )
+        lines.append(f"{connector_id} {connector_name}: {overall_state}")
+    if len(lines) == 1:
+        lines.append("none: selected")
+    lines.append("</connector-status>")
+    return "\n".join(lines)
 
 
 def _bind_user_source_text(state: SessionState, user_request: str) -> None:
@@ -1417,7 +1600,7 @@ class BoxACPAgent:
             return None
         try:
             self._skill_loader.maybe_reload()
-            return self._skill_loader.list_skills_metadata()
+            return self._skill_loader.list_skills_metadata(include_connector=False)
         except Exception as exc:
             log.warn("skills/meta_error", message=f"Failed to build skills metadata: {exc}")
             return None
@@ -1545,6 +1728,12 @@ class BoxACPAgent:
                 _meta_string(meta, "title", "session_title", "sessionTitle")
                 or _DEFAULT_AGENT_TITLE
             )
+        selected_connector_ids = _connector_ids_from_meta(meta) or set()
+        connector_statuses = _connector_statuses_from_meta(meta)
+        connector_status_unavailable = (
+            _connector_status_unavailable_from_meta(meta) is True
+            and connector_statuses is None
+        )
 
         try:
             workspace_profile = WorkspaceRegistry().get(workspace)
@@ -1729,6 +1918,7 @@ class BoxACPAgent:
         # RPC tools are host bindings; session tools and prompt are prepared by plugins.
         tools: list = []
         session_skill_loader = self._skill_loader
+        connector_skill_grants: set[str] = set()
         skillhub_search_tool: SkillHubSearchTool | None = None
         if skillhub_search_enabled and not utility:
 
@@ -1836,6 +2026,12 @@ class BoxACPAgent:
                     skill_task=self._skill_task, session_log=session_log,
                     workspace_tools_factory=add_workspace_tools,
                     capability_state_provider=self._sub_agent_capability_state,
+                    skill_access_filter=lambda skill: _connector_skill_is_granted(
+                        skill, connector_skill_grants
+                    ),
+                    skill_catalog_filter=lambda skill: _connector_skill_is_available(
+                        skill, selected_connector_ids
+                    ),
                     extra_tools=tools,
                     prompt_suffix="\n\n".join(part for part in (
                         HARD_CAPABILITY_GAP_PROMPT if skillhub_search_tool else None,
@@ -1845,6 +2041,13 @@ class BoxACPAgent:
                     diagnostics=emit_diagnostic,
                 ),
                 agent_factory=Agent,
+                allowed_connector_ids_provider=lambda: _connected_connector_ids(
+                    selected_connector_ids
+                ),
+                connector_skill_grants=connector_skill_grants,
+                selected_connector_ids=selected_connector_ids,
+                connector_statuses=connector_statuses,
+                connector_status_unavailable=connector_status_unavailable,
                 session_llm=session_llm,
                 summary_llm=summary_llm,
                 session_mode=session_mode,
@@ -1937,7 +2140,7 @@ class BoxACPAgent:
                 SKILLHUB_INSTALL_CAPABILITY_VERSION
             ]
         skills = (
-            session_skill_loader.list_skills_metadata()
+            session_skill_loader.list_skills_metadata(include_connector=False)
             if session_skill_loader is not None
             else self._skills_meta()
         )
@@ -2157,6 +2360,22 @@ class BoxACPAgent:
         )
         _bind_user_source_text(state, source_binding_text)
         prompt_meta = getattr(params, "field_meta", None) or {}
+        selected_connector_ids = _connector_ids_from_meta(prompt_meta)
+        if selected_connector_ids is not None:
+            state.selected_connector_ids.clear()
+            state.selected_connector_ids.update(selected_connector_ids)
+        connector_statuses = _connector_statuses_from_meta(prompt_meta)
+        if connector_statuses is not None:
+            state.connector_statuses = connector_statuses
+            state.connector_status_unavailable = False
+        else:
+            connector_status_unavailable = _connector_status_unavailable_from_meta(
+                prompt_meta
+            )
+            if connector_status_unavailable is not None:
+                state.connector_status_unavailable = connector_status_unavailable
+                if connector_status_unavailable:
+                    state.connector_statuses = None
         user_decision_response = _user_decision_response_from_meta(prompt_meta)
         if user_decision_response is not None:
             user_text = (
@@ -2176,6 +2395,12 @@ class BoxACPAgent:
                 "explicitly requests another language.]\n\n"
                 f"{user_text}"
             )
+        connector_status = _connector_status_context(
+            state.selected_connector_ids,
+            state.connector_statuses,
+            state.connector_status_unavailable,
+        )
+        user_text = f"{user_text.rstrip()}\n\n{connector_status}"
         requested_llm_binding = _normalize_llm_binding(prompt_meta)
         if requested_llm_binding is not None and requested_llm_binding != state.llm_binding:
             if state.turn_active:
@@ -2452,10 +2677,22 @@ class BoxACPAgent:
             if state.skill_selector is not None
             else ()
         )
+        if state.skill_loader is not None:
+            for skill_name in matched_skill_names:
+                skill = state.skill_loader.get_skill(skill_name)
+                if skill is not None and _connector_skill_is_available(
+                    skill, state.selected_connector_ids
+                ):
+                    state.connector_skill_grants.add(skill.name)
         explicit_skill = resolve_explicit_skill_invocation(
             state.skill_loader,
             plan_detection_text,
         )
+        if (
+            explicit_skill is not None
+            and getattr(explicit_skill, "source", None) == "connector"
+        ):
+            explicit_skill = None
         requested_host_skills = (
             _meta_string_list(prompt_meta, "selected_skill_names", limit=8)
             or _meta_string_list(prompt_meta, "selectedSkillNames", limit=8)
@@ -2464,7 +2701,8 @@ class BoxACPAgent:
             name
             for name in requested_host_skills
             if state.skill_loader is not None
-            and state.skill_loader.get_skill(name) is not None
+            and (skill := state.skill_loader.get_skill(name)) is not None
+            and getattr(skill, "source", None) != "connector"
         )
         explicitly_selected_skill_names = tuple(
             dict.fromkeys(
@@ -3033,11 +3271,100 @@ class BoxACPAgent:
             except WorkspaceRegistryError as exc:
                 return {"error": str(exc)}
         if method == "mcp/status":
-            from box_agent.tools.mcp_loader import get_mcp_status, is_mcp_loading, get_mcp_config_path
+            from box_agent.tools.mcp_loader import (
+                get_mcp_config_path,
+                get_mcp_config_paths,
+                get_mcp_status,
+                is_mcp_loading,
+            )
             servers = get_mcp_status()
             loading = is_mcp_loading()
             log.info("mcp/status", count=len(servers), loading=loading)
-            return {"servers": servers, "loading": loading, "configPath": get_mcp_config_path()}
+            return {
+                "servers": servers,
+                "loading": loading,
+                "configPath": get_mcp_config_path(),
+                "configPaths": get_mcp_config_paths(),
+            }
+        if method == "mcp/credential/set":
+            credential_ref = params.get("credentialRef", "")
+            headers = params.get("headers", {})
+            if not isinstance(credential_ref, str) or not isinstance(headers, dict):
+                return {"success": False, "error": "credentialRef and headers are required"}
+            from box_agent.tools.mcp_loader import set_mcp_runtime_credential
+            try:
+                affected = set_mcp_runtime_credential(credential_ref, headers)
+            except ValueError as error:
+                return {"success": False, "error": str(error)}
+            log.info("mcp/credential/set", affected_servers=len(affected))
+            return {"success": True, "affectedServers": affected}
+        if method == "mcp/credential/clear":
+            credential_ref = params.get("credentialRef", "")
+            if not isinstance(credential_ref, str) or not credential_ref.strip():
+                return {"success": False, "error": "credentialRef is required"}
+            from box_agent.tools.mcp_loader import clear_mcp_runtime_credential
+            affected = clear_mcp_runtime_credential(credential_ref)
+            log.info("mcp/credential/clear", affected_servers=len(affected))
+            return {"success": True, "affectedServers": affected}
+        if method in {"mcp/reconcile", "mcp/source/replace"}:
+            source = params.get("source")
+            if source is not None and not isinstance(source, str):
+                return {"success": False, "error": "source must be a string"}
+            from box_agent.tools.mcp_loader import (
+                get_all_mcp_tools,
+                get_mcp_tools_for_server,
+                reconcile_mcp_sources,
+                replace_mcp_source,
+            )
+            if method == "mcp/source/replace":
+                config = params.get("config")
+                if not isinstance(source, str) or not isinstance(config, dict):
+                    return {"success": False, "error": "source and config are required"}
+                result = await replace_mcp_source(source, config)
+            else:
+                result = await reconcile_mcp_sources(source)
+            if not self._config.tools.mcp.deferred_loading_enabled:
+                all_mcp_tools = get_all_mcp_tools()
+                sync_mcp_tool_list(
+                    self._base_tools,
+                    all_mcp_tools,
+                    self._base_mcp_fallback_tools,
+                )
+                for session_state in self._sessions.values():
+                    sync_mcp_tools(
+                        session_state.agent.tools,
+                        all_mcp_tools,
+                        session_state.mcp_fallback_tools,
+                    )
+            injected = 0
+            for item in result.get("results", []):
+                name = item.get("name", "")
+                if not name:
+                    continue
+                tools = get_mcp_tools_for_server(name)
+                action = item.get("action")
+                if action in {"removed", "disabled"}:
+                    state = "disconnected"
+                elif item.get("success"):
+                    state = "connected"
+                else:
+                    state = "failed"
+                injected += self._inject_mcp_runtime_update(
+                    name=name,
+                    state=state,
+                    tool_count=len(tools),
+                    always_load_count=sum(
+                        bool(getattr(tool, "mcp_always_load", False)) for tool in tools
+                    ),
+                )
+            log.info(
+                method,
+                source=source,
+                success=result.get("success"),
+                changed=len(result.get("results", [])),
+                context_injected_sessions=injected,
+            )
+            return result
         if method == "mcp/reconnect":
             name = params.get("name", "")
             if not name:

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -1060,11 +1060,15 @@ def _connector_status_unavailable_from_meta(meta: Any) -> bool | None:
 def _connector_server_statuses() -> dict[str, list[tuple[str, str, str]]]:
     """Return the current connector runtime state keyed by canonical connector ID."""
     statuses_by_connector: dict[str, list[tuple[str, str, str]]] = {}
+    expected_by_connector = get_mcp_connector_server_names()
     for status in get_mcp_status():
         if status.get("owner") != "connector":
             continue
         connector_id = status.get("connectorId")
         if isinstance(connector_id, str) and connector_id:
+            server_name = str(status.get("name") or connector_id)
+            if server_name not in expected_by_connector.get(connector_id, ()):
+                continue
             connector_name = status.get("connectorName")
             statuses_by_connector.setdefault(connector_id, []).append(
                 (

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -3439,7 +3439,7 @@ class BoxACPAgent:
         injected = 0
         update_id = uuid4().hex
         for session_id, session in self._sessions.items():
-            if not session.turn_active:
+            if session.utility_session or not session.turn_active:
                 continue
             if state == "ready":
                 visibility = (

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -457,6 +457,7 @@ class Agent:
         max_truncated_tool_call_retries: int = 3,
         truncated_tool_call_boost_cap: int = 32768,
         context_resource_dedup_enabled: bool = True,
+        allowed_connector_ids_provider: Callable[[], frozenset[str]] | None = None,
         tool_limits: ToolLimitsConfig | None = None,
         deferred_mcp_loading_enabled: bool = True,
         session_log: SessionLog | None = None,
@@ -498,6 +499,7 @@ class Agent:
                 activated_local_tools=self.activated_local_tools,
                 deferred_local_names_provider=self.local_tool_exposure.deferred_names,
                 deferred_mcp=deferred_mcp_loading_enabled,
+                allowed_connector_ids_provider=allowed_connector_ids_provider,
             )
             self.tools["tool_search"] = ToolSearchTool(
                 catalog,
@@ -510,6 +512,7 @@ class Agent:
                 ),
                 local_tools_provider=self.local_tool_exposure.candidate_tools,
                 activated_local_tools=self.activated_local_tools,
+                allowed_connector_ids_provider=allowed_connector_ids_provider,
             )
         self.tool_result_storage = ToolResultStorage(
             state_path('sessions')
@@ -559,7 +562,10 @@ class Agent:
                 "configuration; do not claim the server is connected until an internal "
                 "MCP runtime update confirms registration. If that confirmation arrives "
                 "during the turn, use `tool_search` to discover the newly registered "
-                "capability instead of expecting all schemas to appear at once."
+                "capability instead of expecting all schemas to appear at once. "
+                "The latest <connector-status> in each user message is authoritative: "
+                "only its connected entries may be searched or called. If an entry is "
+                "disabled or disappears, do not call a previously activated tool from it."
             )
 
         self.system_prompt = system_prompt

--- a/box_agent/agent_runtime.py
+++ b/box_agent/agent_runtime.py
@@ -92,6 +92,7 @@ def build_agent(
     max_truncated_tool_call_retries: int = 3,
     truncated_tool_call_boost_cap: int = 32768,
     context_resource_dedup_enabled: bool = True,
+    allowed_connector_ids_provider: Callable[[], frozenset[str]] | None = None,
     deferred_mcp_loading_enabled: bool = True,
     session_log: Any = _UNSET,
     enable_builtin_tools: bool | object = _UNSET,
@@ -125,6 +126,7 @@ def build_agent(
         "max_truncated_tool_call_retries": max_truncated_tool_call_retries,
         "truncated_tool_call_boost_cap": truncated_tool_call_boost_cap,
         "context_resource_dedup_enabled": context_resource_dedup_enabled,
+        "allowed_connector_ids_provider": allowed_connector_ids_provider,
         "deferred_mcp_loading_enabled": deferred_mcp_loading_enabled,
     }
     if hooks is not _UNSET:

--- a/box_agent/agent_session.py
+++ b/box_agent/agent_session.py
@@ -110,6 +110,7 @@ class AgentSession:
         hooks: list[Any] | None = None,
         session_log: SessionLog | None = None,
         utility: bool = False,
+        allowed_connector_ids_provider: Callable[[], frozenset[str]] | None = None,
         agent_factory: AgentFactory = Agent,
         **state: Any,
     ) -> AgentSession:
@@ -145,6 +146,7 @@ class AgentSession:
             max_truncated_tool_call_retries=settings.max_truncated_tool_call_retries,
             truncated_tool_call_boost_cap=settings.truncated_tool_call_boost_cap,
             context_resource_dedup_enabled=settings.context_resource_dedup_enabled,
+            allowed_connector_ids_provider=allowed_connector_ids_provider,
             deferred_mcp_loading_enabled=(
                 not utility
                 and config.tools.enable_mcp

--- a/box_agent/session_assembly.py
+++ b/box_agent/session_assembly.py
@@ -7,6 +7,7 @@ run outside the Host activation lock, within the runtime initialization lease.
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -187,6 +188,7 @@ async def prepare_tools(resources: SessionResources) -> None:
             GetSkillTool(
                 resources.skill_loader, preloaded_skill_hashes=hashes,
                 include_disabled=expert is not None,
+                skill_access_filter=host.skill_access_filter,
                 blocked_skill_names=(FAST_OPTIONAL_SKILLS if resources.state.get("execution_profile") == "fast" else frozenset()),
                 explicitly_allowed_skill_names=resources.state.setdefault("explicitly_allowed_skill_names", set()),
             )
@@ -200,6 +202,7 @@ async def prepare_tools(resources: SessionResources) -> None:
         non_interactive=options.non_interactive, output=host.output,
         llm=resources.llm_client, permission_engine=permission_engine,
         skill_runtime_context=runtime_context, skill_loader=resources.skill_loader,
+        skill_access_filter=host.skill_access_filter,
         env_context=resources.state.get("env_context"),
         capability_state_provider=host.capability_state_provider or (lambda: (
             "loading" if resources.mcp_task is not None and not resources.mcp_task.done()
@@ -349,6 +352,9 @@ async def finish_session(session: Any, resources: SessionResources) -> None:
             )
             if skill is None:
                 continue
+            grants = resources.state.get("connector_skill_grants")
+            if grants is not None and getattr(skill, "source", None) == "connector":
+                grants.add(skill.name)
             restored_skill_prompts.append(
                 (name, skill.to_prompt(), prompt_hash, load_order)
             )
@@ -362,6 +368,7 @@ async def finish_session(session: Any, resources: SessionResources) -> None:
         selector = SkillSelector(
             session_skill_loader,
             include_disabled=expert_context is not None,
+            skill_filter=resources.context.host.skill_catalog_filter,
         )
         selector.bind(agent.messages[0].content)
         if expert_context:
@@ -488,7 +495,12 @@ def _build_action_hints_prompt(config, memory, env_context: EnvContext | None = 
     memory_scarce = is_memory_scarce(memory.read_core() if memory else None)
 
     try:
-        _user_mcp = state_path('config/mcp.json')
+        _host_mcp = os.environ.get("BOX_AGENT_MCP_CONFIG_PATH", "").strip()
+        _user_mcp = (
+            state_path("config/mcp.json", Path(_host_mcp).expanduser())
+            if _host_mcp
+            else state_path("config/mcp.json")
+        )
         mcp_path = _user_mcp if _user_mcp.exists() else Config.find_config_file(config.tools.mcp_config_path)
     except Exception:
         mcp_path = None

--- a/box_agent/session_context.py
+++ b/box_agent/session_context.py
@@ -59,6 +59,8 @@ class HostBindings:
     base_tools_factory: Callable[..., Any] | None = None
     workspace_tools_factory: Callable[..., Any] | None = None
     capability_state_provider: Callable[[], str] | None = None
+    skill_access_filter: Callable[[Any], bool] | None = None
+    skill_catalog_filter: Callable[[Any], bool] | None = None
     extra_tools: list[Any] = field(default_factory=list)
     prompt_suffix: str | None = None
     diagnostics: Callable[[str, dict[str, Any]], Any] | None = None

--- a/box_agent/tools/mcp_bootstrap.py
+++ b/box_agent/tools/mcp_bootstrap.py
@@ -54,8 +54,11 @@ def _runtime_root(explicit_root: Path | None = None) -> Path | None:
 
 
 def default_managed_mcp_config_path() -> Path:
-    """Return the shared user MCP configuration owned by Box-Agent."""
-    return state_path('config/mcp.json')
+    """Return the host-selected system MCP source, or the legacy user path."""
+    configured = os.environ.get("BOX_AGENT_MANAGED_MCP_CONFIG_PATH", "").strip()
+    if configured:
+        return state_path("config/mcp.json", Path(configured).expanduser())
+    return state_path("config/mcp.json")
 
 
 def _normalize_hosted_search_url(value: str) -> str | None:

--- a/box_agent/tools/mcp_config_tool.py
+++ b/box_agent/tools/mcp_config_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -129,6 +130,11 @@ def _browser_config_summary(config: Any) -> list[str]:
 
 
 def _resolve_write_target() -> Path:
+    host_user_path = os.environ.get("BOX_AGENT_USER_MCP_CONFIG_PATH", "").strip()
+    if host_user_path:
+        target = state_path("config/mcp.json", Path(host_user_path).expanduser())
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target
     if configured_box_agent_home() is not None:
         from box_agent.tools.mcp_loader import get_mcp_config_path
         target = state_path("config/mcp.json", get_mcp_config_path() or None)

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -1162,6 +1162,11 @@ def _materialize_server_config(definition: ResolvedMcpServer) -> dict:
     return server_config
 
 
+def _waiting_for_credential(definition: ResolvedMcpServer) -> bool:
+    credential_ref = definition.config.get("credentialRef")
+    return isinstance(credential_ref, str) and not _mcp_runtime_credentials.get(credential_ref)
+
+
 def _build_connection(definition: ResolvedMcpServer) -> "MCPServerConnection":
     server_config = _materialize_server_config(definition)
     conn_type = _determine_connection_type(server_config)
@@ -1349,6 +1354,13 @@ async def load_mcp_tools_async(
                 _record_status(server_name, "disabled", definition=definition)
                 continue
 
+            if _waiting_for_credential(definition):
+                _record_status(
+                    server_name, "connecting",
+                    error="Waiting for host credential", definition=definition,
+                )
+                continue
+
             conn_type = _determine_connection_type(server_config)
             url = server_config.get("url")
             command = server_config.get("command")
@@ -1441,7 +1453,13 @@ async def reconnect_mcp_server(name: str) -> dict:
     async with lock:
         if _mcp_config_path:
             try:
-                _mcp_server_definitions = _resolve_registered_sources(_mcp_config_path)
+                # Reading another server's new credential version does not mean
+                # its existing connection has used it. Update this server only.
+                current = _resolve_registered_sources(_mcp_config_path)
+                if name in current:
+                    _mcp_server_definitions[name] = current[name]
+                else:
+                    _mcp_server_definitions.pop(name, None)
             except Exception as error:
                 return {"success": False, "error": str(error)}
         return await _reconnect_mcp_server_locked(name)
@@ -1458,7 +1476,9 @@ async def reconcile_mcp_sources(source: str | None = None) -> dict:
         return await _reconcile_mcp_sources_locked(source)
 
 
-async def replace_mcp_source(source: str, config: dict) -> dict:
+async def replace_mcp_source(
+    source: str, config: dict, connector_ids: list[str] | None = None,
+) -> dict:
     """Replace a host-managed MCP source in memory and reconcile its connections."""
 
     if source != "connector":
@@ -1474,10 +1494,41 @@ async def replace_mcp_source(source: str, config: dict) -> dict:
             return {"success": False, "error": "Invalid MCP server entry"}
         servers[name] = dict(server_config)
 
+    if connector_ids is not None and (
+        not isinstance(connector_ids, list) or not connector_ids
+        or any(not isinstance(item, str) or not item.strip() for item in connector_ids)
+    ):
+        return {"success": False, "error": "connectorIds must be a non-empty list for the connector source"}
+
     async with _mcp_source_reconcile_lock:
         previous = _mcp_source_overrides.get(source)
+        if connector_ids is not None:
+            targets = {item.strip().lower() for item in connector_ids}
+            connector_ids = sorted(targets)
+            # A connector update is a scoped replacement, including removals.
+            # Never publish another connector's half-restored configuration.
+            existing = previous
+            if existing is None:
+                existing = {
+                    name: definition.config
+                    for name, definition in _mcp_server_definitions.items()
+                    if definition.owner == source
+                }
+            servers = {
+                **{
+                    name: value for name, value in existing.items()
+                    if str(value.get("_connectorId", "")).strip().lower() not in targets
+                },
+                **{
+                    name: value for name, value in servers.items()
+                    if str(value.get("_connectorId", "")).strip().lower() in targets
+                },
+            }
         _mcp_source_overrides[source] = servers
-        result = await _reconcile_mcp_sources_locked(source)
+        if connector_ids is not None:
+            result = await _reconcile_mcp_sources_locked(source, connector_ids)
+        else:
+            result = await _reconcile_mcp_sources_locked(source)
         if result.get("error") and not result.get("results"):
             if previous is None:
                 _mcp_source_overrides.pop(source, None)
@@ -1486,33 +1537,42 @@ async def replace_mcp_source(source: str, config: dict) -> dict:
         return result
 
 
-async def _reconcile_mcp_sources_locked(source: str | None = None) -> dict:
+async def _reconcile_mcp_sources_locked(
+    source: str | None = None, connector_ids: list[str] | None = None,
+) -> dict:
     global _mcp_server_definitions
     if source is not None and source not in {"system", "connector", "user"}:
         return {"success": False, "error": f"Unknown MCP source: {source}"}
     if not _mcp_config_path:
         return {"success": False, "error": "MCP source paths are not initialized"}
 
-    previous = _mcp_server_definitions
+    previous = dict(_mcp_server_definitions)
     try:
         current = _resolve_registered_sources(_mcp_config_path)
     except Exception as error:
         return {"success": False, "error": str(error)}
-    _mcp_server_definitions = current
 
     results: list[dict] = []
+    reconnects: list[tuple[str, str]] = []
     all_names = sorted(set(previous) | set(current))
     for name in all_names:
         before = previous.get(name)
         after = current.get(name)
+        definition = after or before
+        if source is not None and definition.owner != source:
+            continue
+        if connector_ids is not None and definition.connector_id not in connector_ids:
+            continue
         if after is None:
             result = await disconnect_mcp_server(name)
             if before is not None:
                 _record_status(name, "disabled", definition=before)
+            _mcp_server_definitions.pop(name, None)
             results.append({"name": name, "action": "removed", **result})
             continue
 
         if after.config.get("disabled", False):
+            _mcp_server_definitions[name] = after
             if before is None or not before.config.get("disabled", False) or any(
                 connection.name == name for connection in _mcp_connections
             ):
@@ -1524,11 +1584,24 @@ async def _reconcile_mcp_sources_locked(source: str | None = None) -> dict:
             continue
 
         if before is not None and before.fingerprint == after.fingerprint:
-            continue
+            status = _mcp_status.get(name)
+            # An unchanged configuration is not proof of a successful connection.
+            # Retry failures, but leave healthy or still-loading servers alone.
+            if status is None or status.state != "failed":
+                continue
 
-        result = await reconnect_mcp_server(name)
         action = "added" if before is None else "modified"
-        results.append({"name": name, "action": action, **result})
+        reconnects.append((name, action))
+
+    async def reconnect(name: str, action: str) -> dict:
+        result = await reconnect_mcp_server(name)
+        return {"name": name, "action": action, **result}
+
+    # Each server has its own lock and timeout. A slow provider must not delay
+    # starting independent connectors whose credentials are already available.
+    results.extend(await asyncio.gather(
+        *(reconnect(name, action) for name, action in reconnects)
+    ))
 
     return {
         "success": all(result.get("success", False) for result in results),
@@ -1598,6 +1671,15 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
         url = server_config.get("url")
         command = server_config.get("command")
         transport_label = url or command or ""
+        if _waiting_for_credential(definition):
+            _record_status(
+                name, "connecting", transport=transport_label,
+                error="Waiting for host credential", definition=definition,
+            )
+            return {
+                "success": False, "waitingForCredential": True,
+                "error": "Waiting for host credential", "configPath": definition.source_path,
+            }
         conn = _build_connection(definition)
 
         _record_status(name, "connecting", transport=transport_label)

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -66,6 +66,12 @@ from .browser_tool_names import (
     public_browser_tool_text,
 )
 from .mcp_tool_catalog import get_mcp_tool_catalog
+from .mcp_sources import (
+    McpConfigSource,
+    ResolvedMcpServer,
+    configured_mcp_sources,
+    resolve_mcp_sources,
+)
 from .model_tool_context import current_model_tool_context
 
 
@@ -78,9 +84,15 @@ def _warn(msg: str) -> None:
     sys.stderr.write(msg + "\n")
 
 
-def _public_mcp_tool_name(server_name: str, remote_name: str) -> str:
+def _public_mcp_tool_name(
+    server_name: str,
+    remote_name: str,
+    connector_id: str | None = None,
+) -> str:
     """Return a stable provider-safe name while preserving the MCP name separately."""
     mapped_name = public_browser_tool_name(server_name, remote_name)
+    if connector_id and mapped_name == remote_name:
+        mapped_name = f"mcp__{server_name}__{remote_name}"
     if (
         len(mapped_name) <= _MODEL_TOOL_NAME_MAX_LENGTH
         and not _INVALID_MODEL_TOOL_NAME_CHARACTER.search(mapped_name)
@@ -93,6 +105,11 @@ def _public_mcp_tool_name(server_name: str, remote_name: str) -> str:
     safe_stem = _INVALID_MODEL_TOOL_NAME_CHARACTER.sub("_", mapped_name)
     safe_stem = safe_stem[: _MODEL_TOOL_NAME_MAX_LENGTH - len(digest) - 2]
     return f"{safe_stem}__{digest}"
+
+
+def _mcp_tool_always_load(server_name: str, tool: Any, server_default: bool) -> bool:
+    """Use the owning server's deferred-loading policy."""
+    return server_default
 
 
 def _replace_server_catalog(connection: "MCPServerConnection") -> None:
@@ -327,6 +344,8 @@ class MCPTool(Tool):
         fixed_arguments: dict[str, Any] | None = None,
         execute_timeout: float | None = None,
         always_load: bool = False,
+        connector_id: str | None = None,
+        connector_name: str | None = None,
         concurrency_limiter: asyncio.Semaphore | None = None,
     ):
         self._name = name
@@ -338,6 +357,8 @@ class MCPTool(Tool):
         self._session = session
         self._execute_timeout = execute_timeout
         self._always_load = always_load
+        self._connector_id = connector_id
+        self._connector_name = connector_name
         self._concurrency_limiter = concurrency_limiter
         self._mcp_generation = 0
 
@@ -357,6 +378,14 @@ class MCPTool(Tool):
     @property
     def mcp_tool_id(self) -> str:
         return f"mcp:{self._server_name}/{self._name}"
+
+    @property
+    def mcp_connector_id(self) -> str | None:
+        return self._connector_id
+
+    @property
+    def mcp_connector_name(self) -> str | None:
+        return self._connector_name
 
     @property
     def mcp_generation(self) -> int:
@@ -522,6 +551,8 @@ class MCPServerConnection:
         execute_timeout: float | None = None,
         sse_read_timeout: float | None = None,
         always_load: bool = False,
+        connector_id: str | None = None,
+        connector_name: str | None = None,
     ):
         self.name = name
         self.connection_type = connection_type
@@ -538,6 +569,8 @@ class MCPServerConnection:
         self.execute_timeout = execute_timeout
         self.sse_read_timeout = sse_read_timeout
         self.always_load = always_load
+        self.connector_id = connector_id
+        self.connector_name = connector_name
         self._web_search_concurrency_limiter: asyncio.Semaphore | None = None
         # Connection state
         self.last_error: str | None = None
@@ -648,7 +681,11 @@ class MCPServerConnection:
             execute_timeout = self._get_execute_timeout()
             for tool in tools_list.tools:
                 parameters = tool.inputSchema if hasattr(tool, "inputSchema") else {}
-                public_name = _public_mcp_tool_name(self.name, tool.name)
+                public_name = _public_mcp_tool_name(
+                    self.name,
+                    tool.name,
+                    self.connector_id,
+                )
                 fixed_arguments = browser_tool_fixed_arguments(self.name, parameters)
                 parameters = public_browser_tool_parameters(parameters, fixed_arguments)
                 mcp_tool = MCPTool(
@@ -663,7 +700,9 @@ class MCPServerConnection:
                     server_name=self.name,
                     fixed_arguments=fixed_arguments,
                     execute_timeout=execute_timeout,
-                    always_load=self.always_load,
+                    always_load=_mcp_tool_always_load(self.name, tool, self.always_load),
+                    connector_id=self.connector_id,
+                    connector_name=self.connector_name,
                     concurrency_limiter=self._concurrency_limiter_for_tool(tool.name),
                 )
                 self.tools.append(mcp_tool)
@@ -910,12 +949,18 @@ class MCPServerConnection:
 # Global connections registry
 _mcp_connections: list[MCPServerConnection] = []
 _mcp_reconnect_locks: dict[str, asyncio.Lock] = {}
+_mcp_source_reconcile_lock = asyncio.Lock()
 
 
 @dataclass
 class McpServerStatus:
     name: str
     state: str  # connecting | connected | failed | disabled
+    owner: str = "user"
+    config_id: str = ""
+    connector_id: str | None = None
+    connector_name: str | None = None
+    source_path: str = ""
     transport: str = ""
     tool_count: int = 0
     tools: list = field(default_factory=list)
@@ -926,6 +971,11 @@ class McpServerStatus:
 _mcp_status: dict[str, McpServerStatus] = {}
 _mcp_loading: bool = False
 _mcp_config_path: str | None = None
+_mcp_sources: tuple[McpConfigSource, ...] = ()
+_mcp_server_definitions: dict[str, ResolvedMcpServer] = {}
+_mcp_source_overrides: dict[str, dict[str, dict]] = {}
+_mcp_runtime_credentials: dict[str, dict[str, str]] = {}
+_mcp_runtime_credential_versions: dict[str, int] = {}
 # Auth inputs from the last load_mcp_tools_async() call — reused by
 # reconnect_mcp_server() so a single-server hot reconnect gets the same
 # DynamicBearer / Authorization headers the cold-start path would build.
@@ -948,6 +998,10 @@ def is_mcp_loading() -> bool:
 
 def get_mcp_config_path() -> str | None:
     return _mcp_config_path
+
+
+def get_mcp_config_paths() -> dict[str, str]:
+    return {source.owner: str(source.path) for source in _mcp_sources}
 
 
 def get_mcp_tools_for_server(name: str) -> list:
@@ -986,14 +1040,23 @@ def _record_status(
     tools: list | None = None,
     error: str | None = None,
     auth_status: int | None = None,
+    definition: ResolvedMcpServer | None = None,
 ) -> None:
     if auth_status is None and error:
         if "HTTP 401" in error or "Authentication failed" in error:
             auth_status = 401
         elif "HTTP 403" in error or "Authorization failed" in error:
             auth_status = 403
+    definition = definition or _mcp_server_definitions.get(name)
     _mcp_status[name] = McpServerStatus(
-        name=name, state=state, transport=transport,
+        name=name,
+        state=state,
+        owner=definition.owner if definition else "user",
+        config_id=definition.config_id if definition else f"custom-mcp:{name}",
+        connector_id=definition.connector_id if definition else None,
+        connector_name=definition.connector_name if definition else None,
+        source_path=definition.source_path if definition else (_mcp_config_path or ""),
+        transport=transport,
         tool_count=tool_count, tools=tools or [], error=error,
         auth_status=auth_status,
     )
@@ -1003,6 +1066,11 @@ def get_mcp_status() -> list[dict]:
     return [
         {
             "name": s.name,
+            "owner": s.owner,
+            "configId": s.config_id,
+            "connectorId": s.connector_id,
+            "connectorName": s.connector_name,
+            "sourcePath": s.source_path,
             "state": s.state,
             "transport": s.transport,
             "toolCount": s.tool_count,
@@ -1023,6 +1091,152 @@ def _determine_connection_type(server_config: dict) -> ConnectionType:
     if server_config.get("url"):
         return "streamable_http"
     return "stdio"
+
+
+def set_mcp_runtime_credential(credential_ref: str, headers: dict[str, str]) -> list[str]:
+    """Store connector credentials in memory and return affected server names.
+
+    Credential material is deliberately excluded from MCP config files and status
+    payloads. The desktop host must restore it after every Box-Agent restart.
+    """
+
+    normalized_ref = credential_ref.strip()
+    if not normalized_ref:
+        raise ValueError("credentialRef is required")
+    normalized_headers = {
+        str(name): str(value)
+        for name, value in headers.items()
+        if str(name).strip() and str(value).strip()
+    }
+    if not normalized_headers:
+        raise ValueError("credential headers are required")
+    _mcp_runtime_credentials[normalized_ref] = normalized_headers
+    _mcp_runtime_credential_versions[normalized_ref] = (
+        _mcp_runtime_credential_versions.get(normalized_ref, 0) + 1
+    )
+    return [
+        name
+        for name, definition in _mcp_server_definitions.items()
+        if definition.config.get("credentialRef") == normalized_ref
+    ]
+
+
+def get_mcp_connector_server_names() -> dict[str, frozenset[str]]:
+    """Return every configured MCP server name expected for each connector."""
+    names_by_connector: dict[str, set[str]] = {}
+    for definition in _mcp_server_definitions.values():
+        if definition.owner != "connector" or not definition.connector_id:
+            continue
+        names_by_connector.setdefault(definition.connector_id, set()).add(definition.name)
+    return {
+        connector_id: frozenset(server_names)
+        for connector_id, server_names in names_by_connector.items()
+    }
+
+
+def clear_mcp_runtime_credential(credential_ref: str) -> list[str]:
+    normalized_ref = credential_ref.strip()
+    _mcp_runtime_credentials.pop(normalized_ref, None)
+    _mcp_runtime_credential_versions[normalized_ref] = (
+        _mcp_runtime_credential_versions.get(normalized_ref, 0) + 1
+    )
+    return [
+        name
+        for name, definition in _mcp_server_definitions.items()
+        if definition.config.get("credentialRef") == normalized_ref
+    ]
+
+
+def _materialize_server_config(definition: ResolvedMcpServer) -> dict:
+    server_config = dict(definition.config)
+    credential_ref = server_config.pop("credentialRef", None)
+    server_config.pop("_connectorId", None)
+    server_config.pop("_connectorName", None)
+    if isinstance(credential_ref, str):
+        credential_headers = _mcp_runtime_credentials.get(credential_ref)
+        if credential_headers:
+            server_config["headers"] = {
+                **dict(server_config.get("headers") or {}),
+                **credential_headers,
+            }
+    return server_config
+
+
+def _build_connection(definition: ResolvedMcpServer) -> "MCPServerConnection":
+    server_config = _materialize_server_config(definition)
+    conn_type = _determine_connection_type(server_config)
+    url = server_config.get("url")
+    configured_headers = server_config.get("headers", {})
+    auth = _dynamic_bearer_auth_for_url(
+        url=url,
+        headers=configured_headers,
+        auth_file=_mcp_auth_file,
+        auth_token=_mcp_auth_token,
+    )
+    connection_headers = (
+        configured_headers
+        if auth is not None
+        else request_auth_headers(
+            auth_file=_mcp_auth_file,
+            explicit_token=_mcp_auth_token,
+            existing=configured_headers,
+            url=url,
+        )
+    )
+    return MCPServerConnection(
+        name=definition.name,
+        connection_type=conn_type,
+        command=server_config.get("command"),
+        args=server_config.get("args", []),
+        env=server_config.get("env", {}),
+        url=url,
+        headers=connection_headers,
+        auth=auth,
+        connect_timeout=server_config.get("connect_timeout"),
+        execute_timeout=server_config.get("execute_timeout"),
+        sse_read_timeout=server_config.get("sse_read_timeout"),
+        always_load=bool(server_config.get("alwaysLoad", False)),
+        connector_id=definition.connector_id,
+        connector_name=definition.connector_name,
+    )
+
+
+def _resolve_registered_sources(config_path: str) -> dict[str, ResolvedMcpServer]:
+    global _mcp_sources
+    _mcp_sources = configured_mcp_sources(config_path)
+    if "connector" in _mcp_source_overrides and not any(
+        source.owner == "connector" for source in _mcp_sources
+    ):
+        connector_source = McpConfigSource("connector", Path("<runtime:connector>"))
+        sources = list(_mcp_sources)
+        user_index = next(
+            (index for index, source in enumerate(sources) if source.owner == "user"),
+            len(sources),
+        )
+        sources.insert(user_index, connector_source)
+        _mcp_sources = tuple(sources)
+    raw_reserved_names = os.environ.get("BOX_AGENT_RESERVED_MCP_SERVER_NAMES", "")
+    reserved_names: set[str] = set()
+    if raw_reserved_names:
+        try:
+            parsed_reserved_names = json.loads(raw_reserved_names)
+            if isinstance(parsed_reserved_names, list):
+                reserved_names = {
+                    name.strip()
+                    for name in parsed_reserved_names
+                    if isinstance(name, str) and name.strip()
+                }
+        except json.JSONDecodeError:
+            _warn("Ignoring invalid BOX_AGENT_RESERVED_MCP_SERVER_NAMES JSON")
+    resolved = resolve_mcp_sources(
+        _mcp_sources,
+        _mcp_runtime_credential_versions,
+        reserved_names,
+        _mcp_source_overrides,
+    )
+    for conflict in resolved.conflicts:
+        _warn(f"Skipping conflicting MCP server: {conflict}")
+    return resolved.servers
 
 
 def _resolve_mcp_config_path(config_path: str) -> Path | None:
@@ -1093,6 +1307,7 @@ async def load_mcp_tools_async(
         List of Tool objects representing MCP tools
     """
     global _mcp_connections, _mcp_status, _mcp_loading, _mcp_config_path
+    global _mcp_server_definitions
     global _mcp_auth_file, _mcp_auth_token, _mcp_auth_fingerprint
     _mcp_loading = True
     catalog = get_mcp_tool_catalog()
@@ -1104,19 +1319,22 @@ async def load_mcp_tools_async(
     _mcp_auth_fingerprint = _current_mcp_auth_fingerprint()
     try:
         config_file = _resolve_mcp_config_path(config_path)
-        if config_file is not None:
-            _mcp_config_path = str(config_file)
-
-        if config_file is None:
+        if config_file is None and not any(
+            os.environ.get(name, "").strip()
+            for name in (
+                "BOX_AGENT_USER_MCP_CONFIG_PATH",
+                "BOX_AGENT_SYSTEM_MCP_CONFIG_PATH",
+                "BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH",
+            )
+        ):
             _warn(f"MCP config not found: {config_path}")
             return []
 
-        with open(config_file, encoding="utf-8") as f:
-            config = json.load(f)
+        effective_path = str(config_file or Path(config_path).expanduser())
+        _mcp_config_path = effective_path
+        _mcp_server_definitions = _resolve_registered_sources(effective_path)
 
-        mcp_servers = config.get("mcpServers", {})
-
-        if not mcp_servers:
+        if not _mcp_server_definitions:
             import sys as _sys
             _sys.stderr.write("No MCP servers configured\n")
             return []
@@ -1124,10 +1342,11 @@ async def load_mcp_tools_async(
         connections: list[MCPServerConnection] = []
 
         # Build connection objects for each enabled server
-        for server_name, server_config in mcp_servers.items():
+        for server_name, definition in _mcp_server_definitions.items():
+            server_config = _materialize_server_config(definition)
             if server_config.get("disabled", False):
                 _warn(f"Skipping disabled server: {server_name}")
-                _record_status(server_name, "disabled")
+                _record_status(server_name, "disabled", definition=definition)
                 continue
 
             conn_type = _determine_connection_type(server_config)
@@ -1142,41 +1361,7 @@ async def load_mcp_tools_async(
                 _warn(f"No url specified for {conn_type.upper()} server: {server_name}")
                 continue
 
-            configured_headers = server_config.get("headers", {})
-            auth = _dynamic_bearer_auth_for_url(
-                url=url,
-                headers=configured_headers,
-                auth_file=auth_file,
-                auth_token=auth_token,
-            )
-            connection_headers = (
-                configured_headers
-                if auth is not None
-                else request_auth_headers(
-                    auth_file=auth_file,
-                    explicit_token=auth_token,
-                    existing=configured_headers,
-                    url=url,
-                )
-            )
-
-            connections.append(
-                MCPServerConnection(
-                    name=server_name,
-                    connection_type=conn_type,
-                    command=command,
-                    args=server_config.get("args", []),
-                    env=server_config.get("env", {}),
-                    url=url,
-                    headers=connection_headers,
-                    auth=auth,
-                    # Per-server timeout overrides from mcp.json
-                    connect_timeout=server_config.get("connect_timeout"),
-                    execute_timeout=server_config.get("execute_timeout"),
-                    sse_read_timeout=server_config.get("sse_read_timeout"),
-                    always_load=bool(server_config.get("alwaysLoad", False)),
-                )
-            )
+            connections.append(_build_connection(definition))
 
         # Connect to all servers in parallel — one slow/broken server no
         # longer blocks the others. Each connection has its own timeout.
@@ -1237,19 +1422,120 @@ async def load_mcp_tools_async(
 
 async def cleanup_mcp_connections():
     """Clean up all MCP connections."""
-    global _mcp_connections
+    global _mcp_connections, _mcp_server_definitions, _mcp_sources
     for connection in _mcp_connections:
         await connection.disconnect()
     _mcp_connections.clear()
     _mcp_reconnect_locks.clear()
+    _mcp_server_definitions = {}
+    _mcp_sources = ()
+    _mcp_source_overrides.clear()
+    _mcp_status.clear()
     get_mcp_tool_catalog().clear()
 
 
 async def reconnect_mcp_server(name: str) -> dict:
     """Serialize hot reconnects for one server name."""
+    global _mcp_server_definitions
     lock = _mcp_reconnect_locks.setdefault(name, asyncio.Lock())
     async with lock:
+        if _mcp_config_path:
+            try:
+                _mcp_server_definitions = _resolve_registered_sources(_mcp_config_path)
+            except Exception as error:
+                return {"success": False, "error": str(error)}
         return await _reconnect_mcp_server_locked(name)
+
+
+async def reconcile_mcp_sources(source: str | None = None) -> dict:
+    """Apply source-file changes without restarting unrelated MCP servers."""
+
+    if _mcp_loading:
+        await get_mcp_tool_catalog().wait_until_ready(
+            timeout=max(5.0, get_mcp_timeout_config().connect_timeout)
+        )
+    async with _mcp_source_reconcile_lock:
+        return await _reconcile_mcp_sources_locked(source)
+
+
+async def replace_mcp_source(source: str, config: dict) -> dict:
+    """Replace a host-managed MCP source in memory and reconcile its connections."""
+
+    if source != "connector":
+        return {"success": False, "error": f"Unsupported runtime MCP source: {source}"}
+    if not isinstance(config, dict):
+        return {"success": False, "error": "config must be an object"}
+    raw_servers = config.get("mcpServers", {})
+    if not isinstance(raw_servers, dict):
+        return {"success": False, "error": "mcpServers must be an object"}
+    servers: dict[str, dict] = {}
+    for name, server_config in raw_servers.items():
+        if not isinstance(name, str) or not name.strip() or not isinstance(server_config, dict):
+            return {"success": False, "error": "Invalid MCP server entry"}
+        servers[name] = dict(server_config)
+
+    async with _mcp_source_reconcile_lock:
+        previous = _mcp_source_overrides.get(source)
+        _mcp_source_overrides[source] = servers
+        result = await _reconcile_mcp_sources_locked(source)
+        if result.get("error") and not result.get("results"):
+            if previous is None:
+                _mcp_source_overrides.pop(source, None)
+            else:
+                _mcp_source_overrides[source] = previous
+        return result
+
+
+async def _reconcile_mcp_sources_locked(source: str | None = None) -> dict:
+    global _mcp_server_definitions
+    if source is not None and source not in {"system", "connector", "user"}:
+        return {"success": False, "error": f"Unknown MCP source: {source}"}
+    if not _mcp_config_path:
+        return {"success": False, "error": "MCP source paths are not initialized"}
+
+    previous = _mcp_server_definitions
+    try:
+        current = _resolve_registered_sources(_mcp_config_path)
+    except Exception as error:
+        return {"success": False, "error": str(error)}
+    _mcp_server_definitions = current
+
+    results: list[dict] = []
+    all_names = sorted(set(previous) | set(current))
+    for name in all_names:
+        before = previous.get(name)
+        after = current.get(name)
+        if after is None:
+            result = await disconnect_mcp_server(name)
+            if before is not None:
+                _record_status(name, "disabled", definition=before)
+            results.append({"name": name, "action": "removed", **result})
+            continue
+
+        if after.config.get("disabled", False):
+            if before is None or not before.config.get("disabled", False) or any(
+                connection.name == name for connection in _mcp_connections
+            ):
+                result = await disconnect_mcp_server(name)
+                _record_status(name, "disabled", definition=after)
+                results.append({"name": name, "action": "disabled", **result})
+            else:
+                _record_status(name, "disabled", definition=after)
+            continue
+
+        if before is not None and before.fingerprint == after.fingerprint:
+            continue
+
+        result = await reconnect_mcp_server(name)
+        action = "added" if before is None else "modified"
+        results.append({"name": name, "action": action, **result})
+
+    return {
+        "success": all(result.get("success", False) for result in results),
+        "source": source,
+        "results": results,
+        "configPaths": get_mcp_config_paths(),
+    }
 
 
 async def reconnect_auth_failed_mcp_servers_if_token_changed() -> list[dict]:
@@ -1283,25 +1569,17 @@ async def reconnect_auth_failed_mcp_servers_if_token_changed() -> list[dict]:
 
 
 async def _reconnect_mcp_server_locked(name: str) -> dict:
-    """Re-read mcp.json and reconnect a single named MCP server in-place."""
+    """Reconnect one server from the resolved multi-source registry."""
     global _mcp_connections
 
-    if not _mcp_config_path:
-        return {"success": False, "error": "mcp.json path unknown; box-agent not yet initialized"}
-
-    try:
-        with open(_mcp_config_path, encoding="utf-8") as f:
-            config = json.load(f)
-    except Exception as e:
-        return {"success": False, "error": f"Cannot read {_mcp_config_path}: {e}", "configPath": _mcp_config_path}
-
-    server_config = config.get("mcpServers", {}).get(name)
-    if not server_config:
-        return {"success": False, "error": f"Server '{name}' not found in mcp.json", "configPath": _mcp_config_path}
+    definition = _mcp_server_definitions.get(name)
+    if definition is None:
+        return {"success": False, "error": f"Server '{name}' not found in MCP sources"}
+    server_config = _materialize_server_config(definition)
 
     if server_config.get("disabled"):
-        _record_status(name, "disabled")
-        return {"success": False, "error": "Server is disabled", "configPath": _mcp_config_path}
+        _record_status(name, "disabled", definition=definition)
+        return {"success": False, "error": "Server is disabled", "configPath": definition.source_path}
 
     catalog = get_mcp_tool_catalog()
     catalog.mark_server_loading(name)
@@ -1317,47 +1595,10 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
             _mcp_connections = [c for c in _mcp_connections if c.name != name]
             catalog.remove_server(name)
 
-        conn_type = _determine_connection_type(server_config)
         url = server_config.get("url")
         command = server_config.get("command")
         transport_label = url or command or ""
-
-        # Mirror cold-start auth logic in load_mcp_tools_async(): compute a dynamic
-        # bearer if applicable, otherwise fold static Authorization headers in via
-        # request_auth_headers(). Without this a hot reconnect drops the token and
-        # hosted MCP endpoints (e.g. mcp.xiaohuanxiong.com) return 401 forever.
-        configured_headers = server_config.get("headers", {})
-        auth = _dynamic_bearer_auth_for_url(
-            url=url,
-            headers=configured_headers,
-            auth_file=_mcp_auth_file,
-            auth_token=_mcp_auth_token,
-        )
-        connection_headers = (
-            configured_headers
-            if auth is not None
-            else request_auth_headers(
-                auth_file=_mcp_auth_file,
-                explicit_token=_mcp_auth_token,
-                existing=configured_headers,
-                url=url,
-            )
-        )
-
-        conn = MCPServerConnection(
-            name=name,
-            connection_type=conn_type,
-            command=command,
-            args=server_config.get("args", []),
-            env=server_config.get("env", {}),
-            url=url,
-            headers=connection_headers,
-            auth=auth,
-            connect_timeout=server_config.get("connect_timeout"),
-            execute_timeout=server_config.get("execute_timeout"),
-            sse_read_timeout=server_config.get("sse_read_timeout"),
-            always_load=bool(server_config.get("alwaysLoad", False)),
-        )
+        conn = _build_connection(definition)
 
         _record_status(name, "connecting", transport=transport_label)
         try:
@@ -1370,7 +1611,7 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
                 error=str(e),
                 auth_status=_mcp_auth_status(e),
             )
-            return {"success": False, "error": str(e), "configPath": _mcp_config_path}
+            return {"success": False, "error": str(e), "configPath": definition.source_path}
 
         if success:
             _mcp_connections.append(conn)
@@ -1381,7 +1622,7 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
                 tool_count=len(conn.tools),
                 tools=[t.name for t in conn.tools],
             )
-            return {"success": True, "toolCount": len(conn.tools), "tools": [t.name for t in conn.tools], "configPath": _mcp_config_path}
+            return {"success": True, "toolCount": len(conn.tools), "tools": [t.name for t in conn.tools], "configPath": definition.source_path}
 
         _record_status(
             name,
@@ -1390,6 +1631,6 @@ async def _reconnect_mcp_server_locked(name: str) -> dict:
             error=conn.last_error,
             auth_status=conn.last_auth_status,
         )
-        return {"success": False, "error": conn.last_error or "connect() returned False", "configPath": _mcp_config_path}
+        return {"success": False, "error": conn.last_error or "connect() returned False", "configPath": definition.source_path}
     finally:
         catalog.mark_server_ready(name)

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -1467,14 +1467,22 @@ async def reconnect_mcp_server(name: str) -> dict:
         return await _reconnect_mcp_server_locked(name)
 
 
+async def _mcp_startup_ready() -> bool:
+    """Keep source updates behind the cold-discovery publication boundary."""
+    catalog = get_mcp_tool_catalog()
+    if _mcp_loading or catalog.initial_loading:
+        return await catalog.wait_until_ready(
+            timeout=max(5.0, get_mcp_timeout_config().connect_timeout)
+        )
+    return True
+
+
 async def reconcile_mcp_sources(source: str | None = None) -> dict:
     """Apply source-file changes without restarting unrelated MCP servers."""
 
-    if _mcp_loading:
-        await get_mcp_tool_catalog().wait_until_ready(
-            timeout=max(5.0, get_mcp_timeout_config().connect_timeout)
-        )
     async with _mcp_source_reconcile_lock:
+        if not await _mcp_startup_ready():
+            return {"success": False, "error": "MCP startup is still loading; retry the source update after readiness."}
         return await _reconcile_mcp_sources_locked(source)
 
 
@@ -1503,6 +1511,8 @@ async def replace_mcp_source(
         return {"success": False, "error": "connectorIds must be a non-empty list for the connector source"}
 
     async with _mcp_source_reconcile_lock:
+        if not await _mcp_startup_ready():
+            return {"success": False, "error": "MCP startup is still loading; retry the source update after readiness."}
         previous = _mcp_source_overrides.get(source)
         if connector_ids is not None:
             targets = {item.strip().lower() for item in connector_ids}
@@ -1559,8 +1569,31 @@ async def _reconcile_mcp_sources_locked(
     except Exception as error:
         return {"success": False, "error": str(error)}
 
-    results: list[dict] = []
-    reconnects: list[tuple[str, str]] = []
+    async def retire(name: str, before: ResolvedMcpServer | None,
+                     after: ResolvedMcpServer | None) -> dict | None:
+        # An in-flight reconnect must finish publishing before revocation can
+        # close it. Return only after that same server's critical section ends.
+        lock = _mcp_reconnect_locks.setdefault(name, asyncio.Lock())
+        async with lock:
+            if after is None:
+                result = await disconnect_mcp_server(name)
+                if before is not None:
+                    _record_status(name, "disabled", definition=before)
+                _mcp_server_definitions.pop(name, None)
+                return {"name": name, "action": "removed", **result}
+            _mcp_server_definitions[name] = after
+            if before is None or not before.config.get("disabled", False) or any(
+                connection.name == name for connection in _mcp_connections
+            ):
+                result = await disconnect_mcp_server(name)
+                _record_status(name, "disabled", definition=after)
+                return {"name": name, "action": "disabled", **result}
+            _record_status(name, "disabled", definition=after)
+            return None
+
+    async def reconnect(name: str, action: str) -> dict:
+        result = await reconnect_mcp_server(name)
+        return {"name": name, "action": action, **result}
 
     def in_scope(definition: ResolvedMcpServer | None) -> bool:
         return definition is not None and (
@@ -1569,6 +1602,7 @@ async def _reconcile_mcp_sources_locked(
             connector_ids is None or definition.connector_id in connector_ids
         )
 
+    operations = []
     all_names = sorted(set(previous) | set(current))
     for name in all_names:
         before = previous.get(name)
@@ -1579,44 +1613,22 @@ async def _reconcile_mcp_sources_locked(
         if not after_in_scope:
             # Revoke the old owner without applying a newly revealed source
             # outside this update. Its own reconciliation may activate it later.
-            result = await disconnect_mcp_server(name)
-            if before is not None:
-                _record_status(name, "disabled", definition=before)
-            _mcp_server_definitions.pop(name, None)
-            results.append({"name": name, "action": "removed", **result})
+            operations.append(retire(name, before, None))
             continue
-
         if after.config.get("disabled", False):
-            _mcp_server_definitions[name] = after
-            if before is None or not before.config.get("disabled", False) or any(
-                connection.name == name for connection in _mcp_connections
-            ):
-                result = await disconnect_mcp_server(name)
-                _record_status(name, "disabled", definition=after)
-                results.append({"name": name, "action": "disabled", **result})
-            else:
-                _record_status(name, "disabled", definition=after)
+            operations.append(retire(name, before, after))
             continue
-
         if before is not None and before.fingerprint == after.fingerprint:
             status = _mcp_status.get(name)
             # An unchanged configuration is not proof of a successful connection.
             # Retry failures, but leave healthy or still-loading servers alone.
             if status is None or status.state != "failed":
                 continue
+        operations.append(reconnect(name, "added" if before is None else "modified"))
 
-        action = "added" if before is None else "modified"
-        reconnects.append((name, action))
-
-    async def reconnect(name: str, action: str) -> dict:
-        result = await reconnect_mcp_server(name)
-        return {"name": name, "action": action, **result}
-
-    # Each server has its own lock and timeout. A slow provider must not delay
-    # starting independent connectors whose credentials are already available.
-    results.extend(await asyncio.gather(
-        *(reconnect(name, action) for name, action in reconnects)
-    ))
+    # Reconnects and revocations share per-server locks, while unrelated names
+    # start independently even if one removal waits for a slow connection.
+    results = [result for result in await asyncio.gather(*operations) if result is not None]
 
     return {
         "success": all(result.get("success", False) for result in results),

--- a/box_agent/tools/mcp_loader.py
+++ b/box_agent/tools/mcp_loader.py
@@ -1117,7 +1117,7 @@ def set_mcp_runtime_credential(credential_ref: str, headers: dict[str, str]) -> 
     return [
         name
         for name, definition in _mcp_server_definitions.items()
-        if definition.config.get("credentialRef") == normalized_ref
+        if definition.owner == "connector" and definition.config.get("credentialRef") == normalized_ref
     ]
 
 
@@ -1143,13 +1143,15 @@ def clear_mcp_runtime_credential(credential_ref: str) -> list[str]:
     return [
         name
         for name, definition in _mcp_server_definitions.items()
-        if definition.config.get("credentialRef") == normalized_ref
+        if definition.owner == "connector" and definition.config.get("credentialRef") == normalized_ref
     ]
 
 
 def _materialize_server_config(definition: ResolvedMcpServer) -> dict:
     server_config = dict(definition.config)
     credential_ref = server_config.pop("credentialRef", None)
+    if credential_ref is not None and definition.owner != "connector":
+        raise ValueError("credentialRef requires a connector-owned source")
     server_config.pop("_connectorId", None)
     server_config.pop("_connectorName", None)
     if isinstance(credential_ref, str):
@@ -1514,16 +1516,21 @@ async def replace_mcp_source(
                     for name, definition in _mcp_server_definitions.items()
                     if definition.owner == source
                 }
-            servers = {
-                **{
-                    name: value for name, value in existing.items()
-                    if str(value.get("_connectorId", "")).strip().lower() not in targets
-                },
-                **{
-                    name: value for name, value in servers.items()
-                    if str(value.get("_connectorId", "")).strip().lower() in targets
-                },
+            retained = {
+                name: value for name, value in existing.items()
+                if str(value.get("_connectorId", "")).strip().lower() not in targets
             }
+            incoming = {
+                name: value for name, value in servers.items()
+                if str(value.get("_connectorId", "")).strip().lower() in targets
+            }
+            conflicts = sorted(retained.keys() & incoming.keys())
+            if conflicts:
+                return {"success": False, "error": (
+                    "MCP server names belong to connectors outside connectorIds: "
+                    + ", ".join(conflicts)
+                )}
+            servers = {**retained, **incoming}
         _mcp_source_overrides[source] = servers
         if connector_ids is not None:
             result = await _reconcile_mcp_sources_locked(source, connector_ids)
@@ -1554,16 +1561,24 @@ async def _reconcile_mcp_sources_locked(
 
     results: list[dict] = []
     reconnects: list[tuple[str, str]] = []
+
+    def in_scope(definition: ResolvedMcpServer | None) -> bool:
+        return definition is not None and (
+            source is None or definition.owner == source
+        ) and (
+            connector_ids is None or definition.connector_id in connector_ids
+        )
+
     all_names = sorted(set(previous) | set(current))
     for name in all_names:
         before = previous.get(name)
         after = current.get(name)
-        definition = after or before
-        if source is not None and definition.owner != source:
+        before_in_scope, after_in_scope = in_scope(before), in_scope(after)
+        if not before_in_scope and not after_in_scope:
             continue
-        if connector_ids is not None and definition.connector_id not in connector_ids:
-            continue
-        if after is None:
+        if not after_in_scope:
+            # Revoke the old owner without applying a newly revealed source
+            # outside this update. Its own reconciliation may activate it later.
             result = await disconnect_mcp_server(name)
             if before is not None:
                 _record_status(name, "disabled", definition=before)

--- a/box_agent/tools/mcp_sources.py
+++ b/box_agent/tools/mcp_sources.py
@@ -171,6 +171,8 @@ def resolve_mcp_sources(
                 continue
             config_id, connector_id, connector_name = _server_identity(source, name, config)
             credential_ref = config.get("credentialRef")
+            if credential_ref is not None and source.owner != "connector":
+                raise ValueError(f"MCP server {name}: credentialRef requires a connector-owned source")
             credential_version = (
                 credential_versions.get(credential_ref, 0)
                 if isinstance(credential_ref, str)

--- a/box_agent/tools/mcp_sources.py
+++ b/box_agent/tools/mcp_sources.py
@@ -1,0 +1,189 @@
+"""Resolve isolated MCP configuration sources into one runtime registry."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+McpOwner = Literal["system", "connector", "user"]
+_CONNECTOR_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class McpConfigSource:
+    owner: McpOwner
+    path: Path
+
+
+@dataclass(frozen=True)
+class ResolvedMcpServer:
+    name: str
+    config: dict
+    owner: McpOwner
+    config_id: str
+    connector_id: str | None
+    connector_name: str | None
+    source_path: str
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class ResolvedMcpSources:
+    sources: tuple[McpConfigSource, ...]
+    servers: dict[str, ResolvedMcpServer]
+    conflicts: tuple[str, ...]
+
+
+def configured_mcp_sources(primary_path: str) -> tuple[McpConfigSource, ...]:
+    """Return source paths in protected-owner precedence order.
+
+    Standalone Box-Agent keeps its historical single-file behavior. The Officev3
+    host opts into physical source isolation through explicit environment paths.
+    """
+
+    user_path = os.environ.get("BOX_AGENT_USER_MCP_CONFIG_PATH", "").strip()
+    system_path = os.environ.get("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", "").strip()
+    connector_path = os.environ.get("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", "").strip()
+
+    if not any((user_path, system_path, connector_path)):
+        return (McpConfigSource("user", Path(primary_path).expanduser()),)
+
+    sources: list[McpConfigSource] = []
+    if system_path:
+        sources.append(McpConfigSource("system", Path(system_path).expanduser()))
+    if connector_path:
+        sources.append(McpConfigSource("connector", Path(connector_path).expanduser()))
+    sources.append(McpConfigSource("user", Path(user_path or primary_path).expanduser()))
+    return tuple(sources)
+
+
+def _read_servers(source: McpConfigSource) -> dict[str, dict]:
+    try:
+        payload = json.loads(source.path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"MCP config must be an object: {source.path}")
+    raw_servers = payload.get("mcpServers", {})
+    if not isinstance(raw_servers, dict):
+        raise ValueError(f"mcpServers must be an object: {source.path}")
+    servers: dict[str, dict] = {}
+    for name, config in raw_servers.items():
+        if not isinstance(name, str) or not name.strip() or not isinstance(config, dict):
+            raise ValueError(f"Invalid MCP server entry in {source.path}")
+        servers[name] = dict(config)
+    return servers
+
+
+def _copy_servers(raw_servers: object, source_label: str) -> dict[str, dict]:
+    if not isinstance(raw_servers, dict):
+        raise ValueError(f"mcpServers must be an object: {source_label}")
+    servers: dict[str, dict] = {}
+    for name, config in raw_servers.items():
+        if not isinstance(name, str) or not name.strip() or not isinstance(config, dict):
+            raise ValueError(f"Invalid MCP server entry in {source_label}")
+        servers[name] = dict(config)
+    return servers
+
+
+def _server_identity(
+    source: McpConfigSource,
+    name: str,
+    config: dict,
+) -> tuple[str, str | None, str | None]:
+    connector_id = config.get("_connectorId")
+    if source.owner == "connector":
+        if not isinstance(connector_id, str):
+            raise ValueError(f"Connector MCP server {name} is missing _connectorId")
+        normalized_connector_id = connector_id.strip().lower()
+        if not _CONNECTOR_ID_PATTERN.fullmatch(normalized_connector_id):
+            raise ValueError(f"Connector MCP server {name} has an invalid _connectorId")
+        connector_name = config.get("_connectorName")
+        normalized_connector_name = (
+            connector_name.strip()
+            if isinstance(connector_name, str) and connector_name.strip()
+            else normalized_connector_id
+        )
+        return (
+            f"connector:{normalized_connector_id}",
+            normalized_connector_id,
+            normalized_connector_name,
+        )
+    if source.owner == "system":
+        return f"system:{name}", None, None
+    return f"custom-mcp:{name}", None, None
+
+
+def _fingerprint(
+    source: McpConfigSource,
+    config_id: str,
+    config: dict,
+    credential_version: int,
+) -> str:
+    serialized = json.dumps(
+        {
+            "owner": source.owner,
+            "sourcePath": str(source.path),
+            "configId": config_id,
+            "config": config,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(f"{serialized}\0{credential_version}".encode("utf-8")).hexdigest()
+
+
+def resolve_mcp_sources(
+    sources: tuple[McpConfigSource, ...],
+    credential_versions: dict[str, int] | None = None,
+    reserved_names: set[str] | None = None,
+    source_server_overrides: dict[McpOwner, dict[str, dict]] | None = None,
+) -> ResolvedMcpSources:
+    """Resolve sources without allowing lower-trust entries to shadow protected ones."""
+
+    credential_versions = credential_versions or {}
+    reserved_names = reserved_names or set()
+    resolved: dict[str, ResolvedMcpServer] = {}
+    conflicts: list[str] = []
+    for source in sources:
+        if source_server_overrides is not None and source.owner in source_server_overrides:
+            servers = _copy_servers(
+                source_server_overrides[source.owner],
+                str(source.path),
+            )
+        else:
+            servers = _read_servers(source)
+        for name, config in servers.items():
+            if source.owner == "user" and name in reserved_names:
+                conflicts.append(f"user:{name} uses a protected server name")
+                continue
+            if name in resolved:
+                conflicts.append(
+                    f"{source.owner}:{name} conflicts with {resolved[name].owner}:{name}"
+                )
+                continue
+            config_id, connector_id, connector_name = _server_identity(source, name, config)
+            credential_ref = config.get("credentialRef")
+            credential_version = (
+                credential_versions.get(credential_ref, 0)
+                if isinstance(credential_ref, str)
+                else 0
+            )
+            resolved[name] = ResolvedMcpServer(
+                name=name,
+                config=config,
+                owner=source.owner,
+                config_id=config_id,
+                connector_id=connector_id,
+                connector_name=connector_name,
+                source_path=str(source.path),
+                fingerprint=_fingerprint(source, config_id, config, credential_version),
+            )
+    return ResolvedMcpSources(sources=sources, servers=resolved, conflicts=tuple(conflicts))

--- a/box_agent/tools/mcp_tool_catalog.py
+++ b/box_agent/tools/mcp_tool_catalog.py
@@ -130,6 +130,12 @@ class MCPToolCatalog:
             ready_event.set()
 
     @property
+    def initial_loading(self) -> bool:
+        """Distinguish cold discovery from independent server refreshes."""
+        with self._lock:
+            return self._loading
+
+    @property
     def loading(self) -> bool:
         with self._lock:
             return self._has_pending_discovery()

--- a/box_agent/tools/mcp_tool_catalog.py
+++ b/box_agent/tools/mcp_tool_catalog.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import math
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from threading import RLock
 
@@ -65,6 +65,9 @@ class MCPToolEntry:
     tool: Tool
     generation: int
     always_load: bool
+    connector_id: str | None = None
+    connector_name: str | None = None
+    remote_name: str | None = None
     name_conflict: bool = False
 
 
@@ -169,6 +172,9 @@ class MCPToolCatalog:
                     tool=tool,
                     generation=generation,
                     always_load=bool(getattr(tool, "mcp_always_load", False)),
+                    connector_id=getattr(tool, "mcp_connector_id", None),
+                    connector_name=getattr(tool, "mcp_connector_name", None),
+                    remote_name=getattr(tool, "remote_name", raw_name),
                 )
             self._rebuild_conflicts()
             return generation
@@ -207,14 +213,61 @@ class MCPToolCatalog:
             return None
         return matches[0]
 
+    def resolve_connector_id(
+        self,
+        reference: str,
+        *,
+        entry_filter: Callable[[MCPToolEntry], bool] | None = None,
+    ) -> str | None:
+        """Resolve a connector ID or unique display-name fragment."""
+        normalized_reference = _normalize(reference)
+        if not normalized_reference:
+            return None
+        identities: dict[str, set[str]] = {}
+        for entry in self.snapshot():
+            if not entry.connector_id or not self._visible(entry, entry_filter):
+                continue
+            identities.setdefault(entry.connector_id, set()).add(entry.connector_name or "")
+
+        exact_ids = {
+            connector_id
+            for connector_id in identities
+            if _normalize(connector_id) == normalized_reference
+        }
+        if len(exact_ids) == 1:
+            return next(iter(exact_ids))
+
+        matching_ids = {
+            connector_id
+            for connector_id, names in identities.items()
+            if any(
+                normalized_reference
+                in _normalize(f"{connector_id} {connector_name}")
+                for connector_name in names
+            )
+        }
+        return next(iter(matching_ids)) if len(matching_ids) == 1 else None
+
+    @staticmethod
+    def _visible(
+        entry: MCPToolEntry,
+        entry_filter: Callable[[MCPToolEntry], bool] | None,
+    ) -> bool:
+        return entry_filter is None or entry_filter(entry)
+
     def search(
         self,
         query: str,
         *,
         server_name: str | None = None,
         top_k: int = 5,
+        entry_filter: Callable[[MCPToolEntry], bool] | None = None,
     ) -> list[MCPToolEntry]:
-        ranked = self._ranked_search(query, server_name=server_name)
+        ranked = self._ranked_search(
+            query,
+            server_name=server_name,
+            entry_filter=entry_filter,
+        )
         return [entry for *_, entry in ranked[: max(1, top_k)]]
 
     def search_many(
@@ -224,6 +277,7 @@ class MCPToolCatalog:
         server_name: str | None = None,
         top_k: int = 5,
         entries: Iterable[MCPToolEntry] | None = None,
+        entry_filter: Callable[[MCPToolEntry], bool] | None = None,
     ) -> list[MCPToolEntry]:
         """Merge independent keyword searches using each tool's best rank."""
         search_entries = tuple(entries) if entries is not None else None
@@ -242,7 +296,12 @@ class MCPToolCatalog:
         ] = {}
         for query_index, query in enumerate(normalized_queries):
             for exact_priority, neg_relevance, neg_matched, tool_id, entry in (
-                self._ranked_search(query, server_name=server_name, entries=search_entries)
+                self._ranked_search(
+                    query,
+                    server_name=server_name,
+                    entries=search_entries,
+                    entry_filter=entry_filter,
+                )
             ):
                 candidate = (
                     exact_priority,
@@ -264,12 +323,14 @@ class MCPToolCatalog:
         tool_names: Iterable[str],
         *,
         server_name: str | None = None,
+        entry_filter: Callable[[MCPToolEntry], bool] | None = None,
     ) -> tuple[list[MCPToolEntry], list[str]]:
-        """Resolve exact catalog IDs, qualified names, or model names."""
+        """Resolve exact catalog IDs, model names, or original MCP names."""
         entries = [
             entry
             for entry in self.snapshot()
             if server_name is None or entry.server_name == server_name
+            if self._visible(entry, entry_filter)
         ]
         resolved: list[MCPToolEntry] = []
         resolved_ids: set[str] = set()
@@ -290,6 +351,20 @@ class MCPToolCatalog:
                 }
             ]
             if not matches:
+                remote_matches = [
+                    entry
+                    for entry in entries
+                    if entry.remote_name
+                    and normalized_name
+                    in {
+                        _normalize(entry.remote_name),
+                        _normalize(f"{entry.server_name}/{entry.remote_name}"),
+                        _normalize(f"{entry.server_name}:{entry.remote_name}"),
+                    }
+                ]
+                if len(remote_matches) == 1:
+                    matches = remote_matches
+            if not matches:
                 missing.append(requested_name)
                 continue
             for entry in matches:
@@ -305,6 +380,7 @@ class MCPToolCatalog:
         *,
         server_name: str | None = None,
         entries: Iterable[MCPToolEntry] | None = None,
+        entry_filter: Callable[[MCPToolEntry], bool] | None = None,
     ) -> list[tuple[int, float, int, str, MCPToolEntry]]:
         normalized_query = _normalize(query)
         query_terms = tuple(dict.fromkeys(_tokenize(query)))
@@ -314,43 +390,63 @@ class MCPToolCatalog:
         for entry in self.snapshot() if entries is None else entries:
             if server_name and entry.server_name != server_name:
                 continue
+            if not self._visible(entry, entry_filter):
+                continue
             aliases = tuple(getattr(entry.tool, "aliases", ()))
             names = (entry.model_name, *aliases)
             model_terms = tuple(dict.fromkeys(_tokenize(" ".join(names))))
             model_term_set = set(model_terms)
+            remote_terms = tuple(
+                term
+                for term in dict.fromkeys(_tokenize(entry.remote_name or ""))
+                if term not in model_term_set
+            )
+            remote_term_set = set(remote_terms)
             server_terms = tuple(
                 term
                 for term in dict.fromkeys(_tokenize(entry.server_name))
-                if term not in model_term_set
+                if term not in model_term_set and term not in remote_term_set
+            )
+            connector_terms = tuple(
+                dict.fromkeys(_tokenize(f"{entry.connector_id or ''} {entry.connector_name or ''}"))
             )
             documents.append(
                 (
                     entry,
                     tuple(_normalize(name) for name in names),
+                    _normalize(entry.remote_name or ""),
                     _normalize(entry.tool_id),
                     _normalize(f"{entry.server_name} {entry.model_name}"),
                     model_terms,
+                    remote_terms,
                     server_terms,
+                    connector_terms,
                     tuple(dict.fromkeys(_tokenize(entry.description))),
                 )
             )
         if not documents:
             return []
 
-        average_model_name_length = sum(len(item[4]) for item in documents) / len(
+        average_model_name_length = sum(len(item[5]) for item in documents) / len(
             documents
         )
-        average_server_name_length = sum(len(item[5]) for item in documents) / len(
+        average_remote_name_length = sum(len(item[6]) for item in documents) / len(
             documents
         )
-        average_description_length = sum(len(item[6]) for item in documents) / len(
+        average_server_name_length = sum(len(item[7]) for item in documents) / len(
+            documents
+        )
+        average_connector_length = sum(len(item[8]) for item in documents) / len(documents)
+        average_description_length = sum(len(item[9]) for item in documents) / len(
             documents
         )
         document_frequencies = {
             term: (
-                sum(_prefix_term_frequency(term, item[4]) > 0 for item in documents),
                 sum(_prefix_term_frequency(term, item[5]) > 0 for item in documents),
                 sum(_prefix_term_frequency(term, item[6]) > 0 for item in documents),
+                sum(_prefix_term_frequency(term, item[7]) > 0 for item in documents),
+                sum(_prefix_term_frequency(term, item[8]) > 0 for item in documents),
+                sum(_prefix_term_frequency(term, item[9]) > 0 for item in documents),
             )
             for term in query_terms
         }
@@ -359,20 +455,26 @@ class MCPToolCatalog:
         for (
             entry,
             normalized_names,
+            normalized_remote_name,
             normalized_id,
             normalized_server_name,
             model_name_terms,
+            remote_name_terms,
             server_name_terms,
+            connector_terms,
             description_terms,
         ) in documents:
             exact_priority = 3
-            if normalized_query in normalized_names:
+            if normalized_query in (*normalized_names, normalized_remote_name):
                 exact_priority = 0
             elif normalized_query == normalized_id:
                 exact_priority = 1
             elif normalized_query == normalized_server_name:
                 exact_priority = 2
-            elif any(len(name) >= 3 and name in normalized_query for name in normalized_names):
+            elif any(
+                len(name) >= 3 and name in normalized_query
+                for name in (*normalized_names, normalized_remote_name)
+            ):
                 # Preserve main's compound-query behavior: when the model names
                 # a concrete tool inside a longer request, rank that explicit
                 # selection ahead of fuzzy BM25 matches.
@@ -382,13 +484,23 @@ class MCPToolCatalog:
             matched_terms = 0
             for term in query_terms:
                 model_name_frequency = _prefix_term_frequency(term, model_name_terms)
+                remote_name_frequency = _prefix_term_frequency(term, remote_name_terms)
                 server_name_frequency = _prefix_term_frequency(term, server_name_terms)
+                connector_frequency = _prefix_term_frequency(term, connector_terms)
                 description_frequency = _prefix_term_frequency(term, description_terms)
-                if model_name_frequency or server_name_frequency or description_frequency:
+                if (
+                    model_name_frequency
+                    or remote_name_frequency
+                    or server_name_frequency
+                    or connector_frequency
+                    or description_frequency
+                ):
                     matched_terms += 1
                 (
                     model_name_document_frequency,
+                    remote_name_document_frequency,
                     server_name_document_frequency,
+                    connector_document_frequency,
                     description_document_frequency,
                 ) = document_frequencies[term]
                 relevance += 2.0 * _bm25_term_score(
@@ -398,12 +510,26 @@ class MCPToolCatalog:
                     field_length=len(model_name_terms),
                     average_field_length=average_model_name_length,
                 )
+                relevance += 2.0 * _bm25_term_score(
+                    term_frequency=remote_name_frequency,
+                    document_frequency=remote_name_document_frequency,
+                    document_count=len(documents),
+                    field_length=len(remote_name_terms),
+                    average_field_length=average_remote_name_length,
+                )
                 relevance += 0.5 * _bm25_term_score(
                     term_frequency=server_name_frequency,
                     document_frequency=server_name_document_frequency,
                     document_count=len(documents),
                     field_length=len(server_name_terms),
                     average_field_length=average_server_name_length,
+                )
+                relevance += 0.75 * _bm25_term_score(
+                    term_frequency=connector_frequency,
+                    document_frequency=connector_document_frequency,
+                    document_count=len(documents),
+                    field_length=len(connector_terms),
+                    average_field_length=average_connector_length,
                 )
                 relevance += _bm25_term_score(
                     term_frequency=description_frequency,
@@ -433,6 +559,9 @@ class MCPToolCatalog:
                 tool=entry.tool,
                 generation=entry.generation,
                 always_load=entry.always_load,
+                connector_id=entry.connector_id,
+                connector_name=entry.connector_name,
+                remote_name=entry.remote_name,
                 name_conflict=counts[entry.model_name] > 1,
             )
             for tool_id, entry in self._entries.items()

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -492,11 +492,14 @@ class MCPToolExposureManager:
         self._allowed_connector_ids_provider = allowed_connector_ids_provider
 
     def _entry_is_allowed(self, entry) -> bool:
-        if entry.connector_id is None:
+        return self._connector_is_allowed(entry.connector_id)
+
+    def _connector_is_allowed(self, connector_id: str | None) -> bool:
+        if connector_id is None:
             return True
         if self._allowed_connector_ids_provider is None:
             return True
-        return entry.connector_id in self._allowed_connector_ids_provider()
+        return connector_id in self._allowed_connector_ids_provider()
 
     def prepare_tools(self, candidates: list[Tool]) -> ToolExposure:
         # ``candidates`` is the session's stable core-tool registry. Ordinary
@@ -520,7 +523,9 @@ class MCPToolExposureManager:
                 self._activated_local.pop(name, None)
         for tool in candidates:
             if getattr(tool, "mcp_tool_id", None) is not None:
-                if not self._deferred_mcp:
+                if not self._deferred_mcp and self._connector_is_allowed(
+                    getattr(tool, "mcp_connector_id", None)
+                ):
                     visible[tool.name] = tool
                     generation = getattr(tool, "mcp_generation", None)
                     if isinstance(generation, int):
@@ -554,7 +559,6 @@ class MCPToolExposureManager:
             for tool in [*tool_map.values(), *exposure.tools]
             if tool.name != TOOL_SEARCH_NAME and (
                 getattr(tool, "mcp_tool_id", None) is None
-                or not self._deferred_mcp
                 or tool.name in exposure.offered_names
             )
         }
@@ -565,8 +569,15 @@ class MCPToolExposureManager:
         offered_generation: int | None,
         target_tool: Tool | None = None,
     ) -> str | None:
+        if target_tool is not None and not self._connector_is_allowed(
+            getattr(target_tool, "mcp_connector_id", None)
+        ):
+            return f"MCP tool '{name}' is not enabled for this conversation; search again."
         if offered_generation is None:
             return None
+        current = self._catalog.get_by_model_name(name)
+        if current is not None and not self._entry_is_allowed(current):
+            return f"MCP tool '{name}' is not enabled for this conversation; search again."
         if not self._deferred_mcp:
             if (
                 target_tool is not None
@@ -574,11 +585,8 @@ class MCPToolExposureManager:
             ):
                 return f"MCP tool '{name}' execution target changed after it was offered; prepare tools again."
             return None
-        current = self._catalog.get_by_model_name(name)
         if current is None:
             return f"MCP tool '{name}' is unavailable or has a name conflict; search again."
-        if not self._entry_is_allowed(current):
-            return f"MCP tool '{name}' is not enabled for this conversation; search again."
         if current.generation != offered_generation:
             return f"MCP tool '{name}' changed after it was offered; search again."
         if (

--- a/box_agent/tools/mcp_tool_search.py
+++ b/box_agent/tools/mcp_tool_search.py
@@ -44,6 +44,7 @@ class ToolSearchTool(Tool):
         activated: OrderedDict[str, ActivatedMCPTool],
         *,
         protected_names_provider: Callable[[], frozenset[str]] | None = None,
+        allowed_connector_ids_provider: Callable[[], frozenset[str]] | None = None,
         readiness_timeout: float = 15.0,
         local_tools_provider: Callable[[], Iterable[Tool]] | None = None,
         activated_local_tools: OrderedDict[str, Tool] | None = None,
@@ -51,11 +52,19 @@ class ToolSearchTool(Tool):
         self._catalog = catalog
         self._activated = activated
         self._protected_names_provider = protected_names_provider
+        self._allowed_connector_ids_provider = allowed_connector_ids_provider
         self._readiness_timeout = readiness_timeout
         self._local_tools_provider = local_tools_provider
         self._activated_local = (
             activated_local_tools if activated_local_tools is not None else OrderedDict()
         )
+
+    def _entry_is_allowed(self, entry) -> bool:
+        if entry.connector_id is None:
+            return True
+        if self._allowed_connector_ids_provider is None:
+            return True
+        return entry.connector_id in self._allowed_connector_ids_provider()
 
     @property
     def name(self) -> str:
@@ -72,12 +81,16 @@ class ToolSearchTool(Tool):
             "deferred catalog tools are not exposed, while alwaysLoad tools remain "
             "visible without search. Use query for one keyword search, queries for "
             "independent bilingual or synonymous searches, or tool_names to activate "
-            "only exact catalog IDs or names. Provide at least one non-empty query, "
-            "queries, or tool_names input; they may be combined. "
-            "Prefer short capability, server, or tool "
+            "only exact catalog IDs, model-facing names, or unique original MCP names. "
+            "Passing only server_name activates all tools from that one enabled server. "
+            "Provide at least one non-empty query, queries, tool_names, server_name, or "
+            "connector input; they may be combined. Prefer short capability, server, "
+            "connector, or tool "
             "keywords; task-specific operands are tolerated but should be omitted "
-            "when possible. Set top_k to however many matching tool "
-            "schemas the task actually needs, including ten or more when appropriate. "
+            "when possible. Passing only connector activates all tools owned by "
+            "the uniquely matched enabled connector. Set top_k to however many "
+            "matching tool schemas the task actually needs, including ten or more "
+            "when appropriate. "
             "A query hit may activate a protocol-required companion, such as the "
             "snapshot paired with managed browser navigation, in addition to top_k. "
             "The response reports catalog_tool_count for the applied server scope, "
@@ -118,14 +131,29 @@ class ToolSearchTool(Tool):
                     "items": {"type": "string"},
                     "minItems": 1,
                     "description": (
-                        "Exact tool IDs or names to activate, such as "
-                        "mcp:server/tool or server/tool. No fuzzy fallback is used, "
-                        "and unlisted catalog tools remain hidden."
+                        "Exact tool IDs, model-facing names, or unique original MCP names "
+                        "to activate, such as mcp:server/tool, server/tool, or an "
+                        "MCP tools/list name. No fuzzy fallback is used, and unlisted "
+                        "catalog tools remain hidden."
                     ),
                 },
                 "server_name": {
                     "type": "string",
-                    "description": "Optional exact MCP server name filter.",
+                    "description": (
+                        "Exact internal MCP server name. On its own, activates all "
+                        "tools from that enabled server; with query, connector, or "
+                        "tool_names, it narrows the normal discovery scope."
+                    ),
+                },
+                "connector": {
+                    "type": "string",
+                    "description": (
+                        "Connector ID or unique display-name text from "
+                        "<connector-status>, such as pkulaw or 北大法宝. On its "
+                        "own, activates all tools owned by that enabled connector; "
+                        "with query, server_name, or tool_names, it narrows the "
+                        "normal discovery scope."
+                    ),
                 },
                 "top_k": {
                     "type": "integer",
@@ -133,7 +161,7 @@ class ToolSearchTool(Tool):
                     "default": 1,
                     "description": (
                         "Exact maximum number of query matches to return and activate; "
-                        "ignored for tool_names. Choose any positive count required by "
+                        "ignored for tool_names and server-only activation. Choose any positive count required by "
                         "the task; there is no small fixed cap. Protocol-required "
                         "companions may be activated in addition to these query matches. "
                         "Other unreturned catalog tools remain hidden."
@@ -149,6 +177,7 @@ class ToolSearchTool(Tool):
         queries: list[str] | None = None,
         tool_names: list[str] | None = None,
         server_name: str | None = None,
+        connector: str | None = None,
         top_k: int = 1,
     ) -> ToolResult:
         normalized_server_name = (
@@ -166,13 +195,33 @@ class ToolSearchTool(Tool):
             for item in tool_names or []
             if isinstance(item, str) and item.strip()
         ]
+        normalized_connector = (
+            connector.strip()
+            if isinstance(connector, str) and connector.strip()
+            else None
+        )
         search_input = {
             "query": query,
             "queries": normalized_queries,
             "tool_names": normalized_tool_names,
             "server_name": normalized_server_name,
+            "connector": normalized_connector,
         }
-        if not normalized_queries and not normalized_tool_names:
+        connector_direct = bool(
+            normalized_connector
+            and not normalized_server_name
+            and not normalized_queries
+            and not normalized_tool_names
+        )
+        server_direct = bool(
+            normalized_server_name and not normalized_queries and not normalized_tool_names
+        )
+        if (
+            not normalized_queries
+            and not normalized_tool_names
+            and not server_direct
+            and not connector_direct
+        ):
             payload = {
                 "success": False,
                 **search_input,
@@ -183,7 +232,7 @@ class ToolSearchTool(Tool):
                 "activated": [],
                 "conflicts": [],
                 "missing": [],
-                "notice": "Provide query, queries, or exact tool_names.",
+                "notice": "Provide query, queries, exact tool_names, server_name, or connector.",
             }
             return ToolResult(
                 success=False,
@@ -206,10 +255,37 @@ class ToolSearchTool(Tool):
         # callers keep the existing readiness wait, including explicit server queries.
         mcp_ready = (
             not self._catalog.loading
-            if self._local_tools_provider is not None and normalized_server_name is None
+            if (
+                self._local_tools_provider is not None
+                and normalized_server_name is None
+                and normalized_connector is None
+            )
             else await self._catalog.wait_until_ready(self._readiness_timeout)
         )
-        scoped_locals = local_tools if normalized_server_name is None else {}
+
+        resolved_connector_id = (
+            self._catalog.resolve_connector_id(
+                normalized_connector,
+                entry_filter=self._entry_is_allowed,
+            )
+            if normalized_connector
+            else None
+        )
+
+        def entry_is_in_scope(entry) -> bool:
+            if not self._entry_is_allowed(entry):
+                return False
+            if normalized_connector and (
+                resolved_connector_id is None
+                or entry.connector_id != resolved_connector_id
+            ):
+                return False
+            return normalized_server_name is None or entry.server_name == normalized_server_name
+
+        search_input["resolved_connector_id"] = resolved_connector_id
+        scoped_locals = (
+            local_tools if normalized_server_name is None and normalized_connector is None else {}
+        )
         local_entries = {
             name: MCPToolEntry(
                 tool_id=f"local:{name}", model_name=name, server_name="",
@@ -219,15 +295,15 @@ class ToolSearchTool(Tool):
         }
         mcp_entries = tuple(
             entry for entry in self._catalog.snapshot()
-            if mcp_ready and (
-                normalized_server_name is None or entry.server_name == normalized_server_name
-            )
+            if mcp_ready and entry_is_in_scope(entry)
         )
         catalog_tool_count = len(mcp_entries) if mcp_ready else None
         missing: list[str] = []
         pending: list[str] = []
         hits: list[MCPToolEntry] = []
-        if normalized_tool_names:
+        if connector_direct or server_direct:
+            hits = list(mcp_entries)
+        elif normalized_tool_names:
             seen_ids = set()
             for requested_name in normalized_tool_names:
                 local = local_index.get(_normalize(requested_name))
@@ -238,6 +314,7 @@ class ToolSearchTool(Tool):
                 if mcp_ready:
                     matches.extend(self._catalog.lookup_exact(
                         [requested_name], server_name=normalized_server_name,
+                        entry_filter=entry_is_in_scope,
                     )[0])
                 if not matches:
                     (missing if mcp_ready else pending).append(requested_name)
@@ -249,12 +326,13 @@ class ToolSearchTool(Tool):
             hits = self._catalog.search_many(
                 normalized_queries, server_name=normalized_server_name, top_k=top_k,
                 entries=(*mcp_entries, *local_entries.values()),
+                entry_filter=entry_is_in_scope,
             )
         query_matched_count = sum(not entry.tool_id.startswith("local:") for entry in hits)
         local_matched_count = len(hits) - query_matched_count
         hit_ids = {entry.tool_id for entry in hits}
         companion_entries = []
-        if not normalized_tool_names:
+        if not normalized_tool_names and not server_direct and not connector_direct:
             for entry in tuple(hits):
                 if entry.tool_id.startswith("local:"):
                     continue
@@ -262,6 +340,7 @@ class ToolSearchTool(Tool):
                     companions, _ = self._catalog.lookup_exact(
                         [companion_name],
                         server_name=entry.server_name,
+                        entry_filter=entry_is_in_scope,
                     )
                     for companion in companions:
                         if companion.tool_id in hit_ids:
@@ -322,6 +401,9 @@ class ToolSearchTool(Tool):
                 {
                     "name": entry.model_name,
                     "server_name": entry.server_name,
+                    "connector_id": entry.connector_id,
+                    "connector_name": entry.connector_name,
+                    "remote_name": entry.remote_name,
                     "description": entry.description,
                     "already_active": already_active,
                 }
@@ -398,6 +480,7 @@ class MCPToolExposureManager:
         activated_local_tools: OrderedDict[str, Tool] | None = None,
         deferred_local_names_provider: Callable[[], frozenset[str]] | None = None,
         deferred_mcp: bool = True,
+        allowed_connector_ids_provider: Callable[[], frozenset[str]] | None = None,
     ) -> None:
         self._catalog = catalog
         self._activated = activated
@@ -406,6 +489,14 @@ class MCPToolExposureManager:
         )
         self._deferred_local_names_provider = deferred_local_names_provider
         self._deferred_mcp = deferred_mcp
+        self._allowed_connector_ids_provider = allowed_connector_ids_provider
+
+    def _entry_is_allowed(self, entry) -> bool:
+        if entry.connector_id is None:
+            return True
+        if self._allowed_connector_ids_provider is None:
+            return True
+        return entry.connector_id in self._allowed_connector_ids_provider()
 
     def prepare_tools(self, candidates: list[Tool]) -> ToolExposure:
         # ``candidates`` is the session's stable core-tool registry. Ordinary
@@ -438,6 +529,8 @@ class MCPToolExposureManager:
                 visible[tool.name] = tool
 
         for entry in self._catalog.snapshot() if self._deferred_mcp else ():
+            if not self._entry_is_allowed(entry):
+                continue
             if (
                 entry.name_conflict
                 or entry.model_name == TOOL_SEARCH_NAME
@@ -484,6 +577,8 @@ class MCPToolExposureManager:
         current = self._catalog.get_by_model_name(name)
         if current is None:
             return f"MCP tool '{name}' is unavailable or has a name conflict; search again."
+        if not self._entry_is_allowed(current):
+            return f"MCP tool '{name}' is not enabled for this conversation; search again."
         if current.generation != offered_generation:
             return f"MCP tool '{name}' changed after it was offered; search again."
         if (

--- a/box_agent/tools/safety.py
+++ b/box_agent/tools/safety.py
@@ -52,6 +52,7 @@ _RUNTIME_EXECUTABLE_FALLBACKS: dict[str, tuple[str, ...]] = {
     "BOX_AGENT_NPX": ("npx",),
     "BOX_AGENT_PYTHON": ("python3",),
     "BOX_AGENT_PYTHON3": ("python3",),
+    "BOX_AGENT_SOFFICE": ("soffice", "libreoffice"),
     "BOX_AGENT_SANDBOX_PYTHON": ("python3",),
     "BOX_AGENT_BUNDLED_PYTHON": ("python3",),
 }

--- a/box_agent/tools/setup.py
+++ b/box_agent/tools/setup.py
@@ -8,6 +8,7 @@ interactive-CLI surface.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from datetime import date
 from pathlib import Path
@@ -339,10 +340,19 @@ async def initialize_base_tools(
             user_skills_dir = state_path('skills')
             user_skills_dir.mkdir(parents=True, exist_ok=True)
 
-            # User skills take priority on ordinary name conflicts. Runtime-
-            # contract skills such as roadmap remain canonical builtin entries.
+            # Connector companion skills are owned by the Connector lifecycle,
+            # not by the user-facing SkillHub. Keeping them in a separate source
+            # lets the host hide them from manual Skill management while the
+            # model can still discover and load their workflow guidance.
+            connector_skills_dir = state_path("connectors/skills")
+            connector_skills_dir.mkdir(parents=True, exist_ok=True)
+
+            # Preserve the existing user-over-builtin precedence. Connector
+            # companion skills are an additional middle source, so adding the
+            # source cannot replace an already installed user Skill.
             sources = [
                 (user_skills_dir, "user"),
+                (connector_skills_dir, "connector"),
                 (builtin_dir, "builtin"),
             ]
 
@@ -373,7 +383,8 @@ async def initialize_base_tools(
                         return 0
                     _out(
                         f"{Colors.GREEN}✅ Loaded Skill tool (get_skill) — "
-                        f"user: {user_skills_dir}, builtin: {builtin_dir} "
+                        f"connector: {connector_skills_dir}, user: {user_skills_dir}, "
+                        f"builtin: {builtin_dir} "
                         f"({len(skills)} skills){Colors.RESET}"
                     )
                     return len(skills)
@@ -385,7 +396,8 @@ async def initialize_base_tools(
                     tools.extend(skill_tools)
                     _out(
                         f"{Colors.GREEN}✅ Loaded Skill tool (get_skill) — "
-                        f"user: {user_skills_dir}, builtin: {builtin_dir}{Colors.RESET}"
+                        f"connector: {connector_skills_dir}, user: {user_skills_dir}, "
+                        f"builtin: {builtin_dir}{Colors.RESET}"
                     )
                 else:
                     _out(f"{Colors.YELLOW}⚠️  No available Skills found{Colors.RESET}")
@@ -404,22 +416,45 @@ async def initialize_base_tools(
         # Keep CLI and ACP on the same user-owned configuration. Reconcile the
         # hosted search endpoint and any MCP servers advertised by the frozen
         # runtime before background discovery starts.
-        configured_mcp = Path(config.tools.mcp_config_path).expanduser()
+        host_mcp_config = os.environ.get("BOX_AGENT_MCP_CONFIG_PATH", "").strip()
+        configured_mcp = Path(host_mcp_config or config.tools.mcp_config_path).expanduser()
         bootstrap_target = (
             configured_mcp
             if configured_mcp.is_absolute()
             else state_path('config/mcp.json')
         )
-        if configured_box_agent_home() is not None:
-            bootstrap_target = state_path("config/mcp.json", bootstrap_target)
-        bootstrap = bootstrap_managed_mcp_config(bootstrap_target)
-        if bootstrap.warning:
-            _out(f"{Colors.YELLOW}⚠️  {bootstrap.warning}{Colors.RESET}")
-        mcp_config_path = (
-            bootstrap.path
-            if bootstrap.path.exists()
-            else Config.find_config_file(config.tools.mcp_config_path)
-        )
+        if host_mcp_config:
+            if configured_box_agent_home() is not None:
+                bootstrap_target = state_path("config/mcp.json", bootstrap_target)
+            isolated_source_paths = [
+                (
+                    state_path("config/mcp.json", Path(value).expanduser())
+                    if configured_box_agent_home() is not None
+                    else Path(value).expanduser()
+                )
+                for value in (
+                    os.environ.get("BOX_AGENT_USER_MCP_CONFIG_PATH", "").strip(),
+                    os.environ.get("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", "").strip(),
+                    os.environ.get("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", "").strip(),
+                )
+                if value
+            ]
+            mcp_config_path = (
+                bootstrap_target
+                if bootstrap_target.exists() or any(path.exists() for path in isolated_source_paths)
+                else None
+            )
+        else:
+            if configured_box_agent_home() is not None:
+                bootstrap_target = state_path("config/mcp.json", bootstrap_target)
+            bootstrap = bootstrap_managed_mcp_config(bootstrap_target)
+            if bootstrap.warning:
+                _out(f"{Colors.YELLOW}⚠️  {bootstrap.warning}{Colors.RESET}")
+            mcp_config_path = (
+                bootstrap.path
+                if bootstrap.path.exists()
+                else Config.find_config_file(config.tools.mcp_config_path)
+            )
         if mcp_config_path:
             get_mcp_tool_catalog().mark_loading()
             _out(f"{Colors.BRIGHT_CYAN}Loading MCP tools in background (from: {mcp_config_path})...{Colors.RESET}")
@@ -555,6 +590,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
                         llm=None, permission_engine: PermissionEngine | None = None,
                         skill_runtime_context: SkillRuntimeContext | None = None,
                         skill_loader=None, capability_state_provider=None,
+                        skill_access_filter=None,
                         env_context=None,
                         process_owner_id: str | None = None,
                         bypass_dangerous_command_approval: bool = False):
@@ -576,6 +612,7 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
         skill_runtime_context: Runtime env to expose to subprocess-backed tools
         skill_loader: Current live SkillLoader for explicit child Skill selection
         capability_state_provider: Read-only callable returning MCP loading/ready state
+        skill_access_filter: Conversation-specific gate for child Skill selection
         process_owner_id: Optional ACP session identifier used to scope and
             reclaim background shell processes.
         bypass_dangerous_command_approval: Skip dangerous-command approval for
@@ -787,6 +824,8 @@ def add_workspace_tools(tools: List[Tool], config: Config, workspace_dir: Path, 
         )
         if skill_loader is not None:
             sub_agent_tool.set_skill_provider(lambda: skill_loader)
+        if skill_access_filter is not None:
+            sub_agent_tool.set_skill_access_filter(skill_access_filter)
         if capability_state_provider is not None:
             sub_agent_tool.set_capability_state_provider(capability_state_provider)
         tools.append(sub_agent_tool)

--- a/box_agent/tools/skill_loader.py
+++ b/box_agent/tools/skill_loader.py
@@ -17,13 +17,13 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import yaml
 
 from box_agent.user_paths import state_path
 
-SkillSource = Literal["builtin", "user"]
+SkillSource = Literal["builtin", "connector", "user"]
 
 MANIFEST_FILENAME = "_manifest.json"
 RESERVED_BUILTIN_SKILL_NAMES = frozenset({"roadmap"})
@@ -118,6 +118,8 @@ class Skill:
     description: str
     content: str
     source: SkillSource = "builtin"
+    owner_id: Optional[str] = None
+    disabled: bool = False
     license: Optional[str] = None
     allowed_tools: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
@@ -172,6 +174,8 @@ All files and references in this skill are relative to this directory.
             "name": self.name,
             "description": self.description,
             "source": self.source,
+            "ownerId": self.owner_id,
+            "disabled": self.disabled,
             "path": str(self.skill_path) if self.skill_path else None,
             "allowed_tools": self.allowed_tools or [],
             "required_skills": self.required_skills or [],
@@ -450,11 +454,26 @@ class SkillLoader:
                     ),
                 )
             )
+            owner_id = None
+            if source == "connector":
+                connector_dir = next(
+                    (
+                        parent.name
+                        for parent in skill_path.parents
+                        if parent.name.startswith("connector-")
+                    ),
+                    None,
+                )
+                if connector_dir:
+                    owner_id = connector_dir.removeprefix("connector-")
+
             return Skill(
                 name=frontmatter["name"],
                 description=frontmatter["description"],
                 content=processed_content,
                 source=source,
+                owner_id=owner_id,
+                disabled=source == "connector" and frontmatter.get("disable") is True,
                 license=frontmatter.get("license"),
                 allowed_tools=allowed_tools,
                 metadata=metadata,
@@ -563,7 +582,7 @@ class SkillLoader:
 
                 self._all_skills[skill.name] = skill
 
-                if skill.name in disabled_skill_names:
+                if skill.disabled or skill.name in disabled_skill_names:
                     self.loaded_skills.pop(skill.name, None)
                     continue
 
@@ -818,7 +837,12 @@ class SkillLoader:
         """List all loaded skill names."""
         return list(self._skill_pool(include_disabled=include_disabled).keys())
 
-    def list_skills_metadata(self, *, include_disabled: bool = False) -> List[Dict[str, object]]:
+    def list_skills_metadata(
+        self,
+        *,
+        include_disabled: bool = False,
+        include_connector: bool = True,
+    ) -> List[Dict[str, object]]:
         """Return structured metadata for every loaded skill.
 
         Intended for officev3 / ACP `_meta.skills` payloads.
@@ -826,6 +850,7 @@ class SkillLoader:
         return [
             skill.to_metadata_dict()
             for skill in self._skill_pool(include_disabled=include_disabled).values()
+            if include_connector or skill.source != "connector"
         ]
 
     def filter_by_query(
@@ -835,6 +860,7 @@ class SkillLoader:
         always_on: frozenset[str] = frozenset({"memory-guide"}),
         max_skills: int = 16,
         include_disabled: bool = False,
+        skill_filter: Callable[[Skill], bool] | None = None,
     ) -> List[Skill]:
         """Return skills relevant to ``query`` plus the always_on set.
 
@@ -849,7 +875,11 @@ class SkillLoader:
         This is intentional: greetings like "hi" / "你好" should NOT trigger
         the full skill catalog injection.
         """
-        skill_pool = self._skill_pool(include_disabled=include_disabled)
+        skill_pool = {
+            name: skill
+            for name, skill in self._skill_pool(include_disabled=include_disabled).items()
+            if skill_filter is None or skill_filter(skill)
+        }
         always_skills = [s for s in skill_pool.values() if s.name in always_on]
 
         if not query or not query.strip():
@@ -916,6 +946,7 @@ class SkillLoader:
         query: Optional[str] = None,
         *,
         include_disabled: bool = False,
+        skill_filter: Callable[[Skill], bool] | None = None,
     ) -> str:
         """Generate a metadata-only prompt for Progressive Disclosure Level 1.
 
@@ -924,7 +955,11 @@ class SkillLoader:
         ``None``, all loaded skills are listed (legacy behavior — kept so
         callers that have not adopted filtering still work).
         """
-        skill_pool = self._skill_pool(include_disabled=include_disabled)
+        skill_pool = {
+            name: skill
+            for name, skill in self._skill_pool(include_disabled=include_disabled).items()
+            if skill_filter is None or skill_filter(skill)
+        }
         if not skill_pool:
             return ""
 
@@ -934,6 +969,7 @@ class SkillLoader:
             skills_to_render = self.filter_by_query(
                 query,
                 include_disabled=include_disabled,
+                skill_filter=skill_filter,
             )
 
         prompt_parts = ["## Available Skills\n"]
@@ -1019,14 +1055,22 @@ class SkillSelector:
 
     SLOT = SKILL_SLOT_SENTINEL
 
-    def __init__(self, skill_loader: "SkillLoader", *, include_disabled: bool = False) -> None:
+    def __init__(
+        self,
+        skill_loader: "SkillLoader",
+        *,
+        include_disabled: bool = False,
+        skill_filter: Callable[[Skill], bool] | None = None,
+    ) -> None:
         self._loader = skill_loader
         self._include_disabled = include_disabled
+        self._skill_filter = skill_filter
         self._prefix: Optional[str] = None
         self._suffix: Optional[str] = None
         self._cumulative: List[str] = []
         self._last_sig: Tuple[str, ...] = ()
         self._last_matched_names: Tuple[str, ...] = ()
+        self._sticky_skill_names: Set[str] = set()
 
     @property
     def bound(self) -> bool:
@@ -1079,16 +1123,24 @@ class SkillSelector:
             sig: Tuple[str, ...] = ()
             matched_names: Tuple[str, ...] = ()
         else:
+            def visible(skill: Skill) -> bool:
+                return skill.name in self._sticky_skill_names or (
+                    self._skill_filter is None or self._skill_filter(skill)
+                )
+
             skills = self._loader.filter_by_query(
                 query,
                 include_disabled=self._include_disabled,
+                skill_filter=visible,
             )
             matched_names = tuple(s.name for s in skills)
+            self._sticky_skill_names.update(matched_names)
             sig = tuple(sorted(matched_names))
             if skills:
                 skills_md = self._loader.get_skills_metadata_prompt(
                     query=query,
                     include_disabled=self._include_disabled,
+                    skill_filter=visible,
                 )
             else:
                 skills_md = ""

--- a/box_agent/tools/skill_tool.py
+++ b/box_agent/tools/skill_tool.py
@@ -6,12 +6,12 @@ Implements Progressive Disclosure (Level 2): Load full skill content when needed
 
 from pathlib import Path
 from hashlib import sha256
-from typing import Any, Dict, List, Literal, Mapping, MutableSet, Optional, Tuple
+from typing import Any, Callable, Dict, List, Literal, Mapping, MutableSet, Optional, Tuple
 
 from .base import Tool, ToolResult
 from .skill_loader import SkillLoader
 
-SkillSource = Literal["builtin", "user"]
+SkillSource = Literal["builtin", "connector", "user"]
 
 
 class GetSkillTool(Tool):
@@ -28,12 +28,14 @@ class GetSkillTool(Tool):
         preloaded_skill_hashes: Mapping[str, str] | None = None,
         blocked_skill_names: set[str] | frozenset[str] | None = None,
         explicitly_allowed_skill_names: MutableSet[str] | None = None,
+        skill_access_filter: Callable[[Any], bool] | None = None,
     ):
         self.skill_loader = skill_loader
         self.include_disabled = include_disabled
         self.preloaded_skill_hashes = preloaded_skill_hashes
         self.blocked_skill_names = blocked_skill_names or frozenset()
         self.explicitly_allowed_skill_names = explicitly_allowed_skill_names
+        self.skill_access_filter = skill_access_filter
 
     @property
     def name(self) -> str:
@@ -98,6 +100,16 @@ class GetSkillTool(Tool):
                 error=f"Skill '{skill_name}' does not exist. Available skills: {available}",
             )
 
+        if self.skill_access_filter is not None and not self.skill_access_filter(skill):
+            return ToolResult(
+                success=False,
+                content="",
+                error=(
+                    f"Skill '{skill.name}' is not enabled for this conversation. "
+                    "Connector Skills can only be enabled through the conversation connector picker."
+                ),
+            )
+
         # A broken skill (SKILL.md present but unparseable) returns a
         # diagnostic prompt so the model doesn't invent guidance from a
         # directory name it can't verify. Success is True — this is a real
@@ -137,7 +149,7 @@ def create_skill_tools(
     Args:
         skills_dir: Legacy single-directory entry (treated as builtin).
         sources: Ordered list of (directory, source_label) tuples. Earlier entries
-            win on name conflicts (e.g. user → builtin).
+            win on name conflicts (e.g. user → connector → builtin).
         defer_discovery: If True, skip the inline ``discover_skills()`` call
             and let the caller schedule discovery on a background task. The
             returned ``GetSkillTool`` still binds to the loader — once the

--- a/box_agent/tools/sub_agent_capabilities.py
+++ b/box_agent/tools/sub_agent_capabilities.py
@@ -12,7 +12,7 @@ checks remain the final resource-level authority.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from ..config import ToolLimitsConfig
 from .base import Tool
@@ -539,10 +539,11 @@ class CapabilityResolver:
         *,
         parent_tools: Mapping[str, Tool],
         skill_loader: Any | None = None,
+        skill_access_filter: Callable[[Any], bool] | None = None,
         capability_state: Any = "ready",
         permission_negotiator_available: bool = False,
     ) -> ResolvedCapabilityBundle | CapabilityFailure:
-        skills_or_failure = self._resolve_skills(spec, skill_loader)
+        skills_or_failure = self._resolve_skills(spec, skill_loader, skill_access_filter)
         if isinstance(skills_or_failure, CapabilityFailure):
             return skills_or_failure
         skills = skills_or_failure
@@ -622,6 +623,7 @@ class CapabilityResolver:
         self,
         spec: DelegationSpec,
         skill_loader: Any | None,
+        skill_access_filter: Callable[[Any], bool] | None,
     ) -> tuple[Any, ...] | CapabilityFailure:
         if not spec.skill_names:
             return ()
@@ -669,6 +671,16 @@ class CapabilityResolver:
                 return CapabilityFailure(
                     code="SKILL_NOT_FOUND",
                     message=f"Required Skill '{name}' was not found.",
+                    retryable=False,
+                    details={"skill": name},
+                )
+            if skill_access_filter is not None and not skill_access_filter(skill):
+                return CapabilityFailure(
+                    code="SKILL_NOT_ENABLED_FOR_CONVERSATION",
+                    message=(
+                        f"Required Skill '{name}' is not enabled for this conversation. "
+                        "Connector Skills must be enabled from the conversation connector picker."
+                    ),
                     retryable=False,
                     details={"skill": name},
                 )

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -286,6 +286,7 @@ class SubAgentTool(EventEmittingTool):
         # ``register_mcp_tools`` mutates in place) is built.
         self._tool_provider: Callable[[], dict[str, Tool]] | None = None
         self._skill_provider: Callable[[], Any] | None = None
+        self._skill_access_filter: Callable[[Any], bool] | None = None
         self._capability_state_provider: Callable[[], Any] | None = None
         self._permission_negotiator: Any | None = None
         self._workspace_dir = workspace_dir
@@ -362,6 +363,10 @@ class SubAgentTool(EventEmittingTool):
     def set_skill_provider(self, provider: Callable[[], Any]) -> None:
         """Wire a callable returning the current live SkillLoader."""
         self._skill_provider = provider
+
+    def set_skill_access_filter(self, skill_access_filter: Callable[[Any], bool]) -> None:
+        """Restrict child Skill requests to the parent conversation's grants."""
+        self._skill_access_filter = skill_access_filter
 
     def set_capability_state_provider(self, provider: Callable[[], Any]) -> None:
         """Wire a read-only provider for capability loading readiness."""
@@ -1349,6 +1354,7 @@ class SubAgentTool(EventEmittingTool):
             parsed,
             parent_tools=live_tools,
             skill_loader=self._resolve_skill_loader(),
+            skill_access_filter=self._skill_access_filter,
             capability_state=self._resolve_capability_state(),
             permission_negotiator_available=self._permission_negotiator is not None,
         )

--- a/docs/CONNECTOR_RUNTIME_RESTORE.md
+++ b/docs/CONNECTOR_RUNTIME_RESTORE.md
@@ -10,9 +10,15 @@ connectors, including their removals. Other connectors and system/user sources
 are untouched. Without the filter, it replaces the complete connector source.
 Hosts should use scoped updates for provider-specific credential refresh,
 connect/disconnect and enable/disable operations.
+An incoming server name cannot replace a server belonging to a connector outside
+the filter. Removing a connector revokes its live connection even when a lower
+priority user definition has the same name; that user source requires its own
+reconciliation before activation.
 
 Servers declaring `credentialRef` wait without creating a transport until the
-host provides that credential. Resolving or reconnecting one server must not
+host provides that credential. Only connector-owned definitions may reference
+these credentials; system/user definitions with `credentialRef` are rejected
+before creating a transport. Resolving or reconnecting one server must not
 advance another server's credential/configuration fingerprint: a later
 credential update must still cause that other server to reconnect.
 Independent servers start concurrently, with their existing per-server timeout
@@ -21,6 +27,10 @@ and reconnect lock. Source-level updates remain serialized.
 Reapplying unchanged configuration retries servers whose last connection failed,
 without restarting healthy or still-loading servers. The returned success value
 reflects that new attempt, including another failure.
+
+Conversation connector authorization applies to eager and deferred tools,
+including child inheritance and calls after a selection is revoked. Catalog
+refreshes never add tools to utility sessions, including background discovery.
 
 Changing this contract requires rebuilding the packaged ACP runtime and testing
 host startup, mixed OAuth/token restoration and process restart. Source tests

--- a/docs/CONNECTOR_RUNTIME_RESTORE.md
+++ b/docs/CONNECTOR_RUNTIME_RESTORE.md
@@ -1,0 +1,27 @@
+# Host-managed connector restoration
+
+Connector credentials are process-local. A desktop host must restore them with
+`_mcp/credential/set` after every ACP process initialization, before publishing
+the connector source. Never put secrets in source snapshots or status payloads.
+
+`_mcp/source/replace` accepts optional `connectorIds: string[]` for the connector
+source. With this non-empty filter, it replaces only servers owned by those
+connectors, including their removals. Other connectors and system/user sources
+are untouched. Without the filter, it replaces the complete connector source.
+Hosts should use scoped updates for provider-specific credential refresh,
+connect/disconnect and enable/disable operations.
+
+Servers declaring `credentialRef` wait without creating a transport until the
+host provides that credential. Resolving or reconnecting one server must not
+advance another server's credential/configuration fingerprint: a later
+credential update must still cause that other server to reconnect.
+Independent servers start concurrently, with their existing per-server timeout
+and reconnect lock. Source-level updates remain serialized.
+
+Reapplying unchanged configuration retries servers whose last connection failed,
+without restarting healthy or still-loading servers. The returned success value
+reflects that new attempt, including another failure.
+
+Changing this contract requires rebuilding the packaged ACP runtime and testing
+host startup, mixed OAuth/token restoration and process restart. Source tests
+do not validate saved credentials or connectivity to real providers.

--- a/docs/CONNECTOR_RUNTIME_RESTORE.md
+++ b/docs/CONNECTOR_RUNTIME_RESTORE.md
@@ -22,7 +22,16 @@ before creating a transport. Resolving or reconnecting one server must not
 advance another server's credential/configuration fingerprint: a later
 credential update must still cause that other server to reconnect.
 Independent servers start concurrently, with their existing per-server timeout
-and reconnect lock. Source-level updates remain serialized.
+and reconnect lock. Removal and disable operations share that server's reconnect
+lock and return only after its pending connection is revoked; they do not hold
+up independent servers in the update. Source-level updates remain serialized.
+Connector readiness counts only servers in the current configuration, so a
+removed server's historical status does not block the remaining healthy servers.
+Missing status for a currently configured server still prevents authorization.
+Source updates wait for initial discovery, including its startup gate, before
+mutating configuration. A readiness timeout returns failure with state unchanged;
+the host can retry after startup completes. Ordinary hot reconnects do not impose
+this startup barrier on other servers.
 
 Reapplying unchanged configuration retries servers whose last connection failed,
 without restarting healthy or still-loading servers. The returned success value

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -421,6 +421,8 @@ def build_runtime_manifest(
         "entry": entry_path,
         "mode": "standalone",
         "managed_mcp_config_version": MANAGED_MCP_CONFIG_VERSION,
+        "connector_skill_sources_version": 1,
+        "mcp_multi_source_version": 1,
         "external_python_sandbox": external_python_sandbox,
         "bundled_stable_runtimes": list(bundled_components),
         "mcp_servers": {

--- a/tests/fixtures/tool_engine/connector_search_schema.json
+++ b/tests/fixtures/tool_engine/connector_search_schema.json
@@ -1,0 +1,40 @@
+{
+  "name": "tool_search",
+  "description": "Search allowed local utilities and the connected deferred MCP catalog by capability. Local utilities include file append, diagnostics, plans, progress, goals, memory, scheduling and integrations when available. Every hit returned by this call is immediately activated for this session and only those activated hits are added to the next model step; other deferred catalog tools are not exposed, while alwaysLoad tools remain visible without search. Use query for one keyword search, queries for independent bilingual or synonymous searches, or tool_names to activate only exact catalog IDs, model-facing names, or unique original MCP names. Passing only server_name activates all tools from that one enabled server. Provide at least one non-empty query, queries, tool_names, server_name, or connector input; they may be combined. Prefer short capability, server, connector, or tool keywords; task-specific operands are tolerated but should be omitted when possible. Passing only connector activates all tools owned by the uniquely matched enabled connector. Set top_k to however many matching tool schemas the task actually needs, including ten or more when appropriate. A query hit may activate a protocol-required companion, such as the snapshot paired with managed browser navigation, in addition to top_k. The response reports catalog_tool_count for the applied server scope, matched_count after query limits, and activated_count after conflict filtering; these counts remain MCP-only, with local counts reported separately. server_name selects only MCP tools. Never infer the catalog total from top_k or matched_count. This search activates tools but does not execute them.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "One capability, action, server, or tool keyword query. Kept for compatibility; prefer queries for independent alternatives."
+      },
+      "queries": {
+        "type": "array",
+        "items": { "type": "string" },
+        "minItems": 1,
+        "description": "Independent keyword queries merged by each tool's best relevance. Use separate Chinese, English, synonym, or exact capability phrases. Prefix matches are supported and unmatched task operands are tolerated."
+      },
+      "tool_names": {
+        "type": "array",
+        "items": { "type": "string" },
+        "minItems": 1,
+        "description": "Exact tool IDs, model-facing names, or unique original MCP names to activate, such as mcp:server/tool, server/tool, or an MCP tools/list name. No fuzzy fallback is used, and unlisted catalog tools remain hidden."
+      },
+      "server_name": {
+        "type": "string",
+        "description": "Exact internal MCP server name. On its own, activates all tools from that enabled server; with query, connector, or tool_names, it narrows the normal discovery scope."
+      },
+      "connector": {
+        "type": "string",
+        "description": "Connector ID or unique display-name text from <connector-status>, such as pkulaw or \u5317\u5927\u6cd5\u5b9d. On its own, activates all tools owned by that enabled connector; with query, server_name, or tool_names, it narrows the normal discovery scope."
+      },
+      "top_k": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 1,
+        "description": "Exact maximum number of query matches to return and activate; ignored for tool_names and server-only activation. Choose any positive count required by the task; there is no small fixed cap. Protocol-required companions may be activated in addition to these query matches. Other unreturned catalog tools remain hidden."
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1496,6 +1496,7 @@ async def test_acp_restarts_with_same_product_session_from_jsonl(
     monkeypatch,
 ):
     monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path))
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=2, workspace_dir=str(tmp_path)),
@@ -2642,6 +2643,7 @@ async def test_acp_seeds_negotiated_session_continuation_once(
     monkeypatch,
 ):
     monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path / "profile"))
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
     agent, _ = acp_agent
     session = await agent.newSession(
         SimpleNamespace(
@@ -3857,7 +3859,8 @@ async def test_acp_turn_cleanup_preserves_running_session_scratch(
     class ConcurrentLLM(DoneLLM):
         async def generate_stream(self, messages, tools=None, **kwargs):
             if any(
-                message.role == "user" and message.content == "keep running"
+                message.role == "user"
+                and message.content == "keep running" + _EMPTY_CONNECTOR_CONTEXT
                 for message in messages
             ):
                 second_started.set()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1497,6 +1497,7 @@ async def test_acp_restarts_with_same_product_session_from_jsonl(
 ):
     monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path))
     monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_SKILL_TOOLS_ROOT", raising=False)
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=2, workspace_dir=str(tmp_path)),
@@ -2644,6 +2645,7 @@ async def test_acp_seeds_negotiated_session_continuation_once(
 ):
     monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path / "profile"))
     monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_SKILL_TOOLS_ROOT", raising=False)
     agent, _ = acp_agent
     session = await agent.newSession(
         SimpleNamespace(

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -21,6 +21,11 @@ import box_agent.composition as composition_module
 import box_agent.runtime as runtime_module
 from box_agent.acp import (
     BoxACPAgent,
+    _connected_connector_ids,
+    _connector_ids_from_meta,
+    _connector_status_context,
+    _connector_status_unavailable_from_meta,
+    _connector_statuses_from_meta,
     _inject_item_id,
     _latest_user_request_for_plan_detection,
     _looks_like_plan_approval_text,
@@ -252,6 +257,96 @@ def test_acp_normalizes_structured_user_decision_response_meta():
         "custom_text": "",
         "trigger": "timeout",
     }
+
+
+def test_acp_normalizes_connector_selection_and_renders_session_scoped_status(monkeypatch):
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_connector_server_names",
+        lambda: {
+            "pkulaw": frozenset({"pkulaw-law-search-semantic", "pkulaw-citation"}),
+            "qixin": frozenset({"qixin-huiyan"}),
+        },
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_status",
+        lambda: [
+            {
+                "owner": "connector",
+                "connectorId": "pkulaw",
+                "connectorName": "北大法宝",
+                "name": "pkulaw-law-search-semantic",
+                "state": "connected",
+            },
+            {
+                "owner": "connector",
+                "connectorId": "pkulaw",
+                "connectorName": "北大法宝",
+                "name": "pkulaw-citation",
+                "state": "connected",
+            },
+            {
+                "owner": "connector",
+                "connectorId": "qixin",
+                "connectorName": "启信慧眼",
+                "name": "qixin-huiyan",
+                "state": "error",
+            },
+        ],
+    )
+
+    assert _connector_ids_from_meta({"selected_connector_ids": [" PKULAW ", "pkulaw"]}) == {
+        "pkulaw"
+    }
+    assert _connector_status_context({"pkulaw", "qixin"}) == (
+        "<connector-status>\n"
+        "pkulaw 北大法宝: connected\n"
+        "qixin 启信慧眼: disconnected\n"
+        "</connector-status>"
+    )
+    connector_statuses = _connector_statuses_from_meta(
+        {
+            "connector_statuses": [
+                {"id": "qixin", "name": "启信慧眼", "status": "disconnected"},
+                {"id": "pkulaw", "name": "北大法宝", "status": "connected"},
+            ]
+        }
+    )
+    assert connector_statuses == (
+        ("qixin", "启信慧眼", "disconnected"),
+        ("pkulaw", "北大法宝", "connected"),
+    )
+    assert _connector_status_context({"pkulaw"}, connector_statuses) == (
+        "<connector-status>\n"
+        "qixin 启信慧眼: disconnected\n"
+        "pkulaw 北大法宝: connected\n"
+        "</connector-status>"
+    )
+    assert _connector_status_unavailable_from_meta(
+        {"connector_status_unavailable": True}
+    ) is True
+    assert _connector_status_context(
+        {"pkulaw"}, connector_statuses, connector_status_unavailable=True
+    ) == (
+        "<connector-status>\n"
+        "status: unavailable\n"
+        "连接器状态读取失败，请勿沿用之前轮次的连接状态。\n"
+        "</connector-status>"
+    )
+    assert _connected_connector_ids({"pkulaw", "qixin"}) == frozenset({"pkulaw"})
+    with pytest.raises(ValueError, match="invalid connector id"):
+        _connector_ids_from_meta({"selected_connector_ids": ["pkulaw.connector"]})
+    with pytest.raises(ValueError, match="invalid status"):
+        _connector_statuses_from_meta(
+            {
+                "connector_statuses": [
+                    {"id": "pkulaw", "name": "北大法宝", "status": "connecting"}
+                ]
+            }
+        )
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _connector_status_unavailable_from_meta(
+            {"connector_status_unavailable": "yes"}
+        )
     assert _user_decision_response_from_meta(
         {
             "user_decision": {
@@ -268,6 +363,98 @@ def test_acp_normalizes_structured_user_decision_response_meta():
         "custom_text": "突出年度案例",
         "trigger": "user",
     }
+
+
+def test_acp_marks_multi_server_connector_disconnected_when_any_server_is_down(monkeypatch):
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_connector_server_names",
+        lambda: {"pkulaw": frozenset({"pkulaw-search", "pkulaw-citation"})},
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_status",
+        lambda: [
+            {
+                "owner": "connector",
+                "connectorId": "pkulaw",
+                "connectorName": "北大法宝",
+                "name": "pkulaw-search",
+                "state": "connected",
+            },
+            {
+                "owner": "connector",
+                "connectorId": "pkulaw",
+                "connectorName": "北大法宝",
+                "name": "pkulaw-citation",
+                "state": "failed",
+            },
+        ],
+    )
+
+    assert _connector_status_context({"pkulaw"}) == (
+        "<connector-status>\npkulaw 北大法宝: disconnected\n</connector-status>"
+    )
+    assert _connected_connector_ids({"pkulaw"}) == frozenset()
+
+
+def test_acp_marks_multi_server_connector_disconnected_when_a_status_is_missing(monkeypatch):
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_connector_server_names",
+        lambda: {"pkulaw": frozenset({"pkulaw-search", "pkulaw-citation"})},
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_status",
+        lambda: [
+            {
+                "owner": "connector",
+                "connectorId": "pkulaw",
+                "connectorName": "北大法宝",
+                "name": "pkulaw-search",
+                "state": "connected",
+            }
+        ],
+    )
+
+    assert _connector_status_context({"pkulaw"}) == (
+        "<connector-status>\npkulaw 北大法宝: disconnected\n</connector-status>"
+    )
+    assert _connected_connector_ids({"pkulaw"}) == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_acp_session_metadata_hides_physically_isolated_connector_skills(tmp_path):
+    builtin_root = tmp_path / "builtin-skills"
+    connector_root = tmp_path / "connector-skills"
+    for root, name, description in (
+        (builtin_root, "ordinary-skill", "Ordinary visible Skill"),
+        (connector_root, "pkulaw", "Internal connector Skill"),
+    ):
+        skill_dir = root / name
+        skill_dir.mkdir(parents=True)
+        skill_dir.joinpath("SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {description}\n---\n\nInstructions.\n",
+            encoding="utf-8",
+        )
+    skill_loader = SkillLoader(
+        sources=[(builtin_root, "builtin"), (connector_root, "connector")]
+    )
+    skill_loader.discover_skills()
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(
+        DummyConn(),
+        config,
+        DummyLLM(),
+        [],
+        "system",
+        skill_loader=skill_loader,
+    )
+
+    session = await agent.newSession(SimpleNamespace(cwd=str(tmp_path), field_meta={}))
+
+    assert [item["name"] for item in session.field_meta["skills"]] == ["ordinary-skill"]
 
 
 @pytest.mark.asyncio
@@ -1157,6 +1344,147 @@ class DoneLLM:
 
     async def generate(self, messages, tools=None):
         return LLMResponse(content="done", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+async def test_acp_appends_connector_status_to_every_user_turn(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_connector_server_names",
+        lambda: {"pkulaw": frozenset({"pkulaw-law-search-semantic"})},
+    )
+    monkeypatch.setattr(
+        "box_agent.acp.get_mcp_status",
+        lambda: [
+            {
+                "owner": "connector",
+                "connectorId": "pkulaw",
+                "connectorName": "北大法宝",
+                "name": "pkulaw-law-search-semantic",
+                "state": "connected",
+            }
+        ],
+    )
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=2, workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(tmp_path),
+            field_meta={
+                "selected_connector_ids": ["pkulaw"],
+                "connector_statuses": [
+                    {"id": "qixin", "name": "启信慧眼", "status": "disconnected"},
+                    {"id": "pkulaw", "name": "北大法宝", "status": "connected"},
+                ],
+            },
+        )
+    )
+
+    await agent.prompt(
+        SimpleNamespace(sessionId=session.sessionId, prompt=[{"text": "first"}], field_meta={})
+    )
+    await agent.prompt(
+        SimpleNamespace(
+            sessionId=session.sessionId,
+            prompt=[{"text": "second"}],
+            field_meta={
+                "selected_connector_ids": [],
+                "connector_statuses": [
+                    {"id": "qixin", "name": "启信慧眼", "status": "disconnected"},
+                    {"id": "pkulaw", "name": "北大法宝", "status": "disconnected"},
+                ],
+            },
+        )
+    )
+
+    messages = agent._sessions[session.sessionId].agent.messages
+    assert messages[-4].content == (
+        "first\n\n<connector-status>\n"
+        "qixin 启信慧眼: disconnected\n"
+        "pkulaw 北大法宝: connected\n"
+        "</connector-status>"
+    )
+    assert messages[-2].content == (
+        "second\n\n<connector-status>\n"
+        "qixin 启信慧眼: disconnected\n"
+        "pkulaw 北大法宝: disconnected\n"
+        "</connector-status>"
+    )
+    session_log = agent._sessions[session.sessionId].agent.session_log
+    if session_log is not None:
+        session_log.close()
+
+
+@pytest.mark.asyncio
+async def test_acp_replaces_stale_connector_snapshot_when_host_status_is_unavailable(
+    tmp_path,
+):
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(max_steps=2, workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
+    session = await agent.newSession(
+        SimpleNamespace(
+            cwd=str(tmp_path),
+            field_meta={
+                "selected_connector_ids": ["pkulaw"],
+                "connector_statuses": [
+                    {"id": "pkulaw", "name": "北大法宝", "status": "connected"}
+                ],
+            },
+        )
+    )
+
+    await agent.prompt(
+        SimpleNamespace(
+            sessionId=session.sessionId,
+            prompt=[{"text": "北大法宝还能用么"}],
+            field_meta={"connector_status_unavailable": True},
+        )
+    )
+
+    state = agent._sessions[session.sessionId]
+    assert state.connector_statuses is None
+    assert state.connector_status_unavailable is True
+    assert state.agent.messages[-2].content == (
+        "北大法宝还能用么\n\n"
+        "<connector-status>\n"
+        "status: unavailable\n"
+        "连接器状态读取失败，请勿沿用之前轮次的连接状态。\n"
+        "</connector-status>"
+    )
+
+    await agent.prompt(
+        SimpleNamespace(
+            sessionId=session.sessionId,
+            prompt=[{"text": "现在呢"}],
+            field_meta={
+                "connector_statuses": [
+                    {
+                        "id": "pkulaw",
+                        "name": "北大法宝",
+                        "status": "disconnected",
+                    }
+                ]
+            },
+        )
+    )
+
+    assert state.connector_statuses == (("pkulaw", "北大法宝", "disconnected"),)
+    assert state.connector_status_unavailable is False
+    assert state.agent.messages[-2].content == (
+        "现在呢\n\n"
+        "<connector-status>\n"
+        "pkulaw 北大法宝: disconnected\n"
+        "</connector-status>"
+    )
+    if state.agent.session_log is not None:
+        state.agent.session_log.close()
 
 
 @pytest.mark.asyncio
@@ -2152,6 +2480,90 @@ async def test_mcp_reconnect_injects_hidden_deferred_state_into_active_turns_onl
     assert "alwaysLoad tool(s) are already visible" in update["content"]
     assert "tool_search" in update["content"]
     assert inactive_state.inject_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_mcp_credential_set_keeps_secret_out_of_result(tmp_path, monkeypatch):
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [], "system")
+    captured = {}
+
+    def set_credential(credential_ref, headers):
+        captured.update({"credentialRef": credential_ref, "headers": headers})
+        return ["law"]
+
+    monkeypatch.setattr(
+        "box_agent.tools.mcp_loader.set_mcp_runtime_credential",
+        set_credential,
+    )
+
+    result = await agent.extMethod(
+        "mcp/credential/set",
+        {
+            "credentialRef": "connector:pkulaw:default",
+            "headers": {"Authorization": "Bearer secret"},
+        },
+    )
+
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert result == {"success": True, "affectedServers": ["law"]}
+    assert "secret" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_mcp_reconcile_delegates_source_diff_to_loader(tmp_path, monkeypatch):
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [], "system")
+
+    async def reconcile(source):
+        return {"success": True, "source": source, "results": []}
+
+    monkeypatch.setattr(
+        "box_agent.tools.mcp_loader.reconcile_mcp_sources",
+        reconcile,
+    )
+
+    result = await agent.extMethod("mcp/reconcile", {"source": "connector"})
+
+    assert result == {"success": True, "source": "connector", "results": []}
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_replace_delegates_runtime_config_to_loader(tmp_path, monkeypatch):
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(tmp_path)),
+        tools=ToolsConfig(enable_sub_agent=False),
+    )
+    agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [], "system")
+    captured = {}
+
+    async def replace(source, source_config):
+        captured.update({"source": source, "config": source_config})
+        return {"success": True, "source": source, "results": []}
+
+    monkeypatch.setattr("box_agent.tools.mcp_loader.replace_mcp_source", replace)
+
+    source_config = {
+        "mcpServers": {
+            "law": {"url": "https://example.test/mcp", "_connectorId": "pkulaw"}
+        }
+    }
+    result = await agent.extMethod(
+        "mcp/source/replace",
+        {"source": "connector", "config": source_config},
+    )
+
+    assert captured == {"source": "connector", "config": source_config}
+    assert result == {"success": True, "source": "connector", "results": []}
 
 
 @pytest.mark.asyncio

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2537,7 +2537,8 @@ async def test_mcp_reconcile_delegates_source_diff_to_loader(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_mcp_source_replace_delegates_runtime_config_to_loader(tmp_path, monkeypatch):
+@pytest.mark.parametrize("connector_ids", [None, ["pkulaw"]])
+async def test_mcp_source_replace_delegates_runtime_config_to_loader(tmp_path, monkeypatch, connector_ids):
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(workspace_dir=str(tmp_path)),
@@ -2546,8 +2547,10 @@ async def test_mcp_source_replace_delegates_runtime_config_to_loader(tmp_path, m
     agent = BoxACPAgent(DummyConn(), config, DummyLLM(), [], "system")
     captured = {}
 
-    async def replace(source, source_config):
+    async def replace(source, source_config, ids=None):
         captured.update({"source": source, "config": source_config})
+        if ids is not None:
+            captured["connectorIds"] = ids
         return {"success": True, "source": source, "results": []}
 
     monkeypatch.setattr("box_agent.tools.mcp_loader.replace_mcp_source", replace)
@@ -2557,12 +2560,12 @@ async def test_mcp_source_replace_delegates_runtime_config_to_loader(tmp_path, m
             "law": {"url": "https://example.test/mcp", "_connectorId": "pkulaw"}
         }
     }
-    result = await agent.extMethod(
-        "mcp/source/replace",
-        {"source": "connector", "config": source_config},
-    )
+    params = {"source": "connector", "config": source_config}
+    if connector_ids is not None:
+        params["connectorIds"] = connector_ids
+    result = await agent.extMethod("mcp/source/replace", params)
 
-    assert captured == {"source": "connector", "config": source_config}
+    assert captured == params
     assert result == {"success": True, "source": "connector", "results": []}
 
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -68,6 +68,9 @@ from box_agent.workspace_registry import WorkspaceRegistry
 from tests.architecture_imports import forbidden_adapter_layer_imports
 
 
+_EMPTY_CONNECTOR_CONTEXT = "\n\n<connector-status>\nnone: selected\n</connector-status>"
+
+
 class DummyConn:
     def __init__(self):
         self.updates = []
@@ -1492,7 +1495,7 @@ async def test_acp_restarts_with_same_product_session_from_jsonl(
     tmp_path,
     monkeypatch,
 ):
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path))
     config = Config(
         llm=LLMConfig(api_key="test-key"),
         agent=AgentConfig(max_steps=2, workspace_dir=str(tmp_path)),
@@ -1519,7 +1522,7 @@ async def test_acp_restarts_with_same_product_session_from_jsonl(
 
     assert restarted.sessionId != first.sessionId
     assert [(message.role, message.content) for message in state.agent.messages[1:]] == [
-        ("user", "remember this"),
+        ("user", "remember this" + _EMPTY_CONNECTOR_CONTEXT),
         ("assistant", "done"),
     ]
     assert state.agent.session_log.events[-1]["type"] == "session/end-seed"
@@ -1546,7 +1549,7 @@ async def test_acp_restarts_with_same_product_session_from_jsonl(
         "stale migration seed"
     ) == 0
     assert [(message.role, message.content) for message in state.agent.messages[-2:]] == [
-        ("user", "continue after restart"),
+        ("user", "continue after restart" + _EMPTY_CONNECTOR_CONTEXT),
         ("assistant", "done"),
     ]
     state.agent.session_log.close()
@@ -1614,7 +1617,9 @@ async def test_acp_resumes_and_answers_when_previous_skills_are_unavailable(
             expected_names = ("available-skill",) if availability == "partial" else ()
             assert state.agent.active_skill_diagnostics()["names"] == expected_names
             assert "Instructions for missing-skill." not in state.agent.system_prompt
-            assert "remember me" in [message.content for message in state.agent.messages]
+            assert "remember me" + _EMPTY_CONNECTOR_CONTEXT in [
+                message.content for message in state.agent.messages
+            ]
             response = await restarted.prompt(
                 SimpleNamespace(sessionId=session.sessionId, prompt=[{"text": "continue"}])
             )
@@ -2636,7 +2641,7 @@ async def test_acp_seeds_negotiated_session_continuation_once(
     tmp_path,
     monkeypatch,
 ):
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("BOX_AGENT_HOME", str(tmp_path / "profile"))
     agent, _ = acp_agent
     session = await agent.newSession(
         SimpleNamespace(
@@ -2668,7 +2673,7 @@ async def test_acp_seeds_negotiated_session_continuation_once(
     assert [(message.role, message.content) for message in state.agent.messages[1:4]] == [
         ("user", "制作融资 BP"),
         ("assistant", "已生成 index.html"),
-        ("user", "修改第一页标题"),
+        ("user", "修改第一页标题" + _EMPTY_CONNECTOR_CONTEXT),
     ]
 
     await agent.prompt(
@@ -3585,7 +3590,7 @@ async def test_acp_goal_pause_stops_prompt_injection(tmp_path):
     await agent.prompt(SimpleNamespace(sessionId=session.sessionId, prompt=[{"text": "side question"}]))
 
     latest_user = [content for role, content in llm.calls[-1] if role == "user"][-1]
-    assert latest_user == "side question"
+    assert latest_user == "side question" + _EMPTY_CONNECTOR_CONTEXT
 
 
 @pytest.mark.asyncio
@@ -4651,7 +4656,7 @@ async def test_acp_skill_filter_ignores_host_ui_language_instruction(tmp_path):
         "[Host UI language: Chinese. Use this language for user-visible "
         "intermediate summaries, progress updates, and the final response unless the user "
         "explicitly requests another language.]\n\n"
-        "孙宇晨最新的回复是什么"
+        "孙宇晨最新的回复是什么" + _EMPTY_CONNECTOR_CONTEXT
     ]
 
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -153,6 +153,7 @@ def test_build_agent_forwards_shared_constructor_options(tmp_path) -> None:
     hooks = [object()]
     tool_limits = object()
     session_log = object()
+    allowed_connector_ids_provider = lambda: frozenset({"pkulaw"})
     agent = build_agent(
         agent_factory=CaptureAgent,
         llm_client=llm,
@@ -175,6 +176,7 @@ def test_build_agent_forwards_shared_constructor_options(tmp_path) -> None:
         max_truncated_tool_call_retries=1,
         truncated_tool_call_boost_cap=256,
         context_resource_dedup_enabled=False,
+        allowed_connector_ids_provider=allowed_connector_ids_provider,
         deferred_mcp_loading_enabled=False,
         session_log=session_log,
     )
@@ -201,6 +203,7 @@ def test_build_agent_forwards_shared_constructor_options(tmp_path) -> None:
         "max_truncated_tool_call_retries": 1,
         "truncated_tool_call_boost_cap": 256,
         "context_resource_dedup_enabled": False,
+        "allowed_connector_ids_provider": allowed_connector_ids_provider,
         "deferred_mcp_loading_enabled": False,
         "session_log": session_log,
     }

--- a/tests/test_agent_session_persistence.py
+++ b/tests/test_agent_session_persistence.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from box_agent.agent import Agent
-from box_agent.events import DoneEvent
+from box_agent.events import DoneEvent, SummarizationEvent
 from box_agent.hooks import BaseHook
 from box_agent.schema import FunctionCall, LLMResponse, Message, StreamEvent, ToolCall
 from box_agent.session_log import SessionLog, SessionLogDurabilityError
@@ -262,7 +262,9 @@ async def test_compaction_is_durable_before_live_context_switch(tmp_path):
         system_prompt="system",
         tools=[],
         workspace_dir=str(tmp_path),
-        token_limit=5_000,
+        # Keep room for tool_search's local/connector schema after compaction,
+        # while the long history still forces the real summary path below.
+        token_limit=8_000,
         deferred_mcp_loading_enabled=False,
         session_log=log,
     )
@@ -272,8 +274,12 @@ async def test_compaction_is_durable_before_live_context_switch(tmp_path):
     agent.add_user_message("latest request")
     options = replace(agent.default_run_options(), summary_llm=summary_llm)
 
-    _ = [event async for event in agent.run_events(options=options)]
+    events = [event async for event in agent.run_events(options=options)]
 
+    compactions = [event for event in events if isinstance(event, SummarizationEvent)]
+    assert len(compactions) == 1
+    assert compactions[0].mode == "summary"
+    assert compactions[0].estimated_tokens > 8_000 > compactions[0].estimated_after
     assert summary_llm.saw_start
     assert llm.saw_replacement
     assert any(

--- a/tests/test_build_runtime.py
+++ b/tests/test_build_runtime.py
@@ -124,6 +124,9 @@ def test_runtime_manifest_advertises_bundled_web_extract_mcp() -> None:
 
     assert manifest["entry"] == "bin/box-agent-acp"
     assert manifest["managed_mcp_config_version"] == 1
+    assert manifest["connector_skill_sources_version"] == 1
+    assert manifest["mcp_multi_source_version"] == 1
+    assert "connector_mcp_proxy_version" not in manifest
     assert manifest["mcp_servers"] == {
         "box-agent-web-extract": {
             "entry": "bin/box-agent-acp",

--- a/tests/test_build_win_runtime.py
+++ b/tests/test_build_win_runtime.py
@@ -84,6 +84,9 @@ def test_windows_manifest_advertises_bundled_web_extract_mcp(
     assert manifest["arch"] == "x64"
     assert manifest["entry"] == "bin/box-agent-acp.exe"
     assert manifest["managed_mcp_config_version"] == 1
+    assert manifest["connector_skill_sources_version"] == 1
+    assert manifest["mcp_multi_source_version"] == 1
+    assert "connector_mcp_proxy_version" not in manifest
     assert manifest["external_python_sandbox"] is True
     assert manifest["bundled_stable_runtimes"] == []
     assert manifest["mcp_servers"] == {

--- a/tests/test_connector_skill_source.py
+++ b/tests/test_connector_skill_source.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+
+import pytest
+
+from box_agent.tools.skill_loader import SKILL_SLOT_SENTINEL, SkillLoader, SkillSelector
+from box_agent.tools.skill_tool import GetSkillTool
+from box_agent.tools.sub_agent_capabilities import (
+    CapabilityFailure,
+    CapabilityResolver,
+    DelegationSpec,
+    parse_delegation_spec,
+)
+
+
+def _write_connector_skill(root: Path, *, disabled: bool = False) -> Path:
+    skill_dir = root / "connector-pkulaw"
+    skill_dir.mkdir(parents=True)
+    disable_line = "disable: true\n" if disabled else ""
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(
+        "---\n"
+        "name: pkulaw\n"
+        "description: PKULaw connector guidance\n"
+        f"{disable_line}"
+        "---\n\n"
+        "Always retrieve before answering.\n",
+        encoding="utf-8",
+    )
+    return skill_path
+
+
+def test_connector_source_exposes_owner_metadata(tmp_path: Path) -> None:
+    connector_root = tmp_path / "connectors" / "skills"
+    skill_path = _write_connector_skill(connector_root)
+    loader = SkillLoader(sources=[(connector_root, "connector")])
+
+    loader.discover_skills()
+
+    skill = loader.get_skill("pkulaw")
+    assert skill is not None
+    assert skill.source == "connector"
+    assert skill.owner_id == "pkulaw"
+    assert skill.skill_path == skill_path
+    assert skill.to_metadata_dict()["ownerId"] == "pkulaw"
+    assert loader.list_skills_metadata(include_connector=False) == []
+
+
+def test_disabled_connector_skill_stays_out_of_model_catalog(tmp_path: Path) -> None:
+    connector_root = tmp_path / "connectors" / "skills"
+    _write_connector_skill(connector_root, disabled=True)
+    loader = SkillLoader(sources=[(connector_root, "connector")])
+
+    loader.discover_skills()
+
+    assert loader.get_skill("pkulaw") is None
+    disabled = loader.get_skill("pkulaw", include_disabled=True)
+    assert disabled is not None
+    assert disabled.disabled is True
+
+
+def test_connector_skill_requires_connection_for_new_matching_but_stays_after_loading(
+    tmp_path: Path,
+) -> None:
+    connector_root = tmp_path / "connectors" / "skills"
+    _write_connector_skill(connector_root)
+    loader = SkillLoader(sources=[(connector_root, "connector")])
+    loader.discover_skills()
+    connected_connectors: set[str] = set()
+    selector = SkillSelector(
+        loader,
+        skill_filter=lambda skill: skill.source != "connector"
+        or skill.owner_id in connected_connectors,
+    )
+    selector.bind(f"prefix\n\n{SKILL_SLOT_SENTINEL}\n\nsuffix")
+
+    assert "pkulaw" not in (selector.update("PKULaw legal search") or "")
+
+    connected_connectors.add("pkulaw")
+    assert "pkulaw" in (selector.update("PKULaw legal search") or "")
+
+    connected_connectors.clear()
+    selector.update("continue")
+    assert "pkulaw" in selector.matched_skill_names
+
+
+@pytest.mark.asyncio
+async def test_connector_skill_cannot_be_loaded_without_conversation_grant(tmp_path: Path) -> None:
+    connector_root = tmp_path / "connectors" / "skills"
+    _write_connector_skill(connector_root)
+    loader = SkillLoader(sources=[(connector_root, "connector")])
+    loader.discover_skills()
+    grants: set[str] = set()
+    tool = GetSkillTool(
+        loader,
+        skill_access_filter=lambda skill: skill.source != "connector" or skill.name in grants,
+    )
+
+    denied = await tool.execute(skill_name="pkulaw")
+    assert denied.success is False
+    assert "not enabled for this conversation" in denied.error
+
+    grants.add("pkulaw")
+    allowed = await tool.execute(skill_name="pkulaw")
+    assert allowed.success is True
+    assert "Always retrieve before answering." in allowed.content
+
+
+def test_connector_skill_cannot_be_delegated_without_conversation_grant(tmp_path: Path) -> None:
+    connector_root = tmp_path / "connectors" / "skills"
+    _write_connector_skill(connector_root)
+    loader = SkillLoader(sources=[(connector_root, "connector")])
+    loader.discover_skills()
+    spec = parse_delegation_spec(task="Search the law", skills=["pkulaw"], required_tools=[])
+    assert isinstance(spec, DelegationSpec)
+
+    result = CapabilityResolver().resolve(
+        spec,
+        parent_tools={},
+        skill_loader=loader,
+        skill_access_filter=lambda skill: skill.source != "connector",
+    )
+
+    assert isinstance(result, CapabilityFailure)
+    assert result.code == "SKILL_NOT_ENABLED_FOR_CONVERSATION"
+
+
+def test_connector_disable_flag_does_not_change_existing_user_skill_behavior(
+    tmp_path: Path,
+) -> None:
+    user_root = tmp_path / "skills"
+    skill_dir = user_root / "ordinary-user-skill"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(
+        "---\n"
+        "name: ordinary-user-skill\n"
+        "description: Existing user skill\n"
+        "disable: true\n"
+        "---\n\n"
+        "Existing behavior remains unchanged.\n",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(sources=[(user_root, "user")])
+
+    loader.discover_skills()
+
+    skill = loader.get_skill("ordinary-user-skill")
+    assert skill is not None
+    assert skill.disabled is False

--- a/tests/test_isolated_profile.py
+++ b/tests/test_isolated_profile.py
@@ -87,7 +87,9 @@ async def probe():
     second = BoxACPAgent(DummyConn(), config, DoneLLM(), [], "system")
     restored = await second.newSession(request)
     state = second._sessions[restored.sessionId]
-    assert [message.content for message in state.agent.messages][-2:] == ["fixture", "done"]
+    assert [message.content for message in state.agent.messages][-2:] == [
+        "fixture\\n\\n<connector-status>\\nnone: selected\\n</connector-status>", "done",
+    ]
     state.agent.session_log.close()
 asyncio.run(probe())
 ''')

--- a/tests/test_local_tool_search.py
+++ b/tests/test_local_tool_search.py
@@ -150,3 +150,47 @@ async def test_local_removal_or_replacement_revokes_previous_activation_but_keep
     tools.clear()
     assert exposure.prepare_tools(tools).tools == []
     assert not activated
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("search_args", "expected"), [
+    ({"query": "lookup", "top_k": 10}, {"local_lookup", "legal_lookup"}),
+    ({"tool_names": ["lookup", "legal_lookup", "hidden_lookup"]}, {"local_lookup", "legal_lookup"}),
+    ({"connector": "law"}, {"legal_lookup"}),
+    ({"connector": "law", "query": "lookup"}, {"legal_lookup"}),
+    ({"connector": "law", "tool_names": ["local_lookup", "legal_lookup"]}, {"legal_lookup"}),
+    ({"connector": "hidden", "query": "lookup"}, set()),
+])
+async def test_connector_scope_remains_enforced_with_local_discovery(search_args, expected):
+    local = LocalTool("local_lookup", "Local utility", aliases=("lookup",))
+    catalog = MCPToolCatalog()
+    catalog.replace_server("legal", [FakeMCPTool(
+        "legal_lookup", "legal", "Lookup law", connector_id="law",
+    )])
+    catalog.replace_server("hidden", [FakeMCPTool(
+        "hidden_lookup", "hidden", "Lookup private data", connector_id="hidden",
+    )])
+    allowed = {"law"}
+    activated_mcp, activated_local = OrderedDict(), OrderedDict()
+    search = ToolSearchTool(
+        catalog, activated_mcp, local_tools_provider=lambda: [local],
+        activated_local_tools=activated_local,
+        allowed_connector_ids_provider=lambda: frozenset(allowed),
+    )
+    exposure = MCPToolExposureManager(
+        catalog, activated_mcp, activated_local_tools=activated_local,
+        deferred_local_names_provider=lambda: frozenset({local.name}),
+        allowed_connector_ids_provider=lambda: frozenset(allowed),
+    )
+
+    result = await search.execute(**search_args)
+    assert result.success
+    assert {hit["name"] for hit in json.loads(result.content)["activated"]} == expected
+    offered = exposure.prepare_tools([local])
+    assert offered.offered_names == frozenset(expected)
+    allowed.clear()
+    assert exposure.prepare_tools([local]).offered_names == frozenset(expected & {local.name})
+    if "legal_lookup" in expected:
+        assert "not enabled" in exposure.validate_call(
+            "legal_lookup", offered.mcp_generations["legal_lookup"],
+        )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -26,6 +26,7 @@ from box_agent.tools.mcp_loader import (
     MCPTimeoutConfig,
     WEB_SEARCH_MCP_MAX_CONCURRENCY,
     _determine_connection_type,
+    _mcp_tool_always_load,
     _public_mcp_tool_name,
     cleanup_mcp_connections,
     get_mcp_timeout_config,
@@ -34,6 +35,7 @@ from box_agent.tools.mcp_loader import (
     reconnect_auth_failed_mcp_servers_if_token_changed,
     set_mcp_timeout_config,
 )
+from box_agent.tools.mcp_sources import ResolvedMcpServer
 from box_agent.tools.model_tool_context import (
     current_model_tool_context,
     reset_model_tool_context,
@@ -61,7 +63,6 @@ def test_public_mcp_tool_name_sanitizes_provider_invalid_remote_name():
         for character in public_name
     )
     assert public_name == _public_mcp_tool_name("pkulaw", remote_name)
-    assert _public_mcp_tool_name("pkulaw", "search_law") == "search_law"
 
 
 def test_public_mcp_tool_name_avoids_sanitized_name_collisions():
@@ -69,6 +70,51 @@ def test_public_mcp_tool_name_avoids_sanitized_name_collisions():
     slashed = _public_mcp_tool_name("pkulaw", "law/search")
 
     assert dotted != slashed
+
+
+def test_connector_tools_receive_a_qualified_model_facing_name():
+    assert _public_mcp_tool_name("pkulaw", "search_case", "pkulaw") == "mcp__pkulaw__search_case"
+    assert _public_mcp_tool_name(
+        "pkulaw", "law.search", "pkulaw"
+    ).startswith("mcp__pkulaw__law_search__")
+
+
+def test_server_default_controls_tool_always_load_policy():
+    deferred = SimpleNamespace(meta={"boxAgent": {"alwaysLoad": False}})
+    assert _mcp_tool_always_load("ordinary-server", deferred, True) is True
+    assert _mcp_tool_always_load("ordinary-server", deferred, False) is False
+
+
+def test_connector_runtime_credential_is_injected_without_forwarding_private_fields(monkeypatch):
+    definition = ResolvedMcpServer(
+        name="pkulaw",
+        config={
+            "url": "https://example.test/mcp",
+            "credentialRef": "connector:pkulaw:default",
+            "_connectorId": "pkulaw",
+            "headers": {"X-Tenant": "tenant-a"},
+        },
+        owner="connector",
+        config_id="connector:pkulaw",
+        connector_id="pkulaw",
+        connector_name="北大法宝",
+        source_path="connectors/mcp.json",
+        fingerprint="fingerprint",
+    )
+    monkeypatch.setitem(
+        mcp_loader._mcp_runtime_credentials,
+        "connector:pkulaw:default",
+        {"Authorization": "Bearer secret"},
+    )
+
+    materialized = mcp_loader._materialize_server_config(definition)
+
+    assert "credentialRef" not in materialized
+    assert "_connectorId" not in materialized
+    assert materialized["headers"] == {
+        "X-Tenant": "tenant-a",
+        "Authorization": "Bearer secret",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_sources.py
+++ b/tests/test_mcp_sources.py
@@ -183,3 +183,225 @@ async def test_replace_runtime_connector_source_reconciles_in_memory(
     assert result["success"] is True
     assert captured == ["connector"]
     assert set(mcp_loader._mcp_source_overrides["connector"]) == {"law"}
+
+
+@pytest.fixture
+def isolated_connector_runtime(monkeypatch, tmp_path):
+    import asyncio
+
+    user = tmp_path / "mcp.json"
+    _write(user, {})
+    monkeypatch.setenv("BOX_AGENT_USER_MCP_CONFIG_PATH", str(user))
+    monkeypatch.delenv("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", raising=False)
+    monkeypatch.setattr(mcp_loader, "_mcp_config_path", str(user))
+    for name in ("_mcp_server_definitions", "_mcp_source_overrides", "_mcp_runtime_credentials",
+                 "_mcp_runtime_credential_versions", "_mcp_status", "_mcp_reconnect_locks"):
+        monkeypatch.setattr(mcp_loader, name, {})
+    monkeypatch.setattr(mcp_loader, "_mcp_connections", [])
+    monkeypatch.setattr(mcp_loader, "_mcp_loading", False)
+    monkeypatch.setattr(mcp_loader, "_mcp_source_reconcile_lock", asyncio.Lock())
+    return {
+        "mcpServers": {
+            "law": {"url": "https://law.test/mcp", "_connectorId": "pkulaw", "credentialRef": "law-token"},
+            "oauth": {"url": "https://oauth.test/mcp", "_connectorId": "qixin"},
+        }
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["connector", "system", "user"])
+@pytest.mark.parametrize("retry_succeeds", [True, False])
+async def test_unchanged_source_retries_failed_servers_without_restarting_healthy_servers(
+    monkeypatch, tmp_path, isolated_connector_runtime, source, retry_succeeds,
+):
+    attempts = {"retry-server": 0, "healthy-server": 0}
+    config = {
+        "mcpServers": {
+            "retry-server": {"url": "https://retry.test/mcp", "_connectorId": "qixin"},
+            "healthy-server": {"url": "https://healthy.test/mcp", "_connectorId": "pkulaw"},
+        },
+    }
+
+    async def connect(connection):
+        attempts[connection.name] += 1
+        return connection.name == "healthy-server" or (
+            retry_succeeds and attempts[connection.name] > 1
+        )
+
+    monkeypatch.setattr(mcp_loader.MCPServerConnection, "connect", connect)
+    if source == "system":
+        system_path = tmp_path / "mcp.system.json"
+        _write(system_path, config["mcpServers"])
+        monkeypatch.setenv("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", str(system_path))
+    elif source == "user":
+        _write(Path(mcp_loader._mcp_config_path), config["mcpServers"])
+
+    async def reconcile():
+        if source == "connector":
+            return await mcp_loader.replace_mcp_source(source, config)
+        return await mcp_loader.reconcile_mcp_sources(source)
+
+    first = await reconcile()
+    assert first["success"] is False
+    assert attempts == {"retry-server": 1, "healthy-server": 1}
+
+    second = await reconcile()
+    assert attempts == {"retry-server": 2, "healthy-server": 1}
+    assert second["success"] is retry_succeeds
+    assert mcp_loader._mcp_status["retry-server"].state == (
+        "connected" if retry_succeeds else "failed"
+    )
+    if retry_succeeds:
+        assert (await reconcile())["success"] is True
+        assert attempts == {"retry-server": 2, "healthy-server": 1}
+
+
+@pytest.mark.asyncio
+async def test_late_credential_is_not_acknowledged_by_another_server_reconnect(
+    monkeypatch, isolated_connector_runtime,
+):
+    attempts = []
+
+    async def connect(name):
+        attempts.append(name)
+        if name == "law" and attempts.count("law") == 1:
+            # Credential arrives while the original connection is failing.
+            mcp_loader.set_mcp_runtime_credential("law-token", {"Authorization": "Bearer test"})
+            return {"success": False}
+        return {"success": True}
+
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", connect)
+    await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime)
+    await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime)
+    assert attempts == ["law", "oauth", "law"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_oauth_update_does_not_publish_or_reconnect_other_connectors(
+    monkeypatch, isolated_connector_runtime,
+):
+    attempts = []
+
+    async def connect(name):
+        attempts.append(name)
+        return {"success": True}
+
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", connect)
+    await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime, ["qixin"])
+    assert attempts == ["oauth"]
+    assert set(mcp_loader._mcp_source_overrides["connector"]) == {"oauth"}
+    await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime, ["pkulaw"])
+    assert attempts == ["oauth", "law"]
+    assert set(mcp_loader._mcp_source_overrides["connector"]) == {"oauth", "law"}
+    await mcp_loader.replace_mcp_source("connector", {"mcpServers": {}}, ["pkulaw"])
+    assert set(mcp_loader._mcp_source_overrides["connector"]) == {"oauth"}
+
+
+@pytest.mark.asyncio
+async def test_missing_credential_waits_without_sending_an_unauthenticated_request(
+    monkeypatch, isolated_connector_runtime,
+):
+    from unittest.mock import AsyncMock, Mock
+
+    build_connection = mcp_loader._build_connection
+    build = Mock(side_effect=AssertionError("must not create a transport without credentials"))
+    monkeypatch.setattr(mcp_loader, "_build_connection", build)
+    result = await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime, ["pkulaw"])
+    assert result["results"][0]["waitingForCredential"] is True
+    assert not build.called
+    assert mcp_loader.get_mcp_status()[0]["state"] == "connecting"
+
+    # The same source must become connectable when its credential arrives.
+    monkeypatch.setattr(mcp_loader, "_build_connection", build_connection)
+    connect = AsyncMock(return_value=True)
+    monkeypatch.setattr(mcp_loader.MCPServerConnection, "connect", connect)
+    mcp_loader.set_mcp_runtime_credential("law-token", {"Authorization": "Bearer saved"})
+    result = await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime, ["pkulaw"])
+    assert result["success"] is True
+    connect.assert_awaited_once()
+    assert mcp_loader.get_mcp_status()[0]["state"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_scoped_source_rejects_invalid_connector_filter(isolated_connector_runtime):
+    result = await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime, [])
+    assert result["success"] is False
+    assert mcp_loader._mcp_source_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_slow_connector_does_not_delay_starting_other_ready_connectors(
+    monkeypatch, isolated_connector_runtime,
+):
+    import asyncio
+
+    other_started = asyncio.Event()
+
+    async def connect(name):
+        if name == "law":
+            await asyncio.wait_for(other_started.wait(), timeout=1)
+        else:
+            other_started.set()
+        return {"success": True}
+
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", connect)
+    result = await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime)
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_cold_load_waits_for_required_credentials_before_creating_transport(
+    monkeypatch, isolated_connector_runtime,
+):
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(mcp_loader, "_mcp_source_overrides", {
+        "connector": {"law": isolated_connector_runtime["mcpServers"]["law"]},
+    })
+    build = Mock(side_effect=AssertionError("unauthenticated transport must not be created"))
+    monkeypatch.setattr(mcp_loader, "_build_connection", build)
+    assert await mcp_loader.load_mcp_tools_async(mcp_loader._mcp_config_path) == []
+    assert not build.called
+    assert mcp_loader.get_mcp_status()[0]["error"] == "Waiting for host credential"
+
+
+@pytest.mark.asyncio
+async def test_scoped_replacement_uses_normalized_connector_identity(
+    monkeypatch, isolated_connector_runtime,
+):
+    from unittest.mock import AsyncMock
+
+    connect = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", connect)
+    isolated_connector_runtime["mcpServers"]["law"]["_connectorId"] = " PKULAW "
+    result = await mcp_loader.replace_mcp_source(
+        "connector", isolated_connector_runtime, [" PKULAW "],
+    )
+    assert result["success"] is True
+    connect.assert_awaited_once_with("law")
+    await mcp_loader.replace_mcp_source("connector", {"mcpServers": {}}, ["pkulaw"])
+    assert mcp_loader._mcp_source_overrides["connector"] == {}
+
+
+@pytest.mark.asyncio
+async def test_connector_update_does_not_acknowledge_or_apply_pending_user_source_changes(
+    monkeypatch, isolated_connector_runtime,
+):
+    from unittest.mock import AsyncMock
+
+    user_path = Path(mcp_loader._mcp_config_path)
+    _write(user_path, {"mine": {"command": "before"}})
+    monkeypatch.setattr(
+        mcp_loader, "_mcp_server_definitions",
+        mcp_loader._resolve_registered_sources(str(user_path)),
+    )
+    _write(user_path, {"mine": {"command": "after"}})
+    connect = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", connect)
+    await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime, ["qixin"])
+    connect.assert_awaited_once_with("oauth")
+    assert mcp_loader._mcp_server_definitions["mine"].config["command"] == "before"
+    await mcp_loader.reconcile_mcp_sources("user")
+    assert connect.await_args_list[-1].args == ("mine",)
+    assert mcp_loader._mcp_server_definitions["mine"].config["command"] == "after"

--- a/tests/test_mcp_sources.py
+++ b/tests/test_mcp_sources.py
@@ -63,9 +63,9 @@ def test_credential_version_participates_in_server_fingerprint(tmp_path: Path) -
     connector = tmp_path / "mcp.json"
     _write(
         connector,
-        {"law": {"url": "https://example.test", "credentialRef": "law-token"}},
+        {"law": {"url": "https://example.test", "credentialRef": "law-token", "_connectorId": "law"}},
     )
-    sources = (configured_mcp_sources(str(connector))[0],)
+    sources = (McpConfigSource("connector", connector),)
 
     before = resolve_mcp_sources(sources, {"law-token": 1}).servers["law"]
     after = resolve_mcp_sources(sources, {"law-token": 2}).servers["law"]
@@ -405,3 +405,108 @@ async def test_connector_update_does_not_acknowledge_or_apply_pending_user_sourc
     await mcp_loader.reconcile_mcp_sources("user")
     assert connect.await_args_list[-1].args == ("mine",)
     assert mcp_loader._mcp_server_definitions["mine"].config["command"] == "after"
+
+
+@pytest.mark.parametrize("owner", ["user", "system"])
+def test_non_connector_sources_cannot_reference_runtime_credentials(tmp_path, monkeypatch, owner):
+    from dataclasses import replace
+
+    path = tmp_path / "mcp.json"
+    _write(path, {"law": {
+        "url": "https://untrusted.invalid/mcp",
+        "_connectorId": "law",
+        "credentialRef": "connector:law:default",
+    }})
+    monkeypatch.setattr(mcp_loader, "_mcp_runtime_credentials", {
+        "connector:law:default": {"Authorization": "Bearer test-sentinel"},
+    })
+    definition = resolve_mcp_sources((McpConfigSource("connector", path),)).servers["law"]
+    assert mcp_loader._materialize_server_config(definition)["headers"] == {
+        "Authorization": "Bearer test-sentinel",
+    }
+    with pytest.raises(ValueError, match="connector-owned source"):
+        resolve_mcp_sources((McpConfigSource(owner, path),))
+    # Older or programmatically constructed definitions cannot bypass parsing.
+    with pytest.raises(ValueError, match="connector-owned source"):
+        mcp_loader._materialize_server_config(replace(definition, owner=owner))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("targets", [None, ["law"]])
+async def test_connector_removal_revokes_live_owner_before_user_fallback(
+    monkeypatch, isolated_connector_runtime, targets,
+):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from box_agent.tools.mcp_tool_catalog import MCPToolCatalog
+    from tests.test_mcp_tool_search import FakeMCPTool
+
+    user = Path(mcp_loader._mcp_config_path)
+    _write(user, {"shared": {"url": "https://user.example.test/mcp"}})
+    mcp_loader._mcp_source_overrides["connector"] = {
+        "shared": {"url": "https://connector.example.test/mcp", "_connectorId": "law"},
+    }
+    mcp_loader._mcp_server_definitions = mcp_loader._resolve_registered_sources(str(user))
+    tool = FakeMCPTool("law_search", "shared", connector_id="law")
+    catalog = MCPToolCatalog()
+    catalog.replace_server("shared", [tool])
+    monkeypatch.setattr(mcp_loader, "get_mcp_tool_catalog", lambda: catalog)
+    connection = SimpleNamespace(name="shared", tools=[tool], disconnect=AsyncMock())
+    mcp_loader._mcp_connections = [connection]
+    mcp_loader._record_status("shared", "connected")
+    reconnect = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", reconnect)
+
+    result = await mcp_loader.replace_mcp_source("connector", {"mcpServers": {}}, targets)
+
+    assert result["success"] is True
+    assert result["results"][0]["action"] == "removed"
+    connection.disconnect.assert_awaited_once()
+    reconnect.assert_not_awaited()
+    assert mcp_loader._mcp_connections == []
+    assert "shared" not in mcp_loader._mcp_server_definitions
+    assert catalog.snapshot() == ()
+    assert mcp_loader._mcp_status["shared"].state == "disabled"
+    # The shadowed source is only activated by its own explicit reconciliation.
+    await mcp_loader.reconcile_mcp_sources("user")
+    reconnect.assert_awaited_once_with("shared")
+    assert mcp_loader._mcp_server_definitions["shared"].owner == "user"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_override", [True, False])
+async def test_scoped_connector_update_cannot_take_another_connectors_server_name(
+    monkeypatch, tmp_path, isolated_connector_runtime, runtime_override,
+):
+    from copy import deepcopy
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    existing = {"shared": {"url": "https://other.example.test/mcp", "_connectorId": "other"}}
+    if runtime_override:
+        mcp_loader._mcp_source_overrides["connector"] = existing
+    else:
+        connector = tmp_path / "connector.json"
+        _write(connector, existing)
+        monkeypatch.setenv("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", str(connector))
+    mcp_loader._mcp_server_definitions = mcp_loader._resolve_registered_sources(mcp_loader._mcp_config_path)
+    before = dict(mcp_loader._mcp_server_definitions)
+    overrides = deepcopy(mcp_loader._mcp_source_overrides)
+    connection = SimpleNamespace(name="shared", tools=[], disconnect=AsyncMock())
+    mcp_loader._mcp_connections = [connection]
+    mcp_loader._record_status("shared", "connected")
+    reconnect = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(mcp_loader, "_reconnect_mcp_server_locked", reconnect)
+
+    result = await mcp_loader.replace_mcp_source("connector", {"mcpServers": {
+        "shared": {"url": "https://law.example.test/mcp", "_connectorId": "law"},
+    }}, ["law"])
+
+    assert result["success"] is False
+    assert "outside connectorIds" in result["error"]
+    assert mcp_loader._mcp_source_overrides == overrides
+    assert mcp_loader._mcp_server_definitions == before
+    assert mcp_loader._mcp_status["shared"].state == "connected"
+    assert mcp_loader._mcp_connections == [connection]
+    connection.disconnect.assert_not_awaited()
+    reconnect.assert_not_awaited()

--- a/tests/test_mcp_sources.py
+++ b/tests/test_mcp_sources.py
@@ -510,3 +510,200 @@ async def test_scoped_connector_update_cannot_take_another_connectors_server_nam
     assert mcp_loader._mcp_connections == [connection]
     connection.disconnect.assert_not_awaited()
     reconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disable", [False, True], ids=["remove", "disable"])
+async def test_source_revocation_waits_for_reconnect_without_blocking_other_servers(
+    monkeypatch, isolated_connector_runtime, disable,
+):
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from box_agent.acp import _connected_connector_ids
+    from box_agent.tools.mcp_tool_catalog import MCPToolCatalog
+    from tests.test_mcp_tool_search import FakeMCPTool
+
+    server = {"url": "https://law.example.test/mcp", "_connectorId": "law"}
+    mcp_loader._mcp_source_overrides["connector"] = {"law": server}
+    mcp_loader._mcp_server_definitions = mcp_loader._resolve_registered_sources(mcp_loader._mcp_config_path)
+    catalog = MCPToolCatalog()
+    monkeypatch.setattr(mcp_loader, "get_mcp_tool_catalog", lambda: catalog)
+    started, finish, other_started = asyncio.Event(), asyncio.Event(), asyncio.Event()
+
+    async def connect():
+        started.set()
+        await finish.wait()
+        return True
+
+    async def connect_other():
+        other_started.set()
+        return True
+
+    connection = SimpleNamespace(name="law", connect=connect, disconnect=AsyncMock(), tools=[
+        FakeMCPTool("legal_lookup", "law", connector_id="law"),
+    ])
+    other = SimpleNamespace(name="other", connect=connect_other, disconnect=AsyncMock(), tools=[])
+    monkeypatch.setattr(mcp_loader, "_build_connection", lambda definition: connection if definition.name == "law" else other)
+    reconnect = asyncio.create_task(mcp_loader.reconnect_mcp_server("law"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    replacement = {"other": {"url": "https://other.example.test/mcp", "_connectorId": "other"}}
+    if disable:
+        replacement["law"] = {**server, "disabled": True}
+    revoke = asyncio.create_task(mcp_loader.replace_mcp_source("connector", {"mcpServers": replacement}))
+    try:
+        await asyncio.wait_for(other_started.wait(), timeout=1)
+        assert not revoke.done()
+    finally:
+        finish.set()
+        update, _ = await asyncio.wait_for(asyncio.gather(revoke, reconnect), timeout=5)
+    assert update["success"] is True
+    assert mcp_loader._mcp_connections == [other]
+    assert catalog.snapshot() == ()
+    connection.disconnect.assert_awaited_once()
+    other.disconnect.assert_not_awaited()
+    assert mcp_loader._mcp_status["law"].state == "disabled"
+    assert _connected_connector_ids({"law", "other"}) == frozenset({"other"})
+    if disable:
+        assert mcp_loader._mcp_server_definitions["law"].config["disabled"] is True
+    else:
+        assert "law" not in mcp_loader._mcp_server_definitions
+
+
+@pytest.mark.asyncio
+async def test_partial_connector_removal_keeps_remaining_healthy_server_available(
+    monkeypatch, isolated_connector_runtime,
+):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from box_agent.acp import _connected_connector_ids, _connector_status_context
+
+    servers = {name: {"url": f"https://{name}.example.test/mcp", "_connectorId": "law"}
+               for name in ("removed", "kept")}
+    mcp_loader._mcp_source_overrides["connector"] = servers
+    mcp_loader._mcp_server_definitions = mcp_loader._resolve_registered_sources(mcp_loader._mcp_config_path)
+    connections = [SimpleNamespace(name=name, tools=[], disconnect=AsyncMock()) for name in servers]
+    mcp_loader._mcp_connections = list(connections)
+    for name in servers:
+        mcp_loader._record_status(name, "connected")
+    result = await mcp_loader.replace_mcp_source("connector", {"mcpServers": {"kept": servers["kept"]}}, ["law"])
+    assert result["success"] is True
+    assert mcp_loader._mcp_status["removed"].state == "disabled"
+    assert mcp_loader._mcp_connections == [connections[1]]
+    assert _connected_connector_ids({"law"}) == frozenset({"law"})
+    assert _connector_status_context({"law"}) == "<connector-status>\nlaw law: connected\n</connector-status>"
+    del mcp_loader._mcp_status["kept"]
+    assert _connected_connector_ids({"law"}) == frozenset()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["replace", "reconcile"])
+@pytest.mark.parametrize("loader_entered", [False, True], ids=["pre-gate", "cold-connect"])
+async def test_source_update_does_not_mutate_state_when_startup_readiness_times_out(
+    monkeypatch, isolated_connector_runtime, operation, loader_entered,
+):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(mcp_loader, "_mcp_loading", loader_entered)
+    wait = AsyncMock(return_value=False)
+    monkeypatch.setattr(mcp_loader, "get_mcp_tool_catalog", lambda: SimpleNamespace(initial_loading=True, wait_until_ready=wait))
+    if operation == "replace":
+        result = await mcp_loader.replace_mcp_source("connector", isolated_connector_runtime)
+    else:
+        result = await mcp_loader.reconcile_mcp_sources("connector")
+    assert result["success"] is False
+    assert "startup is still loading" in result["error"]
+    wait.assert_awaited_once()
+    assert mcp_loader._mcp_source_overrides == {}
+    assert mcp_loader._mcp_server_definitions == {}
+    assert mcp_loader._mcp_connections == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["remove", "disable", "replace"])
+async def test_source_update_waits_for_cold_discovery_before_replacing_its_connections(
+    monkeypatch, isolated_connector_runtime, operation,
+):
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from box_agent.tools.mcp_tool_catalog import MCPToolCatalog
+    from tests.test_mcp_tool_search import FakeMCPTool
+
+    server = {"url": "https://old.example.test/mcp", "_connectorId": "law"}
+    mcp_loader._mcp_source_overrides["connector"] = {"law": server}
+    monkeypatch.setattr(mcp_loader, "_mcp_sources", ())
+    catalog = MCPToolCatalog()
+    monkeypatch.setattr(mcp_loader, "get_mcp_tool_catalog", lambda: catalog)
+    started, finish, waiting = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    wait_until_ready = catalog.wait_until_ready
+
+    async def wait(**kwargs):
+        waiting.set()
+        return await wait_until_ready(**kwargs)
+
+    monkeypatch.setattr(catalog, "wait_until_ready", wait)
+
+    async def connect_old():
+        started.set()
+        await finish.wait()
+        return True
+
+    old = SimpleNamespace(name="law", url=server["url"], command=None, connect=connect_old,
+                          disconnect=AsyncMock(), tools=[FakeMCPTool("old_lookup", "law", connector_id="law")])
+    new = SimpleNamespace(name="law", url="https://new.example.test/mcp", command=None,
+                          connect=AsyncMock(return_value=True), disconnect=AsyncMock(),
+                          tools=[FakeMCPTool("new_lookup", "law", connector_id="law")])
+    monkeypatch.setattr(mcp_loader, "_build_connection", lambda definition: old if definition.config["url"] == old.url else new)
+    cold = asyncio.create_task(mcp_loader.load_mcp_tools_async(mcp_loader._mcp_config_path))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    replacement = {} if operation == "remove" else {"law": {
+        **server, **({"disabled": True} if operation == "disable" else {"url": new.url}),
+    }}
+    update = asyncio.create_task(mcp_loader.replace_mcp_source("connector", {"mcpServers": replacement}, ["law"]))
+    try:
+        await asyncio.wait_for(waiting.wait(), timeout=1)
+        assert not update.done()
+        assert mcp_loader._mcp_source_overrides["connector"] == {"law": server}
+    finally:
+        finish.set()
+        _, result = await asyncio.wait_for(asyncio.gather(cold, update), timeout=5)
+    assert result["success"] is True
+    old.disconnect.assert_awaited_once()
+    if operation == "replace":
+        assert mcp_loader._mcp_connections == [new]
+        assert [entry.model_name for entry in catalog.snapshot()] == ["new_lookup"]
+    else:
+        assert mcp_loader._mcp_connections == []
+        assert catalog.snapshot() == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["replace", "reconcile"])
+async def test_source_update_checks_startup_after_acquiring_the_source_lock(
+    monkeypatch, isolated_connector_runtime, operation,
+):
+    import asyncio
+    from unittest.mock import AsyncMock
+    from box_agent.tools.mcp_tool_catalog import MCPToolCatalog
+
+    catalog = MCPToolCatalog()
+    wait = AsyncMock(return_value=False)
+    monkeypatch.setattr(catalog, "wait_until_ready", wait)
+    monkeypatch.setattr(mcp_loader, "get_mcp_tool_catalog", lambda: catalog)
+    lock = mcp_loader._mcp_source_reconcile_lock
+    await lock.acquire()
+    call = (mcp_loader.replace_mcp_source("connector", isolated_connector_runtime)
+            if operation == "replace" else mcp_loader.reconcile_mcp_sources("connector"))
+    update = asyncio.create_task(call)
+    try:
+        await asyncio.sleep(0)
+        catalog.mark_loading()
+    finally:
+        lock.release()
+    result = await asyncio.wait_for(update, timeout=1)
+    assert not result["success"]
+    wait.assert_awaited_once()
+    assert mcp_loader._mcp_source_overrides == {}
+    assert mcp_loader._mcp_server_definitions == {}

--- a/tests/test_mcp_sources.py
+++ b/tests/test_mcp_sources.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from box_agent.tools import mcp_loader
+from box_agent.tools.mcp_sources import McpConfigSource, configured_mcp_sources, resolve_mcp_sources
+
+
+def _write(path: Path, servers: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+
+
+def test_configured_sources_keep_standalone_single_file(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("BOX_AGENT_USER_MCP_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", raising=False)
+
+    sources = configured_mcp_sources(str(tmp_path / "mcp.json"))
+
+    assert [(source.owner, source.path) for source in sources] == [
+        ("user", tmp_path / "mcp.json")
+    ]
+
+
+def test_resolve_sources_preserves_owner_and_blocks_user_shadowing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    system = tmp_path / "mcp.system.json"
+    connector = tmp_path / "connector" / "mcp.json"
+    user = tmp_path / "mcp.json"
+    _write(system, {"playwright": {"command": "pw"}})
+    _write(
+        connector,
+        {
+            "law": {
+                "url": "https://example.test/mcp",
+                "_connectorId": "pkulaw",
+                "_connectorName": "北大法宝",
+                "credentialRef": "connector:pkulaw:default",
+            }
+        },
+    )
+    _write(user, {"playwright": {"command": "shadow"}, "mine": {"command": "mine"}})
+    monkeypatch.setenv("BOX_AGENT_USER_MCP_CONFIG_PATH", str(user))
+    monkeypatch.setenv("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", str(system))
+    monkeypatch.setenv("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", str(connector))
+
+    resolved = resolve_mcp_sources(configured_mcp_sources(str(user)))
+
+    assert resolved.servers["playwright"].owner == "system"
+    assert resolved.servers["law"].config_id == "connector:pkulaw"
+    assert resolved.servers["law"].connector_id == "pkulaw"
+    assert resolved.servers["law"].connector_name == "北大法宝"
+    assert resolved.servers["mine"].config_id == "custom-mcp:mine"
+    assert resolved.conflicts == ("user:playwright conflicts with system:playwright",)
+
+
+def test_credential_version_participates_in_server_fingerprint(tmp_path: Path) -> None:
+    connector = tmp_path / "mcp.json"
+    _write(
+        connector,
+        {"law": {"url": "https://example.test", "credentialRef": "law-token"}},
+    )
+    sources = (configured_mcp_sources(str(connector))[0],)
+
+    before = resolve_mcp_sources(sources, {"law-token": 1}).servers["law"]
+    after = resolve_mcp_sources(sources, {"law-token": 2}).servers["law"]
+
+    assert before.fingerprint != after.fingerprint
+
+
+def test_reserved_official_name_is_rejected_even_when_connector_is_disconnected(
+    tmp_path: Path,
+) -> None:
+    user = tmp_path / "mcp.json"
+    _write(user, {"pkulaw": {"url": "https://evil.test/mcp"}})
+
+    resolved = resolve_mcp_sources(
+        (configured_mcp_sources(str(user))[0],),
+        reserved_names={"pkulaw"},
+    )
+
+    assert "pkulaw" not in resolved.servers
+    assert resolved.conflicts == ("user:pkulaw uses a protected server name",)
+
+
+def test_connector_source_requires_a_normalized_connector_id(tmp_path: Path) -> None:
+    connector = tmp_path / "connector" / "mcp.json"
+    _write(connector, {"law": {"url": "https://example.test/mcp", "_connectorId": " PKULAW "}})
+
+    source = McpConfigSource("connector", connector)
+    resolved = resolve_mcp_sources((source,))
+    assert resolved.servers["law"].connector_id == "pkulaw"
+
+    _write(connector, {"law": {"url": "https://example.test/mcp", "_connectorId": "bad.id"}})
+    with pytest.raises(ValueError, match="invalid _connectorId"):
+        resolve_mcp_sources((source,))
+
+
+def test_runtime_connector_source_override_does_not_require_a_physical_file(
+    tmp_path: Path,
+) -> None:
+    user = tmp_path / "mcp.json"
+    _write(user, {"mine": {"command": "mine"}})
+    connector = McpConfigSource("connector", Path("<runtime:connector>"))
+
+    resolved = resolve_mcp_sources(
+        (connector, McpConfigSource("user", user)),
+        source_server_overrides={
+            "connector": {
+                "law": {
+                    "url": "https://example.test/mcp",
+                    "_connectorId": "pkulaw",
+                    "_connectorName": "北大法宝",
+                }
+            }
+        },
+    )
+
+    assert resolved.servers["law"].owner == "connector"
+    assert resolved.servers["law"].source_path == "<runtime:connector>"
+    assert resolved.servers["mine"].owner == "user"
+
+
+def test_loader_registers_runtime_connector_source_without_connector_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = tmp_path / "mcp.json"
+    _write(user, {"mine": {"command": "mine"}})
+    monkeypatch.setenv("BOX_AGENT_USER_MCP_CONFIG_PATH", str(user))
+    monkeypatch.delenv("BOX_AGENT_SYSTEM_MCP_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_CONNECTOR_MCP_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_RESERVED_MCP_SERVER_NAMES", raising=False)
+    monkeypatch.setattr(
+        mcp_loader,
+        "_mcp_source_overrides",
+        {
+            "connector": {
+                "law": {
+                    "url": "https://example.test/mcp",
+                    "_connectorId": "pkulaw",
+                }
+            }
+        },
+    )
+
+    resolved = mcp_loader._resolve_registered_sources(str(user))
+
+    assert resolved["law"].owner == "connector"
+    assert resolved["law"].source_path == "<runtime:connector>"
+    assert resolved["mine"].owner == "user"
+
+
+@pytest.mark.asyncio
+async def test_replace_runtime_connector_source_reconciles_in_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_loader, "_mcp_source_overrides", {})
+    captured: list[str | None] = []
+
+    async def reconcile(source: str | None) -> dict:
+        captured.append(source)
+        return {"success": True, "source": source, "results": []}
+
+    monkeypatch.setattr(mcp_loader, "_reconcile_mcp_sources_locked", reconcile)
+
+    result = await mcp_loader.replace_mcp_source(
+        "connector",
+        {
+            "mcpServers": {
+                "law": {
+                    "url": "https://example.test/mcp",
+                    "_connectorId": "pkulaw",
+                }
+            }
+        },
+    )
+
+    assert result["success"] is True
+    assert captured == ["connector"]
+    assert set(mcp_loader._mcp_source_overrides["connector"]) == {"law"}

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -32,12 +32,18 @@ class FakeMCPTool(Tool):
         *,
         always_load: bool = False,
         parameters: dict | None = None,
+        connector_id: str | None = None,
+        connector_name: str | None = None,
+        remote_name: str | None = None,
     ) -> None:
         self._name = name
         self._server_name = server_name
         self._description = description
         self._always_load = always_load
         self._parameters = parameters or {"type": "object", "properties": {}}
+        self._connector_id = connector_id
+        self._connector_name = connector_name
+        self._remote_name = remote_name or name
         self._mcp_generation = 0
         self.calls = 0
 
@@ -64,6 +70,18 @@ class FakeMCPTool(Tool):
     @property
     def mcp_always_load(self) -> bool:
         return self._always_load
+
+    @property
+    def mcp_connector_id(self) -> str | None:
+        return self._connector_id
+
+    @property
+    def mcp_connector_name(self) -> str | None:
+        return self._connector_name
+
+    @property
+    def remote_name(self) -> str:
+        return self._remote_name
 
     @property
     def mcp_generation(self) -> int:
@@ -148,6 +166,229 @@ async def test_search_activates_only_the_calling_session() -> None:
     assert [item.name for item in exposed] == ["find_customer"]
     assert exposed[0].parameters == schema
     assert second.prepare_tools([]).tools == []
+
+
+@pytest.mark.asyncio
+async def test_tool_search_filters_connector_tools_before_ranking_and_activation() -> None:
+    catalog = MCPToolCatalog()
+    pkulaw = FakeMCPTool(
+        "mcp__pkulaw__search_case",
+        "pkulaw",
+        "Search laws and cases",
+        connector_id="pkulaw",
+        connector_name="北大法宝",
+        remote_name="search_case",
+    )
+    qixin = FakeMCPTool(
+        "mcp__qixin__search_company",
+        "qixin",
+        "Search companies",
+        connector_id="qixin",
+        connector_name="启信慧眼",
+        remote_name="search_company",
+    )
+    catalog.replace_server("pkulaw", [pkulaw])
+    catalog.replace_server("qixin", [qixin])
+    activated = OrderedDict()
+    search = ToolSearchTool(
+        catalog,
+        activated,
+        allowed_connector_ids_provider=lambda: frozenset({"pkulaw"}),
+    )
+
+    result = await search.execute(queries=["search"], top_k=5)
+    payload = json.loads(result.content)
+
+    assert payload["catalog_tool_count"] == 1
+    assert payload["activated"] == [
+        {
+            "name": "mcp__pkulaw__search_case",
+            "server_name": "pkulaw",
+            "connector_id": "pkulaw",
+            "connector_name": "北大法宝",
+            "remote_name": "search_case",
+            "description": "Search laws and cases",
+            "already_active": False,
+        }
+    ]
+    assert list(activated) == ["mcp:pkulaw/mcp__pkulaw__search_case"]
+
+
+@pytest.mark.asyncio
+async def test_connector_tool_becomes_hidden_and_uncallable_when_conversation_disables_it() -> None:
+    catalog = MCPToolCatalog()
+    tool = FakeMCPTool(
+        "mcp__pkulaw__search_case",
+        "pkulaw",
+        connector_id="pkulaw",
+    )
+    catalog.replace_server("pkulaw", [tool])
+    activated = OrderedDict()
+    allowed_connector_ids = {"pkulaw"}
+    search = ToolSearchTool(
+        catalog,
+        activated,
+        allowed_connector_ids_provider=lambda: frozenset(allowed_connector_ids),
+    )
+    await search.execute(query="case")
+    manager = MCPToolExposureManager(
+        catalog,
+        activated,
+        allowed_connector_ids_provider=lambda: frozenset(allowed_connector_ids),
+    )
+    offered = manager.prepare_tools([])
+
+    assert [item.name for item in offered.tools] == ["mcp__pkulaw__search_case"]
+    allowed_connector_ids.clear()
+    assert manager.prepare_tools([]).tools == []
+    assert manager.validate_call(
+        "mcp__pkulaw__search_case",
+        offered.mcp_generations["mcp__pkulaw__search_case"],
+        tool,
+    ) == "MCP tool 'mcp__pkulaw__search_case' is not enabled for this conversation; search again."
+
+
+@pytest.mark.asyncio
+async def test_tool_search_activates_all_tools_from_an_enabled_server_without_ranking() -> None:
+    catalog = MCPToolCatalog()
+    tool = FakeMCPTool(
+        "mcp__pkulaw__search_case",
+        "pkulaw-law-search-semantic",
+        connector_id="pkulaw",
+    )
+    catalog.replace_server("pkulaw-law-search-semantic", [tool])
+    activated = OrderedDict()
+    search = ToolSearchTool(
+        catalog,
+        activated,
+        allowed_connector_ids_provider=lambda: frozenset({"pkulaw"}),
+    )
+
+    result = await search.execute(server_name="pkulaw-law-search-semantic")
+
+    payload = json.loads(result.content)
+    assert payload["matched_count"] == 1
+    assert payload["activated_count"] == 1
+    assert payload["activated"][0]["name"] == "mcp__pkulaw__search_case"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("connector", ["pkulaw", "北大法宝", "pkulaw 北大法宝"])
+async def test_tool_search_activates_connector_by_id_or_unique_display_name(
+    connector: str,
+) -> None:
+    catalog = MCPToolCatalog()
+    search_case = FakeMCPTool(
+        "mcp__pkulaw__search_case",
+        "pkulaw-law-search-semantic",
+        connector_id="pkulaw",
+        connector_name="北大法宝 · 法律智能检索",
+    )
+    verify_citation = FakeMCPTool(
+        "mcp__pkulaw__verify_citation",
+        "pkulaw-citation",
+        connector_id="pkulaw",
+        connector_name="北大法宝 · 法律智能检索",
+    )
+    catalog.replace_server("pkulaw-law-search-semantic", [search_case])
+    catalog.replace_server("pkulaw-citation", [verify_citation])
+    activated = OrderedDict()
+    search = ToolSearchTool(
+        catalog,
+        activated,
+        allowed_connector_ids_provider=lambda: frozenset({"pkulaw"}),
+    )
+
+    result = await search.execute(connector=connector)
+
+    payload = json.loads(result.content)
+    assert payload["resolved_connector_id"] == "pkulaw"
+    assert payload["catalog_tool_count"] == 2
+    assert payload["activated_count"] == 2
+    assert {item["name"] for item in payload["activated"]} == {
+        "mcp__pkulaw__search_case",
+        "mcp__pkulaw__verify_citation",
+    }
+
+
+@pytest.mark.asyncio
+async def test_tool_search_does_not_resolve_a_disabled_connector() -> None:
+    catalog = MCPToolCatalog()
+    tool = FakeMCPTool(
+        "mcp__pkulaw__search_case",
+        "pkulaw-law-search-semantic",
+        connector_id="pkulaw",
+        connector_name="北大法宝",
+    )
+    catalog.replace_server("pkulaw-law-search-semantic", [tool])
+    search = ToolSearchTool(
+        catalog,
+        OrderedDict(),
+        allowed_connector_ids_provider=lambda: frozenset(),
+    )
+
+    result = await search.execute(connector="北大法宝")
+
+    payload = json.loads(result.content)
+    assert payload["resolved_connector_id"] is None
+    assert payload["catalog_tool_count"] == 0
+    assert payload["activated_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_connector_does_not_activate_user_mcp_tools() -> None:
+    catalog = MCPToolCatalog()
+    user_tool = FakeMCPTool("custom_lookup", "custom-server")
+    catalog.replace_server("custom-server", [user_tool])
+    activated = OrderedDict()
+    search = ToolSearchTool(catalog, activated)
+
+    result = await search.execute(connector="missing-connector")
+
+    payload = json.loads(result.content)
+    assert payload["resolved_connector_id"] is None
+    assert payload["catalog_tool_count"] == 0
+    assert payload["matched_count"] == 0
+    assert payload["activated_count"] == 0
+    assert activated == OrderedDict()
+
+
+@pytest.mark.asyncio
+async def test_tool_search_does_not_open_ambiguous_connector_name_fragments() -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "law-a",
+        [
+            FakeMCPTool(
+                "search_law_a",
+                "law-a",
+                connector_id="law-a",
+                connector_name="法律检索 A",
+            )
+        ],
+    )
+    catalog.replace_server(
+        "law-b",
+        [
+            FakeMCPTool(
+                "search_law_b",
+                "law-b",
+                connector_id="law-b",
+                connector_name="法律检索 B",
+            )
+        ],
+    )
+    search = ToolSearchTool(
+        catalog,
+        OrderedDict(),
+        allowed_connector_ids_provider=lambda: frozenset({"law-a", "law-b"}),
+    )
+
+    result = await search.execute(connector="法律检索")
+
+    payload = json.loads(result.content)
+    assert payload["resolved_connector_id"] is None
+    assert payload["activated_count"] == 0
 
 
 def test_always_load_is_visible_without_activation() -> None:
@@ -257,6 +498,46 @@ def test_catalog_search_does_not_fuzzy_match_tool_id_prefix() -> None:
     ] == ["navigate"]
 
 
+def test_catalog_search_uses_original_mcp_name_after_public_name_truncation() -> None:
+    catalog = MCPToolCatalog()
+    server_name = "pkulaw-law-search-semantic"
+    remote_name = "mcp-law-search-service.get_article"
+    target_name = mcp_loader._public_mcp_tool_name(
+        server_name,
+        remote_name,
+        "pkulaw",
+    )
+    target = FakeMCPTool(
+        target_name,
+        server_name,
+        "根据法规标题和条号获取法条内容。",
+        connector_id="pkulaw",
+        connector_name="北大法宝",
+        remote_name=remote_name,
+    )
+    distractor = FakeMCPTool(
+        mcp_loader._public_mcp_tool_name(
+            server_name,
+            "law_recognition.law_recognition",
+            "pkulaw",
+        ),
+        server_name,
+        "semantic search of law article.",
+        connector_id="pkulaw",
+        connector_name="北大法宝",
+        remote_name="law_recognition.law_recognition",
+    )
+    catalog.replace_server(server_name, [target, distractor])
+
+    hits = catalog.search_many(
+        ["法条精确取条", "get article"],
+        top_k=1,
+    )
+
+    assert "get_article" not in target_name
+    assert [entry.model_name for entry in hits] == [target_name]
+
+
 def test_catalog_deduplicates_server_terms_already_present_in_model_name() -> None:
     catalog = MCPToolCatalog()
     duplicate = FakeMCPTool(
@@ -349,7 +630,7 @@ def test_search_provider_schemas_do_not_require_top_level_unions() -> None:
         assert schema["type"] == "object"
         assert not {"anyOf", "oneOf", "allOf"}.intersection(schema)
         assert set(schema["properties"]) == {
-            "query", "queries", "tool_names", "server_name", "top_k",
+            "query", "queries", "tool_names", "server_name", "connector", "top_k",
         }
         assert schema["additionalProperties"] is False
 
@@ -359,6 +640,7 @@ def test_search_provider_schemas_do_not_require_top_level_unions() -> None:
     {"query": "forecast"},
     {"queries": ["forecast"]},
     {"tool_names": ["weather/get_forecast"]},
+    {"server_name": "weather"},
     {"query": "forecast", "queries": ["forecast"],
      "tool_names": ["weather/get_forecast"]},
 ])
@@ -383,7 +665,6 @@ async def test_search_invoke_accepts_each_input_form_and_combined_inputs(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("arguments", [
     {},
-    {"top_k": 2, "server_name": "weather"},
     {"query": ""},
     {"query": "  "},
     {"queries": [" "]},
@@ -459,6 +740,66 @@ async def test_exact_tool_names_activate_only_explicit_selections() -> None:
         {"get_forecast", "get_air_quality"}
     )
     assert "get_weather_alerts" not in exposure.offered_names
+
+
+@pytest.mark.asyncio
+async def test_exact_original_mcp_name_activates_provider_safe_connector_tool() -> None:
+    catalog = MCPToolCatalog()
+    server_name = "pkulaw-law-search-semantic"
+    remote_name = "mcp-law-search-service.get_article"
+    model_name = mcp_loader._public_mcp_tool_name(
+        server_name,
+        remote_name,
+        "pkulaw",
+    )
+    tool = FakeMCPTool(
+        model_name,
+        server_name,
+        "根据法规标题和条号获取法条内容。",
+        connector_id="pkulaw",
+        connector_name="北大法宝",
+        remote_name=remote_name,
+    )
+    catalog.replace_server(server_name, [tool])
+    activated = OrderedDict()
+    search = ToolSearchTool(
+        catalog,
+        activated,
+        allowed_connector_ids_provider=lambda: frozenset({"pkulaw"}),
+    )
+
+    result = await search.execute(
+        connector="pkulaw",
+        tool_names=[remote_name],
+    )
+
+    payload = json.loads(result.content)
+    assert payload["matched_count"] == 1
+    assert payload["missing"] == []
+    assert [item["name"] for item in payload["activated"]] == [model_name]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_original_mcp_name_requires_server_qualification() -> None:
+    catalog = MCPToolCatalog()
+    catalog.replace_server(
+        "law",
+        [FakeMCPTool("mcp__law__search", "law", remote_name="search")],
+    )
+    catalog.replace_server(
+        "cases",
+        [FakeMCPTool("mcp__cases__search", "cases", remote_name="search")],
+    )
+    activated = OrderedDict()
+    search = ToolSearchTool(catalog, activated)
+
+    ambiguous = await search.execute(tool_names=["search"])
+    qualified = await search.execute(tool_names=["law/search"])
+
+    assert json.loads(ambiguous.content)["missing"] == ["search"]
+    assert [
+        item["name"] for item in json.loads(qualified.content)["activated"]
+    ] == ["mcp__law__search"]
 
 
 @pytest.mark.asyncio
@@ -948,6 +1289,31 @@ def test_agent_explicit_legacy_mode_keeps_mcp_eager_with_local_discovery(tmp_pat
     assert agent._inherited_tools()["lookup"] is tool
     exposure = agent.mcp_tool_exposure.prepare_tools(list(agent.tools.values()))
     assert exposure.offered_names == frozenset({"lookup", "tool_search"})
+
+
+@pytest.mark.asyncio
+async def test_agent_local_discovery_preserves_connector_grants(tmp_path) -> None:
+    catalog = get_mcp_tool_catalog()
+    catalog.clear()
+    catalog.replace_server("legal", [
+        FakeMCPTool("legal_lookup", "legal", connector_id="law"),
+    ])
+    allowed = {"law"}
+    try:
+        agent = Agent(
+            llm_client=object(), system_prompt="test", tools=[],
+            workspace_dir=str(tmp_path), deferred_mcp_loading_enabled=True,
+            allowed_connector_ids_provider=lambda: frozenset(allowed),
+        )
+        result = await agent.tools["tool_search"].execute(connector="law")
+        assert result.success
+        assert "legal_lookup" in agent._inherited_tools()
+        allowed.clear()
+        assert "legal_lookup" not in agent._inherited_tools()
+        result = await agent.tools["tool_search"].execute(tool_names=["legal_lookup"])
+        assert json.loads(result.content)["activated"] == []
+    finally:
+        catalog.clear()
 
 
 def test_late_mcp_registration_cannot_replace_session_search_control() -> None:

--- a/tests/test_mcp_tool_search.py
+++ b/tests/test_mcp_tool_search.py
@@ -215,7 +215,8 @@ async def test_tool_search_filters_connector_tools_before_ranking_and_activation
 
 
 @pytest.mark.asyncio
-async def test_connector_tool_becomes_hidden_and_uncallable_when_conversation_disables_it() -> None:
+@pytest.mark.parametrize("deferred", [True, False])
+async def test_connector_tool_becomes_hidden_and_uncallable_when_conversation_disables_it(deferred) -> None:
     catalog = MCPToolCatalog()
     tool = FakeMCPTool(
         "mcp__pkulaw__search_case",
@@ -234,13 +235,21 @@ async def test_connector_tool_becomes_hidden_and_uncallable_when_conversation_di
     manager = MCPToolExposureManager(
         catalog,
         activated,
+        deferred_mcp=deferred,
         allowed_connector_ids_provider=lambda: frozenset(allowed_connector_ids),
     )
-    offered = manager.prepare_tools([])
+    candidates = [] if deferred else [tool]
+    allowed_connector_ids.clear()
+    assert manager.prepare_tools(candidates).tools == []
+    assert manager.inherited_tools({tool.name: tool}) == {}
+    allowed_connector_ids.add("pkulaw")
+    offered = manager.prepare_tools(candidates)
 
     assert [item.name for item in offered.tools] == ["mcp__pkulaw__search_case"]
     allowed_connector_ids.clear()
-    assert manager.prepare_tools([]).tools == []
+    assert manager.prepare_tools(candidates).tools == []
+    assert manager.inherited_tools({tool.name: tool}) == {}
+    assert manager.validate_call(tool.name, None, tool) is not None
     assert manager.validate_call(
         "mcp__pkulaw__search_case",
         offered.mcp_generations["mcp__pkulaw__search_case"],

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -194,6 +194,7 @@ class TestDetectDangerousCommand:
             ("BOX_AGENT_PYTHON", "${BOX_AGENT_PYTHON:-python3}"),
             ("BOX_AGENT_NPM", "${BOX_AGENT_NPM:-npm}"),
             ("BOX_AGENT_NPX", "${BOX_AGENT_NPX:-npx}"),
+            ("BOX_AGENT_SOFFICE", "$BOX_AGENT_SOFFICE"),
         ],
     )
     def test_injected_runtime_executable_reference_is_trusted(
@@ -213,20 +214,22 @@ class TestDetectDangerousCommand:
         ) is None
 
     @pytest.mark.parametrize(
-        "environment",
+        ("environment", "reference"),
         [
-            {},
-            {"BOX_AGENT_NODE": "node"},
+            ({}, "${BOX_AGENT_NODE:-node}"),
+            ({"BOX_AGENT_NODE": "node"}, "${BOX_AGENT_NODE:-node}"),
+            ({"BOX_AGENT_SOFFICE": "soffice"}, "$BOX_AGENT_SOFFICE"),
         ],
     )
     def test_unverified_runtime_executable_reference_requires_approval(
         self,
         environment,
+        reference,
     ):
         trusted = trusted_runtime_executable_references(environment)
 
         assert detect_dangerous_command(
-            "${BOX_AGENT_NODE:-node} scripts/validate.js",
+            f"{reference} scripts/validate.js",
             trusted_executable_references=trusted,
         ) is not None
 

--- a/tests/test_session_adapter_assembly.py
+++ b/tests/test_session_adapter_assembly.py
@@ -93,6 +93,52 @@ async def test_acp_sessions_share_runtime_and_rebind_closes_only_old_session(tmp
 
 
 @pytest.mark.asyncio
+async def test_managed_session_keeps_connector_skill_grants_for_parent_and_child(tmp_path, monkeypatch):
+    from box_agent.tools.skill_loader import SKILL_SLOT_SENTINEL, SkillLoader
+    from box_agent.tools.skill_tool import GetSkillTool
+    from tests.test_connector_skill_source import _write_connector_skill
+
+    connector_root = tmp_path / "connector-skills"
+    _write_connector_skill(connector_root)
+    loader = SkillLoader(sources=[(connector_root, "connector")])
+    loader.discover_skills()
+    monkeypatch.setattr(acp, "_connected_connector_ids", lambda selected: frozenset(selected))
+    config = Config(
+        llm=LLMConfig(api_key="test"),
+        agent=AgentConfig(workspace_dir=str(tmp_path), enable_memory=False),
+        tools=ToolsConfig(enable_mcp=False, enable_skills=True, enable_sub_agent=True,
+                          enable_file_tools=False, enable_bash=False),
+    )
+    adapter = acp.BoxACPAgent(
+        DummyConn(), config, DoneLLM(), [GetSkillTool(loader)],
+        f"BASE\n{SKILL_SLOT_SENTINEL}", skill_loader=loader,
+    )
+    try:
+        response = await adapter.newSession(SimpleNamespace(cwd=str(tmp_path), field_meta={}))
+        state = adapter._sessions[response.sessionId]
+        skill_tool = state.agent.tools["get_skill"]
+        child_tool = state.agent.tools["sub_agent"]
+        denied = await skill_tool.execute(skill_name="pkulaw")
+        assert not denied.success and "not enabled" in denied.error
+        denied_child = await child_tool.execute(task="Search the law", skills=["pkulaw"], required_tools=[])
+        assert not denied_child.success
+        catalog_update = state.skill_selector.update("pkulaw")
+        assert "pkulaw" not in (catalog_update or "")
+        assert "pkulaw" not in state.skill_selector.matched_skill_names
+
+        await adapter.prompt(SimpleNamespace(
+            sessionId=response.sessionId, prompt=[{"text": "pkulaw legal search"}],
+            field_meta={"selected_connector_ids": ["pkulaw"]},
+        ))
+        assert state.connector_skill_grants == {"pkulaw"}
+        assert (await skill_tool.execute(skill_name="pkulaw")).success
+        allowed_child = await child_tool.execute(task="Search the law", skills=["pkulaw"], required_tools=[])
+        assert allowed_child.success
+    finally:
+        await adapter.aclose()
+
+
+@pytest.mark.asyncio
 async def test_cli_shared_prompt_controls_model_and_session_closes(tmp_path, monkeypatch):
     import sys
 

--- a/tests/test_tool_engine_compatibility.py
+++ b/tests/test_tool_engine_compatibility.py
@@ -1,7 +1,7 @@
 """C1 characterization of the pre-Engine setup and Agent tool contract.
 
-The fixed C1 fixture remains intact. Only the enumerated C5 changes and the
-declared session-cwd description migration are applied before exact comparisons.
+The fixed C1/C5 fixtures remain intact. Enumerated C5 changes, session-cwd
+description changes and the connector search extension are applied before exact comparisons.
 Network/runtime discovery is isolated; setup, tools, stores and Agent are real.
 """
 
@@ -54,6 +54,11 @@ _C5_SCHEMA_CHANGES = json.loads(
 )
 _CWD_SCHEMA_CHANGES = json.loads(
     (Path(__file__).parent / "fixtures/tool_engine/session_cwd_schema_changes.json").read_text()
+)
+_CONNECTOR_SEARCH_SCHEMA = json.loads(
+    (Path(__file__).parent / "fixtures/tool_engine/connector_search_schema.json").read_text(
+        encoding="utf-8"
+    )
 )
 _C5_DISCOVERABLE = {
     "append_file", "query_jsonl", "bash_output", "bash_kill", "sandbox_status",
@@ -227,6 +232,8 @@ def _assert_schema_contract(tools, profile, *, child_read_tools=()):
                 target = target[key]
             assert target[field] == change["before"], (tool.name, change["path"])
             target[field] = change["after"]
+        if tool.name == "tool_search":
+            entry["schema"] = _CONNECTOR_SEARCH_SCHEMA
         if tool.name == "sub_agent":
             # This default is the one capability-dependent schema field. The
             # caller supplies the independently expected read set, never a set

--- a/tests/test_utility_sessions.py
+++ b/tests/test_utility_sessions.py
@@ -157,13 +157,20 @@ async def test_eager_mcp_refresh_keeps_utility_registry_and_provider_tools_empty
         normal = await adapter.newSession(SimpleNamespace(cwd=str(workspace), field_meta={}))
         state = adapter._sessions[utility.sessionId]
         assert state.agent.tools == {}
+        state.turn_active = True
+        adapter._sessions[normal.sessionId].turn_active = True
         if refresh == "background":
             adapter._sync_mcp_registries([remote])
+            adapter._inject_mcp_runtime_update(name="law", state="connected", tool_count=1)
         else:
             await adapter.extMethod(refresh, {"source": "connector", "config": {"mcpServers": {}}})
         assert "connector_lookup" in adapter._sessions[normal.sessionId].agent.tools
         assert state.agent.tools == {}
         assert not state.mcp_fallback_tools
+        assert state.inject_queue.empty()
+        assert not adapter._sessions[normal.sessionId].inject_queue.empty()
+        state.turn_active = False
+        adapter._sessions[normal.sessionId].turn_active = False
         await adapter.prompt(SimpleNamespace(
             sessionId=utility.sessionId, prompt=[{"text": "write a title"}], field_meta={},
         ))

--- a/tests/test_utility_sessions.py
+++ b/tests/test_utility_sessions.py
@@ -50,6 +50,7 @@ def configured_adapter(tmp_path, monkeypatch, llm):
     # level override escape that profile while this fixture builds an adapter
     # directly instead of going through run_acp_server().
     monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.delenv("BOX_AGENT_SKILL_TOOLS_ROOT", raising=False)
     config = Config(
         llm=LLMConfig(api_key="test-key", model=llm.model),
         agent=AgentConfig(workspace_dir=str(workspace), enable_memory=False),
@@ -130,3 +131,42 @@ async def test_utility_preserves_box_session_log_context_after_recreation(tmp_pa
         assert llm.calls and all(not tools for _, tools in llm.calls)
     finally:
         state.agent.session_log.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("refresh", ["mcp/source/replace", "mcp/reconcile", "background"])
+async def test_eager_mcp_refresh_keeps_utility_registry_and_provider_tools_empty(
+    tmp_path, monkeypatch, refresh,
+):
+    from unittest.mock import AsyncMock
+    from box_agent.tools import mcp_loader
+    from tests.test_mcp_tool_search import FakeMCPTool
+
+    llm = RecordingLLM()
+    adapter, workspace = configured_adapter(tmp_path, monkeypatch, llm)
+    adapter._config.tools.enable_mcp = True
+    adapter._config.tools.mcp.deferred_loading_enabled = False
+    remote = FakeMCPTool("connector_lookup", "law", connector_id="law")
+    monkeypatch.setattr(mcp_loader, "get_all_mcp_tools", lambda: [remote])
+    monkeypatch.setattr(mcp_loader, "get_mcp_tools_for_server", lambda name: [remote])
+    result = {"success": True, "results": [{"name": "law", "action": "added", "success": True}]}
+    monkeypatch.setattr(mcp_loader, "replace_mcp_source", AsyncMock(return_value=result))
+    monkeypatch.setattr(mcp_loader, "reconcile_mcp_sources", AsyncMock(return_value=result))
+    try:
+        utility = await adapter.newSession(SimpleNamespace(cwd=str(workspace), field_meta={"utility": True}))
+        normal = await adapter.newSession(SimpleNamespace(cwd=str(workspace), field_meta={}))
+        state = adapter._sessions[utility.sessionId]
+        assert state.agent.tools == {}
+        if refresh == "background":
+            adapter._sync_mcp_registries([remote])
+        else:
+            await adapter.extMethod(refresh, {"source": "connector", "config": {"mcpServers": {}}})
+        assert "connector_lookup" in adapter._sessions[normal.sessionId].agent.tools
+        assert state.agent.tools == {}
+        assert not state.mcp_fallback_tools
+        await adapter.prompt(SimpleNamespace(
+            sessionId=utility.sessionId, prompt=[{"text": "write a title"}], field_meta={},
+        ))
+        assert llm.calls and all(not tools for _, tools in llm.calls)
+    finally:
+        await adapter.aclose()


### PR DESCRIPTION
## Task

Isolate system, connector and user MCP sources, restore process-local connector credentials after ACP startup, and bind connector selection to tool/Skill access and child capabilities. Source updates preserve unrelated owners and synchronize connection publication with removal or disable operations.

Rebased onto main 3f70b0a2bad78414c0f2016dc510128df8591e21, including #118 stable cwd and #120 managed Session preparation/cleanup. Parent and child Skill filters retain the same loader and mutable session grants. Utility sessions remain free of tools, connector-status context and asynchronous MCP discovery prompts.

The source lifecycle now covers same-name source transitions, connector-scoped name conflicts, partial removal of a multi-server connector, in-flight reconnects, cold discovery and its startup gate. Independent hot operations remain parallel. This also recognizes BOX_AGENT_SOFFICE and records connector capability versions in the runtime manifest.

Out of scope: OfficeV3 connector UI/OAuth product flows, scheduled/IM/mobile adapters, installed application upgrades and real external connector calls.

## Proof

Current Head: 9c7b241786921b5e46a6cad17b6915dbd40c7859.
Executable source/test baseline: be3c151a0d056623795b6c799a298919e6ed6ae0. The last commit only refreshes the generated graph trio.

- `bash general_review/ci/preflight.sh` at that source baseline: **4234 passed, 19 skipped, 1 deselected, 3 warnings**, 527.01 seconds. Locked dependency sync, compileall, full tests, sdist and wheel builds succeeded.
- `uv run pytest tests/test_mcp_sources.py tests/test_mcp_tool_search.py tests/test_acp.py tests/test_utility_sessions.py tests/test_mcp_runtime.py tests/test_session_adapter_assembly.py -q --tb=short` — **284 passed**.
- `uv run pytest tests/test_mcp.py tests/test_mcp_*.py tests/test_connector_skill_source.py tests/test_local_tool_search.py -q --tb=short --deselect tests/test_mcp.py::test_connection_timeout_on_unreachable_server` — **223 passed, 3 skipped, 1 deselected**.
- Controlled Event regressions exercise hot reconnect versus remove/disable while another server starts independently; cold discovery versus remove/disable/replace; pre-gate and lock-wait readiness timeouts; and unchanged state on timeout. The original reconnect race probe now exits 0 with no revoked connection, tool or conversation grant remaining.
- Credential injection into non-connector definitions is rejected in both parsing and materialization. Eager/deferred exposure, child inheritance and runtime call validation share connector authorization. Actual managed utility sessions retain empty registries, queues and provider tool lists through source/background refreshes, while normal sessions still receive updates.
- Original ownership probes and tests verify that removing a connector closes its connection without activating a revealed user fallback, scoped updates cannot overwrite another connector's server name, and historical removed-server statuses do not deny remaining healthy members. Missing status for a currently configured member still fails closed.
- Graph regenerated at be3c151a: **410 files, 2205 nodes, 5017 edges**, 624 internal imports, 95 changed-symbol ranges and all 410 fingerprints validated. Strict schema has 0 issues; layers/tour are unchanged; 87 existing orphan warnings remain.
- `git diff --check` passed. Remote checks must complete for this exact new Head before re-review and merge.

The full run reported one requests dependency-version warning and two existing tar extraction deprecation warnings.

## Risk

- Connector tools require explicit conversation selection and valid runtime connection state. Previously loaded Skill guidance retains the existing conversation-grant behavior; it does not grant MCP execution permission.
- Runtime credentialRef is connector-only. User/system files with that field fail validation and must use their own supported authentication configuration. Credentials stay process-local and must be reinjected after ACP restart, before the connector source is published.
- Source changes wait for initial discovery, including the startup gate. A bounded readiness timeout rejects the update without applying runtime/override changes; hosts must retry after startup is ready. Ordinary hot reconnects do not impose this startup barrier on unrelated servers.
- Scoped name collisions return failure without replacing untargeted connectors. A revealed user fallback requires its own explicit reconciliation. Revocation may wait for the same server's bounded pending connection before completing.
- Source tests and Python distributions are verified. Standalone runtime build/install, saved OAuth/token restoration, real-provider connectivity, OfficeV3 restart and fresh installed-host tasks were not performed.
- Rollback must coordinate runtime code and host protocol usage. Session Logs and user files are not migrated. OfficeV3 and scheduled/IM/mobile entrypoints require separate integration validation.

## Target branch consistency

Main was not merged into the contributor branch. Rebase resolution retained #118 cwd/schema behavior, #120 shared lifecycle and interrupted cleanup ordering, reasoning settings and utility isolation. Both adapters use shared capability preparation; source ownership and Tool permissions remain enforced in their capability modules.
