### PR TITLE
fix(llm): preserve thinking settings in subagents and utility calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ box-agent doctor --json             # machine-readable health check
 
 Hosts may opt into a dedicated absolute `BOX_AGENT_HOME` before starting the runtime. This routes Box-Agent-owned configuration and state away from the default user profile without changing the operating-system `HOME`; unset behavior stays compatible. Explicit profiles require their own `config/config.yaml` and never fall back to legacy configuration or login-token environment variables.
 
+For endpoints that reject `reasoning_effort: "none"`, see
+[reasoning configuration](docs/reasoning-configuration.md) for the explicit
+`reasoning_effort_when_disabled: low` compatibility option and child Agent inheritance.
+
 See [isolated runtime profiles](docs/isolated-runtime-profile.md) and the no-background-startup [example configuration](box_agent/config/isolated-profile-example.yaml). This is path/configuration isolation, not an OS sandbox or permission to call a model.
 
 ## CLI Usage

--- a/box_agent/acp/__init__.py
+++ b/box_agent/acp/__init__.py
@@ -5448,6 +5448,7 @@ async def run_acp_server(config: Config | None = None) -> None:
             max_output_tokens=config.llm.max_output_tokens,
             auth_file=config.llm.auth_file,
             timeout=config.llm.timeout,
+            reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
         )
 
         # Kept as a constructor compatibility alias only. Internal calls now

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -1030,6 +1030,9 @@ class Agent:
             self.local_tool_exposure.require_tools(("plan_read", "plan_write"))
 
         sub_agent_tool = self.tools.get("sub_agent")
+        set_child_thinking = getattr(sub_agent_tool, "set_thinking_enabled", None)
+        if callable(set_child_thinking):
+            set_child_thinking(self.thinking_enabled)
         set_child_negotiator = getattr(
             sub_agent_tool,
             "set_permission_negotiator",

--- a/box_agent/agent_runtime.py
+++ b/box_agent/agent_runtime.py
@@ -39,6 +39,7 @@ def build_llm_client(
     max_output_tokens: int,
     auth_file: str,
     timeout: float,
+    reasoning_effort_when_disabled: str | None = None,
     client_factory: LLMClientFactory = LLMClient,
     retry_callback: RetryCallback | None = None,
 ) -> LLMClient:
@@ -58,6 +59,11 @@ def build_llm_client(
         max_output_tokens=max_output_tokens,
         auth_file=auth_file,
         timeout=timeout,
+        **(
+            {"reasoning_effort_when_disabled": reasoning_effort_when_disabled}
+            if reasoning_effort_when_disabled is not None
+            else {}
+        ),
     )
     if retry_callback is not None:
         client.retry_callback = retry_callback

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -225,6 +225,7 @@ MAIN_LLM_KEYS = {
     "context_window",
     "max_output_tokens",
     "timeout",
+    "reasoning_effort_when_disabled",
 }
 
 AGENT_KEYS = frozenset(AgentConfig.model_fields)

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -328,6 +328,7 @@ def _config_summary(config: Config, config_path: Path, show_secrets: bool = Fals
             "context_window": config.llm.context_window,
             "max_output_tokens": config.llm.max_output_tokens,
             "timeout": config.llm.timeout,
+            "reasoning_effort_when_disabled": config.llm.reasoning_effort_when_disabled,
             "retry": {
                 "enabled": config.llm.retry.enabled,
                 "max_retries": config.llm.retry.max_retries,
@@ -345,6 +346,7 @@ def _config_summary(config: Config, config_path: Path, show_secrets: bool = Fals
             "auth_file": config.lite_llm.auth_file,
             "max_output_tokens": config.lite_llm.max_output_tokens,
             "timeout": config.lite_llm.timeout,
+            "reasoning_effort_when_disabled": config.lite_llm.reasoning_effort_when_disabled,
         },
         "image_generation": {
             "configured": bool(config.image_generation.endpoint),
@@ -1469,6 +1471,7 @@ async def _doctor_api_status(config: Config | None) -> dict[str, Any]:
             max_output_tokens=config.llm.max_output_tokens,
             auth_file=config.llm.auth_file,
             timeout=config.llm.timeout,
+            reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
         )
         response = await _probe_llm_api(client)
         if response and response.content:
@@ -1881,6 +1884,7 @@ async def run_agent(
         max_output_tokens=config.llm.max_output_tokens,
         auth_file=config.llm.auth_file,
         timeout=config.llm.timeout,
+        reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
     )
 
     # Set retry callback
@@ -1904,6 +1908,7 @@ async def run_agent(
                 max_output_tokens=config.llm.max_output_tokens,
                 auth_file=config.llm.auth_file,
                 timeout=config.llm.timeout,
+                reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
             )
             await _probe_llm_api(_verify_client)
             print(f"{Colors.GREEN}OK{Colors.RESET}")
@@ -1942,6 +1947,7 @@ async def run_agent(
                             max_output_tokens=config.llm.max_output_tokens,
                             auth_file=config.llm.auth_file,
                             timeout=config.llm.timeout,
+                            reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
                         )
                         if config.llm.retry.enabled:
                             llm_client.retry_callback = on_retry
@@ -1956,6 +1962,7 @@ async def run_agent(
                             max_output_tokens=config.llm.max_output_tokens,
                             auth_file=config.llm.auth_file,
                             timeout=config.llm.timeout,
+                            reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
                         )
                         await _probe_llm_api(_verify_client2)
                         print(f"{Colors.GREEN}OK{Colors.RESET}")

--- a/box_agent/config.py
+++ b/box_agent/config.py
@@ -5,6 +5,7 @@ Provides unified configuration loading and management functionality
 
 import shutil
 from pathlib import Path
+from typing import Literal
 from urllib.parse import urlparse
 
 import yaml
@@ -87,6 +88,9 @@ class LLMConfig(BaseModel):
     # stalls before the first token.
     timeout: float = 1200.0
     retry: RetryConfig = Field(default_factory=RetryConfig)
+    # Endpoint-specific fallback when its reasoning dialect normally sends
+    # "none". "low" requests reduced reasoning; it does not disable reasoning.
+    reasoning_effort_when_disabled: Literal["none", "low"] | None = None
 
     @property
     def context_token_limit(self) -> int:
@@ -123,6 +127,7 @@ class LiteLLMConfig(BaseModel):
     # the main model's long-running agent allowance.
     timeout: float = 600.0
     retry: RetryConfig = Field(default_factory=RetryConfig)
+    reasoning_effort_when_disabled: Literal["none", "low"] | None = None
 
 
 class ImageGenerationConfig(BaseModel):
@@ -483,6 +488,7 @@ class Config(BaseModel):
             max_output_tokens=data.get("max_output_tokens", default_max_output_tokens),
             timeout=float(data.get("timeout", 1200.0) or 1200.0),
             retry=retry_config,
+            reasoning_effort_when_disabled=data.get("reasoning_effort_when_disabled"),
         )
 
         # Parse optional lite_llm block. Mirrors the main LLM auth rules:
@@ -534,6 +540,7 @@ class Config(BaseModel):
                 max_output_tokens=lite_max_output_tokens,
                 timeout=float(lite_llm_data.get("timeout", 600.0) or 600.0),
                 retry=lite_retry,
+                reasoning_effort_when_disabled=lite_llm_data.get("reasoning_effort_when_disabled"),
             )
             lite_llm_config._present = True
 

--- a/box_agent/llm/llm_wrapper.py
+++ b/box_agent/llm/llm_wrapper.py
@@ -169,6 +169,7 @@ class LLMClient:
         auth_token: str = "",
         auth_file: str = "",
         timeout: float = 600.0,
+        reasoning_effort_when_disabled: str | None = None,
     ):
         """Initialize LLM client with specified provider.
 
@@ -192,6 +193,9 @@ class LLMClient:
         self.auth_token = auth_token
         self.auth_file = auth_file
         self.timeout = timeout
+        if reasoning_effort_when_disabled not in (None, "none", "low"):
+            raise ValueError("reasoning_effort_when_disabled must be null, 'none' or 'low'")
+        self.reasoning_effort_when_disabled = reasoning_effort_when_disabled
 
         # Normalize api_base (remove trailing slash)
         api_base = api_base.rstrip("/")
@@ -220,6 +224,7 @@ class LLMClient:
                 auth_token=auth_token,
                 auth_file=auth_file,
                 timeout=timeout,
+                reasoning_effort_when_disabled=reasoning_effort_when_disabled,
             )
         else:
             raise ValueError(f"Unsupported provider: {provider}")

--- a/box_agent/llm/model_profiles.py
+++ b/box_agent/llm/model_profiles.py
@@ -79,6 +79,9 @@ def load_model_profile_revision(
     profile_id = _required_text(profile.get("profileId"), field="profileId")
     if _required_text(profile.get("profileRevision"), field="profileRevision") != revision:
         raise ModelProfileUnavailable("model profile revision identity is inconsistent")
+    disabled_effort = profile.get("reasoningEffortWhenDisabled")
+    if disabled_effort not in (None, "none", "low"):
+        raise ModelProfileUnavailable("model profile reasoningEffortWhenDisabled is invalid")
 
     return {
         "profileId": profile_id,
@@ -95,6 +98,7 @@ def load_model_profile_revision(
             profile.get("maxTokens"), field="maxTokens", default=63_999
         ),
         "timeout": float(profile.get("timeout") or 1200.0),
+        **({"reasoningEffortWhenDisabled": disabled_effort} if disabled_effort is not None else {}),
     }
 
 
@@ -123,6 +127,11 @@ def client_for_model_profile(
         max_output_tokens=max_output_tokens,
         auth_file=profile["authFile"],
         timeout=profile["timeout"],
+        **(
+            {"reasoning_effort_when_disabled": profile["reasoningEffortWhenDisabled"]}
+            if profile.get("reasoningEffortWhenDisabled") is not None
+            else {}
+        ),
     )
 
 

--- a/box_agent/llm/openai_client.py
+++ b/box_agent/llm/openai_client.py
@@ -114,6 +114,7 @@ def _apply_thinking_params(
     *,
     model: str | None,
     thinking_enabled: bool,
+    reasoning_effort_when_disabled: str | None = None,
 ) -> None:
     """Map the session deep-think flag to the provider request dialect."""
     normalized_model = (model or "").strip().casefold()
@@ -135,13 +136,13 @@ def _apply_thinking_params(
         if thinking_enabled:
             params["reasoning_effort"] = _DEEP_THINK_REASONING_EFFORT
         elif not any(marker in normalized_model for marker in _GEMINI_NO_DISABLE_MARKERS):
-            params["reasoning_effort"] = "none"
+            params["reasoning_effort"] = reasoning_effort_when_disabled or "none"
         return
     if thinking_enabled:
         params["reasoning_effort"] = _DEEP_THINK_REASONING_EFFORT
         return
     if _is_sensenova_model(model):
-        params["reasoning_effort"] = "none"
+        params["reasoning_effort"] = reasoning_effort_when_disabled or "none"
 
 
 def _tool_parameter_types(
@@ -487,6 +488,7 @@ class OpenAIClient(LLMClientBase):
         auth_token: str = "",
         auth_file: str = "",
         timeout: float = 600.0,
+        reasoning_effort_when_disabled: str | None = None,
     ):
         """Initialize OpenAI client.
 
@@ -499,6 +501,9 @@ class OpenAIClient(LLMClientBase):
             auth_token: Optional in-memory product login token.
             auth_file: Optional auth.json path read before every request.
             timeout: Wall-clock cap (seconds) for each request to the API.
+            reasoning_effort_when_disabled: Endpoint override for dialects that
+                normally send "none" when thinking is disabled. "low" reduces
+                reasoning; it does not guarantee that reasoning is disabled.
         """
         super().__init__(
             api_key, api_base, model, retry_config,
@@ -510,6 +515,9 @@ class OpenAIClient(LLMClientBase):
         # room to finish tool-call JSON, then it clears itself after the
         # next generate/generate_stream call.
         self._ephemeral_max_output_tokens: int | None = None
+        if reasoning_effort_when_disabled not in (None, "none", "low"):
+            raise ValueError("reasoning_effort_when_disabled must be null, 'none' or 'low'")
+        self.reasoning_effort_when_disabled = reasoning_effort_when_disabled
 
         # Initialize OpenAI client
         self.client = AsyncOpenAI(
@@ -574,6 +582,7 @@ class OpenAIClient(LLMClientBase):
             params,
             model=self.model,
             thinking_enabled=thinking_enabled,
+            reasoning_effort_when_disabled=getattr(self, "reasoning_effort_when_disabled", None),
         )
 
         auth_headers = await self._auth_headers(
@@ -950,6 +959,7 @@ class OpenAIClient(LLMClientBase):
             params,
             model=self.model,
             thinking_enabled=thinking_enabled,
+            reasoning_effort_when_disabled=getattr(self, "reasoning_effort_when_disabled", None),
         )
 
         should_buffer_sensenova_tool_markup = bool(
@@ -1021,7 +1031,11 @@ class OpenAIClient(LLMClientBase):
                 response_stream = await _open_stream()
             except Exception as exc:
                 log_llm_error_meta(provider="openai", mode="stream", exc=exc)
-                if attempt < max_attempts - 1 and is_retryable_stream_error(exc):
+                if (
+                    attempt < max_attempts - 1
+                    and is_retryable_llm_error(exc)
+                    and is_retryable_stream_error(exc)
+                ):
                     delay = self.retry_config.calculate_delay(attempt)
                     logger.warning(
                         "openai generate_stream open attempt %d/%d failed: %s; retrying in %.2fs",
@@ -1161,7 +1175,7 @@ class OpenAIClient(LLMClientBase):
                             break
             except Exception as exc:
                 log_llm_error_meta(provider="openai", mode="stream", exc=exc)
-                if is_retryable_stream_error(exc):
+                if is_retryable_llm_error(exc) and is_retryable_stream_error(exc):
                     if any_user_yield:
                         # Once we've yielded deltas to the consumer we cannot
                         # rewind — surface partial content instead of retrying.

--- a/box_agent/mcp_servers/web_extract_server.py
+++ b/box_agent/mcp_servers/web_extract_server.py
@@ -37,6 +37,7 @@ def _create_configured_llm() -> LLMClient:
         max_output_tokens=config.llm.max_output_tokens,
         auth_file=config.llm.auth_file,
         timeout=config.llm.timeout,
+        reasoning_effort_when_disabled=config.llm.reasoning_effort_when_disabled,
     )
 
 

--- a/box_agent/tools/sub_agent_tool.py
+++ b/box_agent/tools/sub_agent_tool.py
@@ -269,9 +269,11 @@ class SubAgentTool(EventEmittingTool):
         artifact_detection_enabled: bool = True,
         artifact_root_dir: str | None = None,
         provider_stale_seconds: float | None = None,
+        thinking_enabled: bool = False,
     ):
         super().__init__()
         self._llm = llm
+        self._thinking_enabled = thinking_enabled
         # Snapshot taken at construction time. Used as a fallback only; the
         # live parent tool map is preferred (see ``set_tool_provider``) so that
         # tools that load *after* construction — notably MCP tools such as
@@ -308,6 +310,10 @@ class SubAgentTool(EventEmittingTool):
         """Attach the parent's canonical log so children can persist lineage."""
 
         self._parent_session_log = session_log
+
+    def set_thinking_enabled(self, enabled: bool) -> None:
+        """Bind the parent session's current thinking setting before a turn."""
+        self._thinking_enabled = enabled
 
     def _create_child_session_log(
         self,
@@ -768,6 +774,7 @@ class SubAgentTool(EventEmittingTool):
                 llm=llm,
                 messages=messages,
                 tools=child_tools,
+                thinking_enabled=self._thinking_enabled,
                 max_steps=max_steps,
                 max_tool_calls=max_tool_calls,
                 tool_limits=self._tool_limits,
@@ -1166,7 +1173,7 @@ class SubAgentTool(EventEmittingTool):
             synthesis = llm.generate(
                 messages=messages,
                 tools=None,
-                thinking_enabled=False,
+                thinking_enabled=self._thinking_enabled,
                 call_kind="subagent_step",
             )
             if self._batch_synthesis_timeout_seconds > 0:

--- a/docs/reasoning-configuration.md
+++ b/docs/reasoning-configuration.md
@@ -1,0 +1,92 @@
+# Thinking and endpoint compatibility
+
+The session decides whether the Agent should request thinking. The provider
+adapter translates that choice into the model's API dialect. A child Agent
+inherits its parent's current choice in both ordinary delegation and batch file
+synthesis. Changing the parent setting between turns also changes subsequent
+children; standalone `SubAgentTool` callers can pass `thinking_enabled` explicitly.
+
+Utility calls, including image inspection, long-page summaries and the
+continuation judge, continue to request `thinking_enabled=False`. They use the
+same provider adapter, so endpoint compatibility applies to them too.
+
+## Endpoints that reject `none`
+
+Some OpenAI-compatible endpoints accept only `low`, `medium` and `high` for
+`reasoning_effort`. For a model dialect that normally sends `none` when thinking
+is disabled, set this optional **root-level** key in that endpoint's
+`config/config.yaml`:
+
+```yaml
+reasoning_effort_when_disabled: low
+```
+
+Keep the existing endpoint, model and credentials in that file. For an isolated
+runtime, edit the configuration under its own `BOX_AGENT_HOME`.
+
+| Value | Effect when the model dialect normally sends `none` |
+| --- | --- |
+| omitted or `null` | Preserve the existing provider behavior: send `none`. |
+| `none` | Explicitly retain `none`. |
+| `low` | Send `low` instead. This reduces reasoning; it does **not** guarantee reasoning is disabled. |
+
+Other values fail configuration validation. This option affects the existing
+SenseNova and eligible Gemini `none` mappings. It does not force a reasoning
+field onto other models or alter their native thinking controls. Requests with
+thinking enabled retain the existing mapping, including `high` for SenseNova.
+Anthropic requests are unchanged.
+
+The CLI can update and inspect the same setting:
+
+```bash
+box-agent config --set reasoning_effort_when_disabled low
+box-agent config --get llm.reasoning_effort_when_disabled
+```
+
+Remove the key or set it to `null` to restore the previous behavior. No automatic
+parameter negotiation is performed. A deterministic HTTP 422 is returned as an
+error without repeating the same invalid request, including in the streaming
+path. Retryable transport/service failures retain their existing retry policy.
+
+## Configuration ownership and process boundaries
+
+| Client or process | Source of this option |
+| --- | --- |
+| CLI, API verification and ACP startup client | Main `config.yaml` root key. |
+| A `.for_model()` clone | The original client's endpoint option; selecting a different model keeps the same endpoint. |
+| A session bound to an immutable model profile | That profile's optional `reasoningEffortWhenDisabled` field. It does not inherit the fallback client's option. |
+| Bundled web-extraction MCP server | Its own `Config.load()`. Managed MCP configuration forwards `BOX_AGENT_HOME` so the subprocess reads the intended profile directory. |
+| Legacy `lite_llm` configuration block | Its own optional `reasoning_effort_when_disabled`, defaulting to `null` independently of the main endpoint. Current CLI/ACP utility routing uses the main client; adding a `lite_llm` block does not enable a separate utility client. |
+
+For hosts that generate model-profile revisions, include the option in the
+new revision for the affected endpoint, for example:
+
+```json
+{
+  "profileId": "compatible-service",
+  "profileRevision": "compatible-service-r2",
+  "provider": "openai",
+  "apiBase": "https://inference.example/v1",
+  "defaultModel": "SenseNova-Flash-example",
+  "reasoningEffortWhenDisabled": "low"
+}
+```
+
+This is one profile entry in the existing registry, with credentials supplied
+through the existing profile mechanism. The runtime supports this field; a host
+that writes registry entries must include it explicitly. Do not mutate an old
+immutable revision to change its meaning.
+
+After changing configuration, recreate the Agent client and restart the MCP
+subprocess. The web-extraction server caches its client; editing a file does not
+change an already running process. If an MCP server uses another
+`BOX_AGENT_HOME`, configure that profile separately.
+
+## Verification boundary
+
+The regression tests exercise both SDK request paths, parent-to-child inheritance
+across turns, utilities, profile isolation, deterministic 422 handling, and a
+real MCP stdio subprocess with an offline HTTP transport. These prove source
+behavior and configuration propagation. They do not prove a deployed runtime was
+rebuilt or restarted, endpoint behavior on a live service, or end-to-end PPT
+delivery quality.

--- a/tests/test_mcp_reasoning_policy.py
+++ b/tests/test_mcp_reasoning_policy.py
@@ -1,0 +1,64 @@
+"""A managed MCP subprocess reads the endpoint policy from its own profile."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from box_agent.tools.mcp_bootstrap import bootstrap_managed_mcp_config
+from box_agent.tools.mcp_loader import MCPServerConnection
+
+
+@pytest.mark.asyncio
+async def test_managed_web_mcp_reads_disabled_policy_and_sends_compatible_wire(tmp_path, monkeypatch):
+    root = tmp_path / "profile"
+    (root / "config").mkdir(parents=True)
+    monkeypatch.setenv("BOX_AGENT_HOME", str(root))
+    (root / "config/config.yaml").write_text(
+        "api_key: test\napi_base: https://inference.example/v1\nprovider: openai\n"
+        "model: SenseNova-Flash-test\nreasoning_effort_when_disabled: low\n")
+    child = tmp_path / "web_extract_mock.py"
+    child.write_text('''
+import json, os, sys
+sys.path.insert(0, sys.argv[1])
+assert os.environ.get("BOX_AGENT_HOME") == sys.argv[2]
+import httpx
+from openai import AsyncOpenAI
+from box_agent.mcp_servers import web_extract_server as server
+from box_agent.mcp_servers.web_extract import WebExtractTool, _FetchedPage
+
+original = server._create_configured_llm
+def configured():
+    llm = original()
+    original_client = llm._client.client
+    async def transport(request):
+        await original_client.close()
+        body = json.loads(request.content)
+        if body.get("reasoning_effort") != "low":
+            return httpx.Response(422, json={"error": {"message": "Only low/medium/high accepted"}})
+        return httpx.Response(200, json={"id": "mock", "created": 1, "model": llm.model,
+            "object": "chat.completion", "choices": [{"index": 0, "finish_reason": "stop",
+            "message": {"role": "assistant", "content": "wire reasoning_effort=low"}}]})
+    llm._client.client = AsyncOpenAI(api_key="test", base_url=llm.api_base,
+        max_retries=0, http_client=httpx.AsyncClient(transport=httpx.MockTransport(transport)))
+    return llm
+async def fake_fetch(self, url):
+    return _FetchedPage(content="Source evidence. " * 3000, final_url=url)
+server._create_configured_llm = configured
+WebExtractTool._fetch = fake_fetch
+server.main()
+''')
+    config = root / "config/mcp.json"
+    bootstrap_managed_mcp_config(config, web_extract_command=sys.executable)
+    entry = json.loads(config.read_text())["mcpServers"]["box-agent-web-extract"]
+    connection = MCPServerConnection(name="box-agent-web-extract", command=sys.executable,
+        args=[str(child), str(Path(__file__).resolve().parents[1]), str(root.resolve())],
+        env=entry["env"], connect_timeout=15, execute_timeout=15)
+    try:
+        assert await connection.connect()
+        result = await connection.session.call_tool("web_extract", {"url": "https://example.invalid/article"})
+        assert not result.isError, result.content
+        assert "wire reasoning_effort=low" in result.content[0].text
+    finally:
+        await connection.disconnect()

--- a/tests/test_reasoning_disabled_policy.py
+++ b/tests/test_reasoning_disabled_policy.py
@@ -1,0 +1,270 @@
+"""Endpoint-specific reasoning compatibility is applied at the provider wire."""
+
+import json
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from openai import AsyncOpenAI, UnprocessableEntityError
+from pydantic import ValidationError
+
+from box_agent.config import Config
+from box_agent.llm import LLMClient
+from box_agent.retry import RetryConfig
+from box_agent.schema import LLMProvider, Message
+
+
+MODEL = "SenseNova-Flash-Lite-test"
+
+
+@asynccontextmanager
+async def wire_client(*, policy=None, reject=False, model=MODEL, respond=None):
+    requests = []
+
+    def handle(request):
+        payload = json.loads(request.content)
+        requests.append(payload)
+        if respond is not None:
+            return respond(payload)
+        if reject:
+            return httpx.Response(422, json={"error": {
+                "message": "reasoning_effort is invalid; the model service could not complete this request",
+                "type": "invalid_request_error",
+            }})
+        choice = {"index": 0, "finish_reason": "stop"}
+        body = {"id": "test-response", "created": 1, "model": model, "choices": [choice]}
+        if payload.get("stream"):
+            choice["delta"] = {"content": "OK"}
+            body["object"] = "chat.completion.chunk"
+            return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                                  text="data: " + json.dumps(body) + "\n\ndata: [DONE]\n\n")
+        choice["message"] = {"role": "assistant", "content": '{"continue": false}'}
+        body["object"] = "chat.completion"
+        return httpx.Response(200, json=body)
+
+    client = LLMClient(api_key="test", provider=LLMProvider.OPENAI,
+                       api_base="https://inference.example/v1", model=model,
+                       retry_config=RetryConfig(max_retries=2, initial_delay=0, max_delay=0),
+                       reasoning_effort_when_disabled=policy)
+    original = client._client.client
+    client._client.client = AsyncOpenAI(api_key="test", base_url=client.api_base,
+        max_retries=0, http_client=httpx.AsyncClient(transport=httpx.MockTransport(handle)))
+    try:
+        yield client, requests
+    finally:
+        await client._client.client.close()
+        await original.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("policy,enabled,expected", [
+    (None, False, "none"), ("none", False, "none"), ("low", False, "low"), ("low", True, "high"),
+])
+async def test_endpoint_policy_changes_only_disabled_reasoning_wire(stream, policy, enabled, expected):
+    async with wire_client(policy=policy) as (client, requests):
+        bound = client.for_model(MODEL + "-child")
+        if stream:
+            events = [event async for event in bound.generate_stream(
+                [Message(role="user", content="hello")], thinking_enabled=enabled)]
+            assert events[-1].type == "finish"
+        else:
+            await bound.generate([Message(role="user", content="hello")], thinking_enabled=enabled)
+        assert len(requests) == 1
+        assert requests[0]["reasoning_effort"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_deterministic_422_is_not_retried_even_with_transient_words(stream):
+    async with wire_client(policy="low", reject=True) as (client, requests):
+        with pytest.raises(UnprocessableEntityError):
+            if stream:
+                async for _ in client.generate_stream([Message(role="user", content="hello")]):
+                    pass
+            else:
+                await client.generate([Message(role="user", content="hello")])
+        assert len(requests) == 1
+
+
+def test_yaml_endpoint_policy_is_validated_and_lite_endpoint_does_not_inherit(tmp_path):
+    path = tmp_path / "config.yaml"
+    settings = {"api_key": "test", "api_base": "https://inference.example/v1", "provider": "openai",
+                "model": MODEL, "reasoning_effort_when_disabled": "low", "lite_llm": {
+                    "api_key": "other", "api_base": "https://other.example/v1", "model": MODEL}}
+    import yaml
+    path.write_text(yaml.safe_dump(settings))
+    config = Config.from_yaml(path)
+    assert config.llm.reasoning_effort_when_disabled == "low"
+    assert config.lite_llm.reasoning_effort_when_disabled is None
+    settings["reasoning_effort_when_disabled"] = "medium"
+    path.write_text(yaml.safe_dump(settings))
+    with pytest.raises(ValidationError, match="reasoning_effort_when_disabled"):
+        Config.from_yaml(path)
+
+
+def test_runtime_factory_forwards_only_explicit_endpoint_policy():
+    from box_agent.agent_runtime import build_llm_client
+    received = []
+    def factory(**kwargs):
+        received.append(kwargs)
+        return object()
+    for policy in (None, "low"):
+        build_llm_client(api_key="test", provider=LLMProvider.OPENAI,
+            api_base="https://example.invalid", model=MODEL, retry_config=None,
+            max_output_tokens=128, auth_file="", timeout=10, client_factory=factory,
+            reasoning_effort_when_disabled=policy)
+    assert "reasoning_effort_when_disabled" not in received[0]
+    assert received[1]["reasoning_effort_when_disabled"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_profile_switch_uses_its_own_policy_without_leaking_fallback(tmp_path, monkeypatch):
+    from box_agent.llm.model_profiles import client_for_model_profile, load_model_profile_revision, ModelProfileUnavailable
+    profiles = {}
+    for name, policy in (("limited", "low"), ("ordinary", None)):
+        profiles[name] = {"profileId": name, "profileRevision": name, "provider": "openai",
+            "apiBase": f"https://{name}.example/v1", "apiKey": "test", "defaultModel": MODEL,
+            **({"reasoningEffortWhenDisabled": policy} if policy else {})}
+    path = tmp_path / "profiles.json"
+    path.write_text(json.dumps({"version": 1, "profiles": profiles}))
+    monkeypatch.setenv("BOX_AGENT_MODEL_PROFILES_FILE", str(path))
+    async with wire_client(policy="low") as (fallback, _):
+        for name, expected in (("limited", "low"), ("ordinary", None)):
+            client = client_for_model_profile({"profileId": name, "profileRevision": name, "model": MODEL},
+                                              fallback_client=fallback)
+            try:
+                assert client.reasoning_effort_when_disabled == expected
+                assert client._client.reasoning_effort_when_disabled == expected
+            finally:
+                await client._client.client.close()
+    profiles["limited"]["reasoningEffortWhenDisabled"] = "invalid"
+    path.write_text(json.dumps({"version": 1, "profiles": profiles}))
+    with pytest.raises(ModelProfileUnavailable, match="reasoningEffortWhenDisabled"):
+        load_model_profile_revision("limited")
+
+
+@pytest.mark.asyncio
+async def test_utility_image_web_and_continuation_judge_share_provider_policy(tmp_path):
+    from PIL import Image
+    from box_agent.tools.image_inspection_tool import ImageInspectionTool
+    from box_agent.mcp_servers.web_extract import WebExtractTool
+    from box_agent.turn_continuation import model_says_continue
+    image = tmp_path / "image.png"
+    Image.new("RGB", (10, 10), "white").save(image)
+    async with wire_client(policy="low") as (client, requests):
+        result = await ImageInspectionTool(llm=client, workspace_dir=str(tmp_path)).invoke(
+            {"image_paths": [str(image)], "instruction": "Inspect the image"})
+        assert result.success, result.error
+        assert any(block.get("type") == "image_url" for block in requests[0]["messages"][-1]["content"])
+        summary, error = await WebExtractTool(llm=client)._summarize(
+            "Evidence text", "https://example.invalid", requested_model="", requested_max_output_tokens=None)
+        assert summary and error is None
+        assert not await model_says_continue(client, user_request="Do the task", candidate_response="Completed")
+        assert len(requests) == 3
+        assert [r["reasoning_effort"] for r in requests] == ["low", "low", "low"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["deepseek-v4", "qwen-test", "gpt-4.1", "gemini-2.5-pro", "glm-5.3"])
+async def test_disabled_override_preserves_other_provider_dialects(model):
+    async with wire_client(policy=None, model=model) as (before, before_requests):
+        await before.generate([Message(role="user", content="hello")])
+    async with wire_client(policy="low", model=model) as (after, after_requests):
+        await after.generate([Message(role="user", content="hello")])
+    assert before_requests == after_requests
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batch", [False, True], ids=["general_loop", "batch_files"])
+@pytest.mark.parametrize("policy", [None, "low"])
+async def test_direct_agent_child_thinking_reaches_sdk_wire_across_turns(tmp_path, monkeypatch, batch, policy):
+    from pathlib import Path
+    from box_agent.agent import Agent
+    from box_agent.tools.file.read_tool import ReadTool
+    from box_agent.tools.sub_agent_tool import SubAgentTool
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    source = tmp_path / "input.txt"
+    source.write_text("Revenue is 42.")
+    child_requests = []
+    expecting_child = False
+
+    def respond(payload):
+        nonlocal expecting_child
+        choice = {"index": 0, "finish_reason": "stop"}
+        message = {"role": "assistant"}
+        is_parent = any(t["function"]["name"] == "sub_agent" for t in payload.get("tools", []))
+        if expecting_child:
+            child_requests.append(payload)
+            message["content"] = "child finished"
+            expecting_child = False
+        elif is_parent and payload["messages"][-1]["role"] == "user":
+            arguments = {"task": "Summarize the assigned material"}
+            if batch:
+                arguments["files"] = [str(source)]
+            message["tool_calls"] = [{"index": 0, "id": f"child-{len(child_requests)}",
+                "type": "function", "function": {"name": "sub_agent", "arguments": json.dumps(arguments)}}]
+            choice["finish_reason"] = "tool_calls"
+            expecting_child = True
+        else:
+            message["content"] = "parent finished" if is_parent else '{"continue": false}'
+        body = {"id": "wire-agent", "created": 1, "model": MODEL, "choices": [choice]}
+        if payload.get("stream"):
+            choice["delta"] = message
+            body["object"] = "chat.completion.chunk"
+            return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                text="data: " + json.dumps(body) + "\n\ndata: [DONE]\n\n")
+        choice["message"] = message
+        body["object"] = "chat.completion"
+        return httpx.Response(200, json=body)
+
+    async with wire_client(policy=policy, respond=respond) as (client, _):
+        read = ReadTool(workspace_dir=str(tmp_path))
+        child = SubAgentTool(llm=client, parent_tools={"read_file": read}, workspace_dir=str(tmp_path))
+        agent = Agent(llm_client=client, system_prompt="Be concise", tools=[read, child],
+            workspace_dir=str(tmp_path), max_steps=3)
+        for enabled in (True, False):
+            agent.thinking_enabled = enabled
+            agent.add_user_message("Delegate this summary")
+            events = [event async for event in agent.run_events()]
+            assert events[-1].final_content == "parent finished"
+    assert [r["reasoning_effort"] for r in child_requests] == ["high", policy or "none"]
+    assert [bool(r.get("stream")) for r in child_requests] == [not batch, not batch]
+
+
+@pytest.mark.asyncio
+async def test_cli_doctor_preserves_explicit_endpoint_policy(tmp_path, monkeypatch):
+    from box_agent import cli
+    path = tmp_path / "config.yaml"
+    path.write_text("api_key: test\nprovider: openai\nmodel: SenseNova-Flash-test\n"
+                    "api_base: https://inference.example/v1\nreasoning_effort_when_disabled: low\n")
+    captured = []
+
+    class ProbeClient:
+        def __init__(self, **kwargs):
+            captured.append(kwargs)
+
+    async def probe(client):
+        from box_agent.schema import LLMResponse
+        return LLMResponse(content="OK", finish_reason="stop")
+
+    monkeypatch.setattr(cli, "LLMClient", ProbeClient)
+    monkeypatch.setattr(cli, "_probe_llm_api", probe)
+    result = await cli._doctor_api_status(Config.from_yaml(path))
+    assert result["status"] == "ok", result
+    assert captured[0]["reasoning_effort_when_disabled"] == "low"
+
+
+def test_cli_config_reports_endpoint_policy_and_validates_updates(tmp_path, monkeypatch, capsys):
+    from box_agent import cli
+    path = tmp_path / "config.yaml"
+    path.write_text("api_key: test\nprovider: openai\nmodel: SenseNova-Flash-test\n")
+    monkeypatch.setattr(cli.Config, "find_config_file", lambda _name: path)
+    assert cli.cmd_config(set_pair=("reasoning_effort_when_disabled", "low")) == 0
+    capsys.readouterr()
+    assert cli.cmd_config(get_key="llm.reasoning_effort_when_disabled") == 0
+    assert capsys.readouterr().out.strip() == "low"
+    previous = path.read_text()
+    assert cli.cmd_config(set_pair=("reasoning_effort_when_disabled", "medium")) == 1
+    assert path.read_text() == previous

--- a/tests/test_reasoning_disabled_policy.py
+++ b/tests/test_reasoning_disabled_policy.py
@@ -256,15 +256,18 @@ async def test_cli_doctor_preserves_explicit_endpoint_policy(tmp_path, monkeypat
     assert captured[0]["reasoning_effort_when_disabled"] == "low"
 
 
-def test_cli_config_reports_endpoint_policy_and_validates_updates(tmp_path, monkeypatch, capsys):
+@pytest.mark.parametrize("set_key", ["reasoning_effort_when_disabled", "llm.reasoning_effort_when_disabled"])
+@pytest.mark.parametrize("get_key", ["reasoning_effort_when_disabled", "llm.reasoning_effort_when_disabled"])
+def test_cli_config_reports_endpoint_policy_and_validates_updates(tmp_path, monkeypatch, capsys, set_key, get_key):
     from box_agent import cli
     path = tmp_path / "config.yaml"
     path.write_text("api_key: test\nprovider: openai\nmodel: SenseNova-Flash-test\n")
     monkeypatch.setattr(cli.Config, "find_config_file", lambda _name: path)
-    assert cli.cmd_config(set_pair=("reasoning_effort_when_disabled", "low")) == 0
+    assert cli.cmd_config(set_pair=(set_key, "low")) == 0
     capsys.readouterr()
-    assert cli.cmd_config(get_key="llm.reasoning_effort_when_disabled") == 0
+    assert Config.from_yaml(path).llm.reasoning_effort_when_disabled == "low"
+    assert cli.cmd_config(get_key=get_key) == 0
     assert capsys.readouterr().out.strip() == "low"
     previous = path.read_text()
-    assert cli.cmd_config(set_pair=("reasoning_effort_when_disabled", "medium")) == 1
+    assert cli.cmd_config(set_pair=(set_key, "medium")) == 1
     assert path.read_text() == previous

--- a/tests/test_sub_agent_thinking.py
+++ b/tests/test_sub_agent_thinking.py
@@ -1,0 +1,71 @@
+"""Parent session thinking reaches both child execution strategies."""
+
+from pathlib import Path
+
+import pytest
+
+from box_agent.agent import Agent
+from box_agent.schema import FunctionCall, LLMResponse, StreamEvent, ToolCall
+from box_agent.tools.file.read_tool import ReadTool
+from box_agent.tools.sub_agent_tool import SubAgentTool
+
+
+class DelegatingLLM:
+    model = "test-model"
+    max_output_tokens = 128
+
+    def __init__(self, files=()):
+        self.files = list(files)
+        self.child_thinking = []
+
+    async def generate(self, messages=None, **kwargs):
+        if kwargs.get("call_kind") != "subagent_step":
+            return LLMResponse(content='{"continue": false}', finish_reason="stop")
+        self.child_thinking.append(kwargs["thinking_enabled"])
+        return LLMResponse(content="child finished", finish_reason="stop")
+
+    async def generate_stream(self, *, messages, **kwargs):
+        if kwargs.get("call_kind") == "subagent_step":
+            self.child_thinking.append(kwargs["thinking_enabled"])
+            yield StreamEvent(type="text", delta="child finished")
+            yield StreamEvent(type="finish", finish_reason="stop")
+        elif messages[-1].role == "user":
+            yield StreamEvent(type="finish", finish_reason="tool_use", tool_calls=[
+                ToolCall(id=f"child-{len(self.child_thinking)}", type="function", function=FunctionCall(
+                    name="sub_agent", arguments={"task": "Summarize the assigned material",
+                                                  **({"files": self.files} if self.files else {})},
+                )),
+            ])
+        else:
+            yield StreamEvent(type="text", delta="parent finished")
+            yield StreamEvent(type="finish", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batch", [False, True], ids=["general_loop", "batch_files"])
+@pytest.mark.parametrize("initial", [True, False])
+async def test_direct_agent_passes_current_thinking_to_children_across_turns(tmp_path, monkeypatch, batch, initial):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    source = tmp_path / "input.txt"
+    source.write_text("Revenue is 42.")
+    llm = DelegatingLLM([str(source)] if batch else [])
+    read = ReadTool(workspace_dir=str(tmp_path))
+    child = SubAgentTool(llm=llm, parent_tools={"read_file": read}, workspace_dir=str(tmp_path))
+    agent = Agent(llm_client=llm, system_prompt="Be concise", tools=[read, child],
+                  workspace_dir=str(tmp_path), thinking_enabled=initial, max_steps=3)
+    for enabled in (initial, not initial):
+        agent.thinking_enabled = enabled
+        agent.add_user_message("Delegate this summary")
+        events = [event async for event in agent.run_events()]
+        assert events[-1].final_content == "parent finished"
+    assert llm.child_thinking == [initial, not initial]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_standalone_subagent_accepts_explicit_thinking(tmp_path, enabled):
+    llm = DelegatingLLM()
+    child = SubAgentTool(llm=llm, parent_tools={}, thinking_enabled=enabled)
+    result = await child.execute(task="Summarize", required_tools=[])
+    assert result.success
+    assert llm.child_thinking == [enabled]


### PR DESCRIPTION
## Task

父 Agent 开启 thinking 时，普通和批量子任务原来会按默认关闭值调用模型，SenseNova 请求因而发送 `reasoning_effort=none`。现在两种子任务继承父会话当前设置，跨轮切换也会更新。

部分端点拒绝辅助调用中的 `none`。新增端点配置 `reasoning_effort_when_disabled: low`，由 LLM 适配器统一转换，覆盖 CLI、ACP、独立 model profile 和 bundled web-extraction MCP 子进程；主任务开启思考时的映射保持原样。确定性的 422 不再因错误文本包含网络关键字而重复重试。

当前分支基于已包含 Tool #113、Session #114 和流恢复修复的 main；本 PR 的差异仅涉及 thinking 继承、端点配置和请求重试判定，不包含 Skill #117 改动。`ProgressEvent` 导入已由 main 的 `6460279` 修复，不属于当前 PR 差异。不改变工具权限、业务 Skill 或 PPT 流程。

## Proof

### 当前 Head 验证

- Reviewed Head：`226f05e90fa7fde64cffa2b23c404f4c74a4b640`；base / merge-base：`7c85e82abe3915903f9d2b9f068a5a099c10d071`。
- 当前 Head 的 Python 3.10/3.11/3.12、GitGuardian、`teamwork/local-ci` 五项检查均通过。
- 独立 worktree 执行下面的聚焦验证：**198 passed in 7.59s**；compileall 和 `git diff --check origin/main...HEAD` 通过。
- 完整 15 文件 merge-base diff 的代码/安全审查 APPROVE、架构审查 CLEAR，无未解决 P0/P1/P2。本地审查输入不冒充已提交的 GitHub required review。

```bash
uv sync --frozen --all-extras
uv run --no-sync pytest tests/test_reasoning_disabled_policy.py tests/test_sub_agent_thinking.py tests/test_mcp_reasoning_policy.py tests/test_model_profiles.py tests/test_lite_llm_routing.py tests/test_openai_client_sensenova.py tests/test_cli_config.py tests/test_agent_runtime.py tests/test_sub_agent_tool.py -q --tb=short
uv run --no-sync python -m compileall -q box_agent
git diff --check origin/main...HEAD
```

### 原提交的历史验证

以下保留提交者原有验证记录，其 SHA 和组合版本属于历史证据，不冒称已在当前 Head 重跑了其中的安装包、集成矩阵或全部离线探针。

- 新测试检查真实 SDK 的 streaming/non-streaming 请求内容、Agent 到两种子任务的调用、跨轮 true/false、默认和 low 策略。
- 覆盖 image inspection、web summary、continuation judge、profile 隔离、非法配置和确定性 422。独立审查发现并修复了 CLI 根级/dotted 配置路径不对称，四种 get/set 组合检查实际配置生效及非法值回滚。
- 真实 MCP stdio 子进程加载隔离 BOX_AGENT_HOME，用离线 HTTP transport 验证配置到请求的传递；未调用真实服务。
- 独立 main 分支 `058f7c07c3e6b9a284beb01f1eabb534644b8a67` 完整 preflight：`UV_OFFLINE=1 UV_PYTHON=3.11 PYTEST_ADDOPTS=-s bash general_review/ci/preflight.sh`，3923 passed、18 skipped、1 deselected；锁定依赖安装、compileall、sdist 和 wheel 构建均通过。`-s` 仅关闭 pytest 全局捕获，保留 capsys/capfd；deselect 沿用仓库脚本。
- wheel/sdist 中 908 个 Python 源码与 Skill 文件逐字节匹配该提交；未包含 pyc 缓存。wheel 另装入临时目录，以隔离导入验证配置映射、子任务 setter 和流式恢复入口，未使用源 checkout 的 box_agent 包。
- 两个 PR 的实际合并树与本地整合版本逐字节一致，无冲突；整合后的 Context、Session、Skill、子任务与 reasoning 回归共 418 passed（295 + 123）。
- 纯 main 的流式恢复测试复现 6 failed / 17 passed；补齐导入后同组 23 passed。

- 独立只读本地复审 APPROVE，原 CLI 配置路径 P2 已关闭，无未解决阻塞；复审定向 73 passed。本地检查不代替 GitHub required checks 或维护者合并审批。

## Risk

- 默认未配置时保留原行为。受影响端点需要显式设置 `reasoning_effort_when_disabled: low`；`low` 是降低思考强度，不能保证完全关闭思考。其他模型的原生 thinking 控制不变。
- 固定 profile 使用自己的 `reasoningEffortWhenDisabled`，不继承另一个端点的配置。宿主生成 profile 时需把该字段写入新 revision。
- 配置变更后需要重新创建客户端并重启缓存客户端的 MCP 子进程。此次未改原评测配置、未恢复暂停的 PPT 矩阵，未安装或重启 officev3 runtime。
- 原故障端点行为来自既有 preflight 证据；本 PR 的新验证为离线请求和构建验证，不声明真实 PPT 任务交付通过。

## Design and architecture impact

Agent 转发当前 thinking 状态，SubAgentTool 负责两种子任务策略继承，LLM adapter 负责端点请求映射；CLI/ACP/profile/MCP 只传配置。新增配置可选，默认兼容；未改 Tool schema、Skill manifest 或权限。README 和 `docs/reasoning-configuration.md` 说明配置与部署边界。回滚完整代码版本并撤回对应显式配置即可。

## Target branch consistency

当前 base 是 `upstream/main 7c85e82abe3915903f9d2b9f068a5a099c10d071`，Reviewed Head 为 `226f05e90fa7fde64cffa2b23c404f4c74a4b640`；已核对 base 是 Head 的祖先。main 中已包含 #113/#114 和 `ProgressEvent` 导入修复，当前 diff 不重复计入这些改动，也不包含 #117 的 Skill/Context 重构。当前准确 Head 的 `teamwork/local-ci` 已成功；旧 `058f7c…` 的本地构建与安装证据保留在历史 Proof 中。
