### PR TITLE
refactor(context): add durable CLI recovery and injectable compaction

### DIFF
--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "d715ff42905edaa44541efcfc4797564bcb56024",
-  "generatedAt": "2026-09-10T21:15:39.701Z",
+  "gitCommitHash": "f501eebf61a6934c1fceee713f207db39b73354c",
+  "generatedAt": "2026-09-10T21:45:40.960Z",
   "files": {
     ".dockerignore": {
       "filePath": ".dockerignore",
@@ -3515,7 +3515,7 @@
     },
     "box_agent/cli.py": {
       "filePath": "box_agent/cli.py",
-      "contentHash": "20a7780244fd734281568041a1d068bab6749f22e4668ea9ef985cc1df399847",
+      "contentHash": "70b625e2905a2720560a0c01cb61638b5e338b6e1f63a26dac9de52ef6004489",
       "functions": [
         {
           "name": "run_setup_wizard",
@@ -4023,17 +4023,17 @@
             "workspace_dir",
             "task",
             "initial_goal",
-            "session_id",
             "sandbox_mode",
             "verify_api",
             "json_summary",
             "deep_think",
             "force_plan_start",
-            "goal_autopilot_enabled"
+            "goal_autopilot_enabled",
+            "session_id"
           ],
           "returnType": "int",
           "exported": true,
-          "lineCount": 872
+          "lineCount": 874
         },
         {
           "name": "main",
@@ -4444,7 +4444,7 @@
         "run_agent",
         "main"
       ],
-      "totalLines": 2794,
+      "totalLines": 2796,
       "hasStructuralAnalysis": true
     },
     "box_agent/client_info.py": {
@@ -15179,7 +15179,7 @@
     },
     "box_agent/session_context.py": {
       "filePath": "box_agent/session_context.py",
-      "contentHash": "8fe6ddf1788070a018af9b714a329ed5213337dce7316f6ea19a2a70309d9ae6",
+      "contentHash": "91fae103270b05c620ea5f0c8c00278d4e953a497a278e02e9aef236c083de46",
       "functions": [],
       "classes": [
         {

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "b7b884768974bb5ca5103a1740349eef9e3e7c0f",
-  "generatedAt": "2026-09-10T21:00:36.250Z",
+  "gitCommitHash": "d715ff42905edaa44541efcfc4797564bcb56024",
+  "generatedAt": "2026-09-10T21:15:39.701Z",
   "files": {
     ".dockerignore": {
       "filePath": ".dockerignore",
@@ -1923,7 +1923,7 @@
     },
     "box_agent/agent_runtime.py": {
       "filePath": "box_agent/agent_runtime.py",
-      "contentHash": "b8cfe73b28d22f1453d47ad0f0813d5f804203f807d62d928a5ca318b17cb19a",
+      "contentHash": "c31efa566f0bee4d328e2198a7dd301837ee8079cdd95d68e7d0f949bccc340c",
       "functions": [
         {
           "name": "build_llm_client",
@@ -1973,11 +1973,12 @@
             "session_log",
             "enable_builtin_tools",
             "skill_runtime",
+            "session_id",
             "agent_factory"
           ],
           "returnType": "Agent",
           "exported": true,
-          "lineCount": 72
+          "lineCount": 75
         },
         {
           "name": "build_permission_engine",
@@ -2083,7 +2084,7 @@
         "build_memory_manager",
         "build_memory_extractor"
       ],
-      "totalLines": 216,
+      "totalLines": 219,
       "hasStructuralAnalysis": true
     },
     "box_agent/agent_service.py": {
@@ -2132,7 +2133,7 @@
     },
     "box_agent/agent_session.py": {
       "filePath": "box_agent/agent_session.py",
-      "contentHash": "9c27e9ec8091cb3d1e20670c15f622cc9e174b72115686390ae3be5d7555cc3d",
+      "contentHash": "141f1a666aaf081c0b0ef16c7d9ffd4eb49c200d5f6c4b58c837fe045d0fd93e",
       "functions": [],
       "classes": [
         {
@@ -2186,7 +2187,7 @@
             "mcp_fallback_tools"
           ],
           "exported": true,
-          "lineCount": 382
+          "lineCount": 385
         }
       ],
       "imports": [
@@ -2273,12 +2274,12 @@
       "exports": [
         "AgentSession"
       ],
-      "totalLines": 417,
+      "totalLines": 420,
       "hasStructuralAnalysis": true
     },
     "box_agent/agent.py": {
       "filePath": "box_agent/agent.py",
-      "contentHash": "8eda3ef74f2b98583c0e22916b30ca88876236bd00d0ef6f956e9b1062a2cfe2",
+      "contentHash": "763e588316928ca3cd441fe7ef297ea1259d3e99b30024667c25d18d0b9153d4",
       "functions": [
         {
           "name": "_clean_goal_text",
@@ -2492,7 +2493,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 845
+          "lineCount": 853
         }
       ],
       "imports": [
@@ -2716,7 +2717,7 @@
         "_GoalWriteTool",
         "Agent"
       ],
-      "totalLines": 1282,
+      "totalLines": 1290,
       "hasStructuralAnalysis": true
     },
     "box_agent/artifacts.py": {
@@ -3514,7 +3515,7 @@
     },
     "box_agent/cli.py": {
       "filePath": "box_agent/cli.py",
-      "contentHash": "5768eff0c406a1777a7364beb0cca729d5ab51a414b487c053d3a469e4fb8fe2",
+      "contentHash": "20a7780244fd734281568041a1d068bab6749f22e4668ea9ef985cc1df399847",
       "functions": [
         {
           "name": "run_setup_wizard",
@@ -3779,11 +3780,12 @@
             "text",
             "evidence",
             "progress",
-            "json_output"
+            "json_output",
+            "session_id"
           ],
           "returnType": "int",
           "exported": true,
-          "lineCount": 110
+          "lineCount": 130
         },
         {
           "name": "_workspace_from_args",
@@ -3799,7 +3801,7 @@
           "params": [],
           "returnType": "argparse.Namespace",
           "exported": true,
-          "lineCount": 222
+          "lineCount": 232
         },
         {
           "name": "cmd_setup",
@@ -4021,6 +4023,7 @@
             "workspace_dir",
             "task",
             "initial_goal",
+            "session_id",
             "sandbox_mode",
             "verify_api",
             "json_summary",
@@ -4030,14 +4033,14 @@
           ],
           "returnType": "int",
           "exported": true,
-          "lineCount": 846
+          "lineCount": 872
         },
         {
           "name": "main",
           "params": [],
           "returnType": "int",
           "exported": true,
-          "lineCount": 104
+          "lineCount": 106
         }
       ],
       "classes": [],
@@ -4366,6 +4369,13 @@
           ]
         },
         {
+          "source": "box_agent.session_log",
+          "specifiers": [
+            "SessionLog",
+            "default_session_root"
+          ]
+        },
+        {
           "source": "box_agent.user_paths",
           "specifiers": [
             "state_path"
@@ -4434,7 +4444,7 @@
         "run_agent",
         "main"
       ],
-      "totalLines": 2735,
+      "totalLines": 2794,
       "hasStructuralAnalysis": true
     },
     "box_agent/client_info.py": {
@@ -4564,7 +4574,7 @@
     },
     "box_agent/composition.py": {
       "filePath": "box_agent/composition.py",
-      "contentHash": "0e38a813eaa6cf64ce2e029590913e4451c495dc2fdc49f5c26de59f9b6ff223",
+      "contentHash": "9c5c726f4f729a7afda7415cb4447deafec1e830417ed6e71265e98223e23476",
       "functions": [
         {
           "name": "_default_capabilities",
@@ -4573,7 +4583,7 @@
           ],
           "returnType": "dict[str, Any]",
           "exported": true,
-          "lineCount": 33
+          "lineCount": 34
         },
         {
           "name": "_kernel_run_arguments",
@@ -4701,7 +4711,7 @@
           ],
           "returnType": "AsyncIterator[AgentEvent]",
           "exported": true,
-          "lineCount": 100
+          "lineCount": 109
         }
       ],
       "classes": [],
@@ -4802,7 +4812,7 @@
         "_cleanup_task_finished",
         "run_agent_loop_with_default_services"
       ],
-      "totalLines": 455,
+      "totalLines": 466,
       "hasStructuralAnalysis": true
     },
     "box_agent/config.py": {
@@ -7591,9 +7601,45 @@
       "totalLines": 6,
       "hasStructuralAnalysis": true
     },
+    "box_agent/kernel/compact_engine.py": {
+      "filePath": "box_agent/kernel/compact_engine.py",
+      "contentHash": "44e953f467744efe3d72253c398b1edcdabb08442c796249042c37203c8dcb19",
+      "functions": [],
+      "classes": [
+        {
+          "name": "DefaultCompactEngine",
+          "methods": [
+            "compact_if_needed"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 15
+        }
+      ],
+      "imports": [
+        {
+          "source": ".context_engine",
+          "specifiers": [
+            "_maybe_summarize"
+          ]
+        },
+        {
+          "source": ".context_types",
+          "specifiers": [
+            "CompactionInput",
+            "CompactionOutcome"
+          ]
+        }
+      ],
+      "exports": [
+        "DefaultCompactEngine"
+      ],
+      "totalLines": 23,
+      "hasStructuralAnalysis": true
+    },
     "box_agent/kernel/context_engine.py": {
       "filePath": "box_agent/kernel/context_engine.py",
-      "contentHash": "a50a4acdb6612500be270d3a794f02e97fd434cf5c4e67ea06511611204bcc0e",
+      "contentHash": "38b53400f15e3a4ac244718ca670328125ff131333ff2619204af6d6645d6018",
       "functions": [
         {
           "name": "_summary_message_text",
@@ -7777,11 +7823,12 @@
             "session_step",
             "force",
             "estimate_tools",
-            "summary_input_token_limit"
+            "summary_input_token_limit",
+            "before_summary"
           ],
           "returnType": "CompactionOutcome",
           "exported": true,
-          "lineCount": 175
+          "lineCount": 179
         },
         {
           "name": "_is_summary_marker",
@@ -7824,27 +7871,7 @@
           "lineCount": 10
         }
       ],
-      "classes": [
-        {
-          "name": "CompactionOutcome",
-          "methods": [
-            "blocked",
-            "__iter__"
-          ],
-          "properties": [
-            "messages",
-            "estimated_before",
-            "estimated_after",
-            "mode",
-            "summary_calls",
-            "error",
-            "error_type",
-            "trigger_source"
-          ],
-          "exported": true,
-          "lineCount": 25
-        }
-      ],
+      "classes": [],
       "imports": [
         {
           "source": "json",
@@ -7871,15 +7898,10 @@
           ]
         },
         {
-          "source": "dataclasses",
-          "specifiers": [
-            "dataclass"
-          ]
-        },
-        {
           "source": "typing",
           "specifiers": [
             "Any",
+            "Callable",
             "Final"
           ]
         },
@@ -7908,10 +7930,15 @@
             "Tool",
             "ToolResult"
           ]
+        },
+        {
+          "source": ".context_types",
+          "specifiers": [
+            "CompactionOutcome"
+          ]
         }
       ],
       "exports": [
-        "CompactionOutcome",
         "_summary_message_text",
         "_create_summary",
         "_deterministic_history_fallback",
@@ -7934,7 +7961,98 @@
         "request_input_tokens",
         "skill_reference_budget_chars"
       ],
-      "totalLines": 860,
+      "totalLines": 838,
+      "hasStructuralAnalysis": true
+    },
+    "box_agent/kernel/context_types.py": {
+      "filePath": "box_agent/kernel/context_types.py",
+      "contentHash": "2bd49b4c66a6cd620cde2eecabe9adfc356dc8d870eda31d30e8ee7f903b6d5e",
+      "functions": [],
+      "classes": [
+        {
+          "name": "CompactionInput",
+          "methods": [],
+          "properties": [
+            "history",
+            "token_limit",
+            "llm",
+            "summary_llm",
+            "tools",
+            "api_total_tokens",
+            "api_prompt_tokens",
+            "skip_check",
+            "allow_llm_summary",
+            "session_id",
+            "turn_id",
+            "title",
+            "before_summary",
+            "force",
+            "estimate_tools",
+            "summary_input_token_limit"
+          ],
+          "exported": true,
+          "lineCount": 23
+        },
+        {
+          "name": "CompactionOutcome",
+          "methods": [
+            "__post_init__",
+            "blocked",
+            "__iter__"
+          ],
+          "properties": [
+            "messages",
+            "estimated_before",
+            "estimated_after",
+            "mode",
+            "summary_calls",
+            "error",
+            "error_type",
+            "trigger_source",
+            "protected_messages",
+            "still_over_limit"
+          ],
+          "exported": true,
+          "lineCount": 33
+        }
+      ],
+      "imports": [
+        {
+          "source": "collections.abc",
+          "specifiers": [
+            "Callable"
+          ]
+        },
+        {
+          "source": "dataclasses",
+          "specifiers": [
+            "dataclass"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Any"
+          ]
+        },
+        {
+          "source": "..schema",
+          "specifiers": [
+            "Message"
+          ]
+        },
+        {
+          "source": "..tools.base",
+          "specifiers": [
+            "Tool"
+          ]
+        }
+      ],
+      "exports": [
+        "CompactionInput",
+        "CompactionOutcome"
+      ],
+      "totalLines": 72,
       "hasStructuralAnalysis": true
     },
     "box_agent/kernel/hook_types.py": {
@@ -8154,7 +8272,7 @@
     },
     "box_agent/kernel/loop.py": {
       "filePath": "box_agent/kernel/loop.py",
-      "contentHash": "ba5d3bca8374a7ae46d87d5a5f2313d8c045d846725a8dd7a12db398707706a6",
+      "contentHash": "b21c7c2bad452c96e7813196e120331965f2516b788df22db1cce0d0359f7170",
       "functions": [
         {
           "name": "_resolve_provider_stale_seconds",
@@ -8345,7 +8463,7 @@
           ],
           "returnType": "AsyncIterator[AgentEvent]",
           "exported": true,
-          "lineCount": 2029
+          "lineCount": 2038
         },
         {
           "name": "run_agent_loop",
@@ -8576,7 +8694,6 @@
             "REQUEST_INPUT_HEADROOM_TOKENS",
             "_fallback_context_estimate",
             "_is_compaction_metadata",
-            "_maybe_summarize",
             "_validate_transient_followup_result"
           ]
         },
@@ -8729,7 +8846,7 @@
         "AgentLoopKernel",
         "run_agent_loop"
       ],
-      "totalLines": 2762,
+      "totalLines": 2770,
       "hasStructuralAnalysis": true
     },
     "box_agent/kernel/permission_gateway.py": {
@@ -8757,7 +8874,7 @@
     },
     "box_agent/kernel/ports.py": {
       "filePath": "box_agent/kernel/ports.py",
-      "contentHash": "d9c4a164e190b7840008470bf9f1cbf4c4727ccbcbfda51f88d7995c81bf45e3",
+      "contentHash": "2f0406b77e7a5d3f2559c2622aa8e726520156890e4fe2826f6b3f1619655a32",
       "functions": [],
       "classes": [
         {
@@ -8976,6 +9093,15 @@
           "lineCount": 29
         },
         {
+          "name": "CompactEnginePort",
+          "methods": [
+            "compact_if_needed"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 8
+        },
+        {
           "name": "KernelServices",
           "methods": [],
           "properties": [
@@ -8994,10 +9120,11 @@
             "hook_dispatch",
             "hook_context",
             "skill_engine",
-            "context_engine"
+            "context_engine",
+            "compact_engine"
           ],
           "exported": true,
-          "lineCount": 19
+          "lineCount": 20
         }
       ],
       "imports": [
@@ -9049,6 +9176,13 @@
             "Tool",
             "ToolResult"
           ]
+        },
+        {
+          "source": ".context_types",
+          "specifiers": [
+            "CompactionInput",
+            "CompactionOutcome"
+          ]
         }
       ],
       "exports": [
@@ -9070,9 +9204,10 @@
         "PreparedContextPort",
         "SkillEnginePort",
         "ContextEnginePort",
+        "CompactEnginePort",
         "KernelServices"
       ],
-      "totalLines": 437,
+      "totalLines": 452,
       "hasStructuralAnalysis": true
     },
     "box_agent/kernel/state.py": {
@@ -13206,7 +13341,7 @@
     },
     "box_agent/plugins/defaults.py": {
       "filePath": "box_agent/plugins/defaults.py",
-      "contentHash": "4a5a5f6c81faa9b9bfb2ffd91635356d4d81733d76cd3fc55c1a763ba3335278",
+      "contentHash": "e16d2e5d77a6f2b0b827c82c3c588d4314339a40a4a0c240151e9af1e6c41414",
       "functions": [
         {
           "name": "skill_loader_from_catalog",
@@ -13253,11 +13388,12 @@
             "tool_result_store",
             "tool_engine",
             "skill_engine",
-            "context_engine"
+            "context_engine",
+            "compact_engine"
           ],
           "returnType": "tuple[PluginDescriptor, ...]",
           "exported": true,
-          "lineCount": 68
+          "lineCount": 78
         },
         {
           "name": "create_default_plugin_host",
@@ -13276,11 +13412,12 @@
             "tool_engine",
             "plugins",
             "skill_engine",
-            "context_engine"
+            "context_engine",
+            "compact_engine"
           ],
           "returnType": "PluginHost",
           "exported": true,
-          "lineCount": 42
+          "lineCount": 44
         },
         {
           "name": "_bind_skill_store",
@@ -13299,7 +13436,7 @@
           ],
           "returnType": "KernelServices",
           "exported": true,
-          "lineCount": 26
+          "lineCount": 27
         },
         {
           "name": "compose_default_services",
@@ -13317,11 +13454,12 @@
             "tool_result_store",
             "tool_engine",
             "skill_engine",
-            "context_engine"
+            "context_engine",
+            "compact_engine"
           ],
           "returnType": "KernelServices",
           "exported": true,
-          "lineCount": 43
+          "lineCount": 49
         }
       ],
       "classes": [],
@@ -13349,6 +13487,7 @@
             "ToolEnginePort",
             "SkillEnginePort",
             "ContextEnginePort",
+            "CompactEnginePort",
             "ToolExposurePort",
             "ToolResultStorePort"
           ]
@@ -13393,7 +13532,7 @@
         "kernel_services_from_registry",
         "compose_default_services"
       ],
-      "totalLines": 314,
+      "totalLines": 335,
       "hasStructuralAnalysis": true
     },
     "box_agent/plugins/descriptors.py": {
@@ -14743,7 +14882,7 @@
     },
     "box_agent/session_assembly.py": {
       "filePath": "box_agent/session_assembly.py",
-      "contentHash": "b3dd8fe98a6fd070504f18f0f4f3ae2ef617a1dcbbf2a657b4af9230cfc45ac3",
+      "contentHash": "09b4bf98e01454852cda70db186a67622c4afd116d27dc10b496963a01cbb8b8",
       "functions": [
         {
           "name": "_prepared",
@@ -14788,7 +14927,7 @@
           ],
           "returnType": "None",
           "exported": true,
-          "lineCount": 13
+          "lineCount": 19
         },
         {
           "name": "prepare_tools",
@@ -15035,12 +15174,12 @@
         "build_session_permission_policy",
         "close_owned_clients"
       ],
-      "totalLines": 663,
+      "totalLines": 669,
       "hasStructuralAnalysis": true
     },
     "box_agent/session_context.py": {
       "filePath": "box_agent/session_context.py",
-      "contentHash": "afb5575b27e6f2f6adbd78846ffde7f75b5920b846bdb1d3bbcd0188684eeb37",
+      "contentHash": "8fe6ddf1788070a018af9b714a329ed5213337dce7316f6ea19a2a70309d9ae6",
       "functions": [],
       "classes": [
         {
@@ -15050,6 +15189,7 @@
             "workspace_dir",
             "token_limit",
             "utility",
+            "resume_session_log",
             "profile",
             "sandbox_mode",
             "non_interactive",
@@ -15064,7 +15204,7 @@
             "state"
           ],
           "exported": true,
-          "lineCount": 18
+          "lineCount": 19
         },
         {
           "name": "HostBindings",
@@ -15164,7 +15304,7 @@
         "SessionContext",
         "RunContext"
       ],
-      "totalLines": 98,
+      "totalLines": 99,
       "hasStructuralAnalysis": true
     },
     "box_agent/session_continuation.py": {
@@ -15231,7 +15371,7 @@
     },
     "box_agent/session_log.py": {
       "filePath": "box_agent/session_log.py",
-      "contentHash": "3207b60d7abdb4bea332ff0a4a875bbf832c5b4744c6e041011cbd81fab3c18d",
+      "contentHash": "8366c4c6727a503aa0c0e5e5ac4c091569fb2f0c51ec4fb030a5149868be7e7f",
       "functions": [
         {
           "name": "_encode_record",
@@ -15251,6 +15391,13 @@
           "returnType": "Path",
           "exported": true,
           "lineCount": 3
+        },
+        {
+          "name": "default_session_root",
+          "params": [],
+          "returnType": "Path",
+          "exported": true,
+          "lineCount": 7
         },
         {
           "name": "_normalize_cwd",
@@ -15319,17 +15466,14 @@
           "lineCount": 2
         },
         {
-          "name": "SessionProjection",
+          "name": "SessionOpenResult",
           "methods": [],
           "properties": [
-            "messages",
-            "goal",
-            "plan",
-            "todos",
-            "skills"
+            "log",
+            "resumed"
           ],
           "exported": true,
-          "lineCount": 8
+          "lineCount": 5
         },
         {
           "name": "SessionLog",
@@ -15338,6 +15482,7 @@
             "events",
             "failed",
             "assert_workspace",
+            "open_or_create",
             "create",
             "open",
             "_recover_log",
@@ -15350,6 +15495,7 @@
             "_surface_nodes",
             "_append_surface_message",
             "replace_surface",
+            "reset_surface",
             "replay",
             "repair_interrupted_turn",
             "prepare_resume",
@@ -15357,7 +15503,7 @@
           ],
           "properties": [],
           "exported": true,
-          "lineCount": 755
+          "lineCount": 805
         }
       ],
       "imports": [
@@ -15451,6 +15597,12 @@
           "specifiers": [
             "Message"
           ]
+        },
+        {
+          "source": ".session_projection",
+          "specifiers": [
+            "SessionProjection"
+          ]
         }
       ],
       "exports": [
@@ -15458,16 +15610,76 @@
         "SessionLogDurabilityError",
         "SessionLogInUseError",
         "SessionLogWorkspaceMismatch",
-        "SessionProjection",
+        "SessionOpenResult",
         "_encode_record",
         "_session_dir",
+        "default_session_root",
         "_normalize_cwd",
         "_is_legacy_workflow_context",
         "_acquire_writer_lock",
         "_release_writer_lock",
         "SessionLog"
       ],
-      "totalLines": 925,
+      "totalLines": 983,
+      "hasStructuralAnalysis": true
+    },
+    "box_agent/session_projection.py": {
+      "filePath": "box_agent/session_projection.py",
+      "contentHash": "0379bf86b91d6d040efd0ff2abcbf6f1d7656c590431808856edba8b3632a238",
+      "functions": [],
+      "classes": [
+        {
+          "name": "SessionProjection",
+          "methods": [
+            "__init__",
+            "messages",
+            "goal",
+            "plan",
+            "todos",
+            "skills"
+          ],
+          "properties": [
+            "_messages",
+            "_goal",
+            "_plan",
+            "_todos",
+            "_skills"
+          ],
+          "exported": true,
+          "lineCount": 47
+        }
+      ],
+      "imports": [
+        {
+          "source": "dataclasses",
+          "specifiers": [
+            "dataclass"
+          ]
+        },
+        {
+          "source": "copy",
+          "specifiers": [
+            "deepcopy"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Any",
+            "Sequence"
+          ]
+        },
+        {
+          "source": ".schema",
+          "specifiers": [
+            "Message"
+          ]
+        }
+      ],
+      "exports": [
+        "SessionProjection"
+      ],
+      "totalLines": 68,
       "hasStructuralAnalysis": true
     },
     "box_agent/session_prompts.py": {
@@ -33981,12 +34193,12 @@
     },
     "docs/AGENT_SESSION.md": {
       "filePath": "docs/AGENT_SESSION.md",
-      "contentHash": "f66a8c5e32d77b4056449b1842ea0aa8ad2b2cbb4242bf8559dd1ee6c826489e",
+      "contentHash": "76b0c530cc393579a3ab27764273920dca7ff436fb059507fe889c10c5ca43f4",
       "functions": [],
       "classes": [],
       "imports": [],
       "exports": [],
-      "totalLines": 201,
+      "totalLines": 235,
       "hasStructuralAnalysis": true
     },
     "docs/ARCHITECTURE_CN.md": {
@@ -34061,22 +34273,22 @@
     },
     "docs/CONTEXT_COMPRESSION_CN.md": {
       "filePath": "docs/CONTEXT_COMPRESSION_CN.md",
-      "contentHash": "de9a23c299a179e743bbafc4eb470e163a2984a941f74db21ecb53754b0c0fb3",
+      "contentHash": "f9cc1090cb26ead4d455291fc7ea1ef12ba78818ba206341fe33b6674e1ba79f",
       "functions": [],
       "classes": [],
       "imports": [],
       "exports": [],
-      "totalLines": 165,
+      "totalLines": 177,
       "hasStructuralAnalysis": true
     },
     "docs/CONTEXT_COMPRESSION.md": {
       "filePath": "docs/CONTEXT_COMPRESSION.md",
-      "contentHash": "7036f8f712b02862663915e65ec146fb2f6b82764986bca733c3069db26babf2",
+      "contentHash": "f3c22cd7d90fd24d48cdd968c252b7f1aa2a72727867740da2637f1ca89f8f13",
       "functions": [],
       "classes": [],
       "imports": [],
       "exports": [],
-      "totalLines": 207,
+      "totalLines": 224,
       "hasStructuralAnalysis": true
     },
     "docs/design/README.md": {

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -25,8 +25,8 @@
       "GitHub Actions"
     ],
     "description": "一个具备 Jupyter 沙箱、数据分析、MCP 工具、ACP 协议、多模型提供商支持和独立运行时打包能力的 AI Agent 框架。注意：该项目包含超过 100 个源文件；如需更快的分析，可考虑将范围限定到某个子目录。",
-    "analyzedAt": "2026-09-10T20:59:08.389Z",
-    "gitCommitHash": "b7b884768974bb5ca5103a1740349eef9e3e7c0f"
+    "analyzedAt": "2026-09-10T21:15:38.894Z",
+    "gitCommitHash": "d715ff42905edaa44541efcfc4797564bcb56024"
   },
   "nodes": [
     {
@@ -2502,8 +2502,8 @@
       "name": "_summary_message_text",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        141,
-        167
+        115,
+        141
       ],
       "summary": "把消息正文、角色、工具调用、调用标识和思考文本序列化为确定性摘要输入；多模态正文用预算序列化器替换图片 base64 数据。",
       "tags": [
@@ -2521,8 +2521,8 @@
       "name": "_create_summary",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        170,
-        204
+        144,
+        178
       ],
       "summary": "实现 create summary 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2540,8 +2540,8 @@
       "name": "_deterministic_history_fallback",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        207,
-        252
+        181,
+        226
       ],
       "summary": "实现 deterministic history fallback 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2559,8 +2559,8 @@
       "name": "_message_chars",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        255,
-        272
+        229,
+        246
       ],
       "summary": "估算消息正文、思考、工具调用及信封的字符成本，图片内容额外按像素 token 量换算字符成本而不计入 base64 长度。",
       "tags": [
@@ -2578,8 +2578,8 @@
       "name": "_transient_followup_token_estimate",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        319,
-        339
+        293,
+        313
       ],
       "summary": "验证一次性跟进内容的 text／input_image 块并估算请求 token；图片使用统一像素估算，非法类型、格式或空图片数据会被拒绝。",
       "tags": [
@@ -2597,8 +2597,8 @@
       "name": "_validate_transient_followup_result",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        342,
-        411
+        316,
+        385
       ],
       "summary": "实现 validate transient followup result 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2616,8 +2616,8 @@
       "name": "_bound_text_middle",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        414,
-        433
+        388,
+        407
       ],
       "summary": "实现 bound text middle 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2635,8 +2635,8 @@
       "name": "_bound_retained_messages",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        436,
-        482
+        410,
+        456
       ],
       "summary": "实现 bound retained messages 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2654,8 +2654,8 @@
       "name": "_fallback_context_estimate",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        485,
-        503
+        459,
+        477
       ],
       "summary": "实现 fallback context estimate 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2673,8 +2673,8 @@
       "name": "_estimate_context_from_latest_response",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        506,
-        546
+        480,
+        520
       ],
       "summary": "实现 estimate context from latest response 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2692,8 +2692,8 @@
       "name": "_recent_message_groups",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        549,
-        569
+        523,
+        543
       ],
       "summary": "实现 recent message groups 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2711,8 +2711,8 @@
       "name": "_select_recent_messages",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        572,
-        599
+        546,
+        573
       ],
       "summary": "实现 select recent messages 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2730,8 +2730,8 @@
       "name": "_restore_runtime_state",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        602,
-        640
+        576,
+        614
       ],
       "summary": "实现 restore runtime state 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
@@ -2749,10 +2749,10 @@
       "name": "_maybe_summarize",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        643,
-        817
+        617,
+        795
       ],
-      "summary": "依据完整工具定义估算或 force 标记触发一次历史压缩，在摘要输入超限或生成失败时使用确定性回退。保留近期完整消息组与可信工具状态，逐步压缩摘要并在重建请求仍超预算时返回 blocked 结果。",
+      "summary": "依据完整工具定义估算或 force 标记触发压缩，在模型摘要或确定性回退之前优先调用 before_summary，未提供回调时保留旧 SessionLog 参数兼容路径，回调失败直接向调用方传播。原有近期消息组、可信工具状态、摘要预算及 blocked 规则保持有效，结果新增受保护消息数并使用 context_types 中的 CompactionOutcome。",
       "tags": [
         "function",
         "kernel",
@@ -2768,31 +2768,12 @@
       "name": "_is_compaction_metadata",
       "filePath": "box_agent/kernel/context_engine.py",
       "lineRange": [
-        828,
-        840
+        806,
+        818
       ],
       "summary": "实现 is compaction metadata 处理，是该文件职责中的一个可复用步骤。",
       "tags": [
         "function",
-        "kernel",
-        "context-compaction",
-        "history",
-        "validation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:box_agent/kernel/context_engine.py:CompactionOutcome",
-      "type": "class",
-      "name": "CompactionOutcome",
-      "filePath": "box_agent/kernel/context_engine.py",
-      "lineRange": [
-        114,
-        138
-      ],
-      "summary": "封装 Compaction Outcome 的状态与行为，是该文件职责中的可复用类型。",
-      "tags": [
-        "class",
         "kernel",
         "context-compaction",
         "history",
@@ -14331,7 +14312,7 @@
       "type": "document",
       "name": "CONTEXT_COMPRESSION.md",
       "filePath": "docs/CONTEXT_COMPRESSION.md",
-      "summary": "英文说明上下文压缩触发、摘要保真、恢复与观测事件；普通 Skill 读取正文留在历史 tool 消息中，可随历史压缩重新读取，不因读取成功固定在 system。",
+      "summary": "英文说明上下文压缩、摘要保真、恢复与观测；CompactEnginePort 沿用既有算法，Kernel 保留 before_summary 和先持久化再更新 live surface 的责任。完整工具估算、强制重试、摘要预算、tuple 兼容与 falsey 借用压缩器均保留；Skill 正文继续作为普通可压缩资料。",
       "tags": [
         "documentation",
         "protocol",
@@ -14344,7 +14325,7 @@
       "type": "document",
       "name": "CONTEXT_COMPRESSION_CN.md",
       "filePath": "docs/CONTEXT_COMPRESSION_CN.md",
-      "summary": "中文说明上下文压缩触发、摘要保真、恢复与观测事件；普通 Skill 读取正文留在历史 tool 消息中，可随历史压缩重新读取，不因读取成功固定在 system。",
+      "summary": "中文说明上下文压缩、摘要保真、恢复与观测；CompactEnginePort 沿用既有算法，Kernel 保留 before_summary 和先持久化再更新 live surface 的责任。完整工具估算、强制重试、摘要预算、tuple 兼容与 falsey 借用压缩器均保留；Skill 正文继续作为普通可压缩资料。",
       "tags": [
         "documentation",
         "protocol",
@@ -21010,7 +20991,7 @@
       "type": "file",
       "name": "session_log.py",
       "filePath": "box_agent/session_log.py",
-      "summary": "以追加式 JSONL 持久化会话事实，提供写锁、投影、cwd 校验和中断修复。为请求资料保存按 SHA-256 寻址的不可变 UTF-8 快照，校验路径、符号链接及内容哈希，先同步快照再由调用方提交请求事件。",
+      "summary": "追加式 JSONL 保存唯一持久会话事实，提供写锁、cwd 校验、open_or_create 和中断恢复；读取返回独立防御性 SessionProjection。必需 surface/reset 清除两个 reducer 的消息 surface并保留目标、计划、Todo、Skill 与审计事件；内容寻址的不可变 Skill 请求快照和持久化错误边界保持。",
       "tags": [
         "持久化",
         "会话恢复",
@@ -21024,8 +21005,8 @@
       "name": "_encode_record",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        82,
-        91
+        81,
+        90
       ],
       "summary": "将会话事件编码为一行 UTF-8 JSON，保持日志记录可独立解析。",
       "tags": [
@@ -21042,8 +21023,8 @@
       "name": "_session_dir",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        94,
-        96
+        93,
+        95
       ],
       "summary": "以会话 ID 的 SHA-256 十六进制摘要作为目录名，在指定根目录下定位会话日志。",
       "tags": [
@@ -21060,8 +21041,8 @@
       "name": "_normalize_cwd",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        99,
-        102
+        107,
+        110
       ],
       "summary": "通过绝对路径和平台大小写规则规范 cwd，保留符号链接身份而不解析链接目标。",
       "tags": [
@@ -21078,8 +21059,8 @@
       "name": "_is_legacy_workflow_context",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        116,
-        126
+        124,
+        134
       ],
       "summary": "识别旧版工作流上下文，避免将过期派生状态重放为当前事实。",
       "tags": [
@@ -21096,8 +21077,8 @@
       "name": "_acquire_writer_lock",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        129,
-        152
+        137,
+        160
       ],
       "summary": "获取会话文件的跨进程写锁，拒绝同时写入同一日志。",
       "tags": [
@@ -21114,8 +21095,8 @@
       "name": "_release_writer_lock",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        155,
-        167
+        163,
+        175
       ],
       "summary": "释放平台对应的文件锁并关闭锁句柄。",
       "tags": [
@@ -21132,8 +21113,8 @@
       "name": "SessionLogCorrupted",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        55,
-        56
+        57,
+        58
       ],
       "summary": "标识会话日志格式或记录内容损坏而无法可靠恢复。",
       "tags": [
@@ -21150,8 +21131,8 @@
       "name": "SessionLogDurabilityError",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        59,
-        60
+        61,
+        62
       ],
       "summary": "标识追加或刷新日志失败，防止把未持久化事实当作成功。",
       "tags": [
@@ -21168,8 +21149,8 @@
       "name": "SessionLogInUseError",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        63,
-        64
+        65,
+        66
       ],
       "summary": "标识会话日志已由另一个写入者持有。",
       "tags": [
@@ -21186,28 +21167,10 @@
       "name": "SessionLogWorkspaceMismatch",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        67,
-        68
+        69,
+        70
       ],
       "summary": "标识恢复会话的工作目录与原日志记录不一致。",
-      "tags": [
-        "数据模型",
-        "持久化",
-        "会话恢复",
-        "jsonl"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:box_agent/session_log.py:SessionProjection",
-      "type": "class",
-      "name": "SessionProjection",
-      "filePath": "box_agent/session_log.py",
-      "lineRange": [
-        72,
-        79
-      ],
-      "summary": "保存事件重放得到的消息、目标及会话派生状态。",
       "tags": [
         "数据模型",
         "持久化",
@@ -21222,10 +21185,10 @@
       "name": "SessionLog",
       "filePath": "box_agent/session_log.py",
       "lineRange": [
-        170,
-        924
+        178,
+        982
       ],
-      "summary": "管理单写入者 JSONL 日志及消息、目标和派生状态投影，可选恢复先备份损坏字节再替换日志。新增按内容 hash 寻址的不可变 Skill 请求快照，拒绝越界或符号链接路径，核验 UTF-8 与字节哈希并同步文件及目录；Todo/Skill 非列表投影仍回退为空。",
+      "summary": "管理单写入者 JSONL 与内容寻址的 Skill 请求快照；open_or_create 区分真正的新会话和缺少主文件的损坏目录，恢复失败释放写锁。必需 reset 同时清除 replay 与增量 surface reducer 的消息，保留目标、计划、Todo、Skill 事实和审计历史，replay 返回防御性投影。",
       "tags": [
         "数据模型",
         "持久化",
@@ -27507,7 +27470,7 @@
       "type": "file",
       "name": "session_assembly.py",
       "filePath": "box_agent/session_assembly.py",
-      "summary": "按共享插件顺序准备模型、工具、提示和恢复状态，绑定会话 SkillRuntime，并仅为 ACP 开启旧记录的可用子集恢复。Get/List 工具保留范围与宿主访问、目录过滤器；恢复后的连接器 grant 从 Agent 已验证的读取状态派生，来源和权限策略仍归宿主及能力模块。",
+      "summary": "按共享插件顺序准备模型、工具、提示与恢复状态，绑定会话唯一 SkillRuntime并保留 Get/List 范围和宿主过滤。resume_session_log 路径先按 profile 校验 Skill 记录再 prepare_resume；CLI 严格恢复，ACP 保留可用子集策略，connector grant 从已验证的 Agent 状态派生。",
       "tags": [
         "session",
         "composition",
@@ -27597,8 +27560,8 @@
       "name": "prepare_tools",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        140,
-        249
+        146,
+        255
       ],
       "summary": "装配 cwd 下工具并登记清理，保留 Get/List 原有允许和阻止范围、宿主访问及目录过滤器；随后绑定会话 SkillRuntime，utility 继续不自动注册工具。",
       "tags": [
@@ -27616,8 +27579,8 @@
       "name": "prepare_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        252,
-        341
+        258,
+        347
       ],
       "summary": "按 CLI、ACP 或 Python profile 组合 cwd、模式、运行时与环境提示；utility 跳过自动记忆和生图，但 ACP 宿主附加提示仍可携带恢复信息。",
       "tags": [
@@ -27635,8 +27598,8 @@
       "name": "prepare_hooks",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        344,
-        351
+        350,
+        357
       ],
       "summary": "优先借用宿主 Hook 列表，仅在适用的非 ACP、未预备入口按配置加载 Hook。",
       "tags": [
@@ -27654,8 +27617,8 @@
       "name": "finish_session",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        354,
-        385
+        360,
+        391
       ],
       "summary": "使用 Agent 已验证的活动 Skill 派生 connector 会话 grant，避免第二次恢复；再以宿主目录过滤器绑定 SkillSelector，禁用条目不因专家会话自动放开。",
       "tags": [
@@ -27673,8 +27636,8 @@
       "name": "_workspace_layout_path",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        388,
-        409
+        394,
+        415
       ],
       "summary": "规范共享工作区布局中的目录值，用于提示路径约定。",
       "tags": [
@@ -27692,8 +27655,8 @@
       "name": "_workspace_layout_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        412,
-        441
+        418,
+        447
       ],
       "summary": "描述宿主选定工作区与稳定会话 cwd，明确工具相对路径、产物扫描和目录判空规则；不恢复旧输出根目录语义。",
       "tags": [
@@ -27711,8 +27674,8 @@
       "name": "_filesystem_access_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        444,
-        497
+        450,
+        503
       ],
       "summary": "根据能力策略与工作区生成可访问范围和目录授权提示。",
       "tags": [
@@ -27730,8 +27693,8 @@
       "name": "_build_action_hints_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        500,
-        522
+        506,
+        528
       ],
       "summary": "结合记忆与 Playwright 可用性生成宿主引导提示，优先使用 BOX_AGENT_MCP_CONFIG_PATH 指向的 MCP 配置。",
       "tags": [
@@ -27749,8 +27712,8 @@
       "name": "build_acp_session_prompt",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        525,
-        619
+        531,
+        625
       ],
       "summary": "集中组合 ACP 模式、固定 cwd、访问策略、运行环境、专家和后续建议提示，并按显式开关加入通用任务目录组织规则。",
       "tags": [
@@ -27768,8 +27731,8 @@
       "name": "create_application_runtime",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        622,
-        625
+        628,
+        631
       ],
       "summary": "创建应用级 PluginRuntime，避免宿主适配器直接依赖插件初始化细节。",
       "tags": [
@@ -27787,8 +27750,8 @@
       "name": "build_session_permission_policy",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        628,
-        640
+        634,
+        646
       ],
       "summary": "将配置能力与已规范的宿主文件系统上下文合并，在默认模式下重建会话工作区边界。",
       "tags": [
@@ -27806,8 +27769,8 @@
       "name": "close_owned_clients",
       "filePath": "box_agent/session_assembly.py",
       "lineRange": [
-        643,
-        662
+        649,
+        668
       ],
       "summary": "按对象身份去重并逆序关闭进程拥有的模型客户端，继续尝试全部清理并保留原始异常。",
       "tags": [
@@ -29338,7 +29301,7 @@
       "type": "file",
       "name": "agent.py",
       "filePath": "box_agent/agent.py",
-      "summary": "提供 Agent 公共 API、消息与目标状态，由 Agent 持有会话唯一的 SkillRuntime；旧激活接口改为注册普通参考资料，每轮构造 Context 处理正文投影。SessionLog 继续保存持久事实，plugins、连接器许可回调及稳定 cwd 约束沿原运行入口传递。公共构造只在 Runtime 为 None 时新建实例，并复用共享 Store 绑定检查，保留 falsey 借用实例及已有持久化归属。",
+      "summary": "提供 Agent 公共 API、消息与目标状态，持有会话唯一 SkillRuntime，每轮构造 Context 处理普通资料投影。逻辑 Session ID 进入默认运行选项；clear_history 先提交并 flush 必需的 surface/reset，再清除内存消息和轮转资源账本。SessionLog、plugins、连接器许可及稳定 cwd 边界保留。公共构造只在 Runtime 为 None 时新建实例，并复用共享 Store 绑定检查，保留 falsey 借用实例及已有持久化归属。",
       "tags": [
         "agent-runtime",
         "public-api",
@@ -29588,9 +29551,9 @@
       "filePath": "box_agent/agent.py",
       "lineRange": [
         437,
-        1281
+        1289
       ],
-      "summary": "持有消息、目标与会话唯一 SkillRuntime，旧 Skill 激活接口登记普通宿主资料，每轮创建 Context 并通过通用组合入口执行。直接 API 恢复严格验证当前来源；连接器许可继续约束 MCP 目录和搜索，受管能力沿 KernelServices 传递。公共构造复用 _bind_skill_store，拒绝更换或清空借用 SkillRuntime 已绑定的 Store；仅 None 触发默认创建，falsey 实例保持身份。",
+      "summary": "持有消息、目标与会话唯一 SkillRuntime，旧激活接口登记普通宿主资料，每轮通过 Context 和组合入口执行。逻辑 Session ID 随默认选项传递；清除历史先经 Store append/flush 提交必需 reset，再修改内存。严格 Skill 恢复、连接器许可和受管服务边界保持。公共构造复用 _bind_skill_store，拒绝更换或清空借用 SkillRuntime 已绑定的 Store；仅 None 触发默认创建，falsey 实例保持身份。",
       "tags": [
         "agent-runtime",
         "public-api",
@@ -29604,7 +29567,7 @@
       "type": "file",
       "name": "agent_runtime.py",
       "filePath": "box_agent/agent_runtime.py",
-      "summary": "集中构造 LLM、Agent、权限和记忆对象，保留可注入工厂及兼容参数转发；显式传递会话 SkillRuntime、plugins、连接器许可和内置工具门控。",
+      "summary": "集中构造 LLM、Agent、权限和记忆对象，保留可注入工厂和兼容参数转发；仅显式提供时传递逻辑 Session ID、会话 SkillRuntime、plugins、连接器许可与内置工具门控。",
       "tags": [
         "runtime",
         "依赖注入",
@@ -29637,9 +29600,9 @@
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
         73,
-        144
+        147
       ],
-      "summary": "通过可替换工厂构造 Agent，集中转发 SessionLog、工具门控、连接器许可和显式 SkillRuntime；仅在调用方提供时加入可选能力参数，保留兼容构造路径。",
+      "summary": "通过可替换工厂构造 Agent，转发 SessionLog、工具门控、连接器许可与显式 SkillRuntime；仅在提供时加入逻辑 Session ID 和其他可选参数，保留旧工厂兼容性。",
       "tags": [
         "工具函数",
         "runtime",
@@ -29654,8 +29617,8 @@
       "name": "build_permission_engine",
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
-        147,
-        161
+        150,
+        164
       ],
       "summary": "使用宿主解析的策略、工作目录和授权存储创建共享权限引擎。",
       "tags": [
@@ -29672,8 +29635,8 @@
       "name": "build_memory_manager",
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
-        164,
-        175
+        167,
+        178
       ],
       "summary": "根据显式记忆配置创建共享 MemoryManager，保留可注入构造工厂。",
       "tags": [
@@ -29690,8 +29653,8 @@
       "name": "build_memory_extractor",
       "filePath": "box_agent/agent_runtime.py",
       "lineRange": [
-        178,
-        200
+        181,
+        203
       ],
       "summary": "为记忆管理器绑定 LLM、冷却时间与步骤间隔，创建共享提取器。",
       "tags": [
@@ -29707,7 +29670,7 @@
       "type": "file",
       "name": "agent_session.py",
       "filePath": "box_agent/agent_session.py",
-      "summary": "统一活跃会话状态、配置引用和插件生命周期，为每轮绑定 KernelServices 并按所有权释放资源。创建入口可转交调用方 SkillRuntime，继续保留连接器许可、utility 工具门控和稳定 cwd，不复制 Skill 读取状态。",
+      "summary": "统一会话状态、配置和插件生命周期，为每轮绑定 KernelServices 并按所有权释放资源。创建入口可传递逻辑 Session ID 与调用方 SkillRuntime，保留 utility 门控、连接器许可和稳定 cwd，不复制 Skill 读取状态。",
       "tags": [
         "session-lifecycle",
         "plugin-runtime",
@@ -29722,9 +29685,9 @@
       "filePath": "box_agent/agent_session.py",
       "lineRange": [
         32,
-        413
+        416
       ],
-      "summary": "统一活跃会话状态、配置引用和插件生命周期，为每轮绑定 KernelServices 并按所有权释放资源。创建入口可转交调用方 SkillRuntime，继续保留连接器许可、utility 工具门控和稳定 cwd，不复制 Skill 读取状态。",
+      "summary": "统一会话状态、配置和插件生命周期，为每轮绑定 KernelServices 并按所有权释放资源。创建入口可传递逻辑 Session ID 与调用方 SkillRuntime，保留 utility 门控、连接器许可和稳定 cwd，不复制 Skill 读取状态。",
       "tags": [
         "数据模型",
         "会话",
@@ -29738,7 +29701,7 @@
       "type": "file",
       "name": "cli.py",
       "filePath": "box_agent/cli.py",
-      "summary": "实现 CLI 配置、诊断与交互，经 AgentSession.open 复用共享能力装配和生命周期。目录匹配仅更新元数据，slash 显式选择交给 Agent 的 SkillRuntime；普通输入不自动预载正文，通用和代码会话仍保留用户选定 cwd。",
+      "summary": "实现 CLI 配置、诊断与交互，通过 AgentSession 复用共享装配和清理；--session-id/--resume 创建或恢复逻辑 SessionLog，Agent、运行选项、trace 和命名目标共享同一 ID。恢复严格校验 Skill 后才修复中断调用，CLI 关闭自身日志；只有新建未命名会话兼容旧工作区目标文件。目录匹配与显式 Skill 选择仍保持分工。",
       "tags": [
         "cli",
         "entry-point",
@@ -29753,8 +29716,8 @@
       "name": "run_setup_wizard",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        116,
-        211
+        117,
+        212
       ],
       "summary": "引导用户配置模型接口与关键运行参数，并保存可启动的 YAML 配置。",
       "tags": [
@@ -29771,8 +29734,8 @@
       "name": "_mask_secret",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        231,
-        238
+        232,
+        239
       ],
       "summary": "把敏感值转换为受限掩码，避免配置输出泄漏完整凭据。",
       "tags": [
@@ -29789,8 +29752,8 @@
       "name": "_is_secret_path",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        241,
-        242
+        242,
+        243
       ],
       "summary": "判断配置键路径是否属于 API key 或 token 等敏感字段。",
       "tags": [
@@ -29807,8 +29770,8 @@
       "name": "_normalize_config_path",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        245,
-        258
+        246,
+        259
       ],
       "summary": "规范点分配置键路径，供 get/set 子命令访问嵌套字段。",
       "tags": [
@@ -29825,8 +29788,8 @@
       "name": "_normalize_display_path",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        261,
-        273
+        262,
+        274
       ],
       "summary": "把配置路径格式化为便于终端展示的字符串。",
       "tags": [
@@ -29843,8 +29806,8 @@
       "name": "_get_nested",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        276,
-        282
+        277,
+        283
       ],
       "summary": "沿配置键列表读取嵌套字典中的值。",
       "tags": [
@@ -29861,8 +29824,8 @@
       "name": "_set_nested",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        285,
-        295
+        286,
+        296
       ],
       "summary": "按点分路径更新嵌套配置，并创建缺失的中间映射。",
       "tags": [
@@ -29879,8 +29842,8 @@
       "name": "_parse_config_value",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        298,
-        301
+        299,
+        302
       ],
       "summary": "解析命令行配置值为 YAML 支持的布尔、数字、列表或字符串。",
       "tags": [
@@ -29897,8 +29860,8 @@
       "name": "_load_config_yaml",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        304,
-        309
+        305,
+        310
       ],
       "summary": "读取当前 YAML 配置并校验顶层映射，返回配置路径与数据。",
       "tags": [
@@ -29915,8 +29878,8 @@
       "name": "_config_summary",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        312,
-        406
+        313,
+        407
       ],
       "summary": "生成经过敏感字段遮蔽的配置摘要，供文本和 JSON 输出复用。",
       "tags": [
@@ -29933,8 +29896,8 @@
       "name": "_print_config_summary",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        409,
-        470
+        410,
+        471
       ],
       "summary": "在终端输出当前配置文件和主要配置项。",
       "tags": [
@@ -29951,8 +29914,8 @@
       "name": "_json_print",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        473,
-        474
+        474,
+        475
       ],
       "summary": "以统一 JSON 格式输出 CLI 的机器可读结果。",
       "tags": [
@@ -29969,8 +29932,8 @@
       "name": "_config_exit_error",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        477,
-        482
+        478,
+        483
       ],
       "summary": "输出配置子命令错误并设置非零退出状态。",
       "tags": [
@@ -29987,8 +29950,8 @@
       "name": "get_log_directory",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        485,
-        487
+        486,
+        488
       ],
       "summary": "根据当前用户 profile 定位 Agent 日志目录。",
       "tags": [
@@ -30005,8 +29968,8 @@
       "name": "show_log_directory",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        490,
-        532
+        491,
+        533
       ],
       "summary": "打印日志位置并按需调用文件管理器打开目录。",
       "tags": [
@@ -30023,8 +29986,8 @@
       "name": "_open_directory_in_file_manager",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        535,
-        549
+        536,
+        550
       ],
       "summary": "针对 Windows、macOS 或 Linux 调用系统目录打开命令。",
       "tags": [
@@ -30041,8 +30004,8 @@
       "name": "read_log_file",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        552,
-        575
+        553,
+        576
       ],
       "summary": "读取指定日志文件并以 CLI 可用格式返回内容。",
       "tags": [
@@ -30059,8 +30022,8 @@
       "name": "print_banner",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        578,
-        595
+        579,
+        596
       ],
       "summary": "显示 Box-Agent 启动横幅与版本信息。",
       "tags": [
@@ -30077,8 +30040,8 @@
       "name": "print_help",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        598,
-        633
+        599,
+        634
       ],
       "summary": "显示交互模式支持的命令和使用提示。",
       "tags": [
@@ -30095,8 +30058,8 @@
       "name": "print_session_info",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        636,
-        671
+        637,
+        672
       ],
       "summary": "输出当前模型、工作区和会话运行配置。",
       "tags": [
@@ -30113,8 +30076,8 @@
       "name": "print_stats",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        674,
-        695
+        675,
+        696
       ],
       "summary": "打印当前会话的 token 用量、工具调用和运行统计。",
       "tags": [
@@ -30131,8 +30094,8 @@
       "name": "_session_stats",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        698,
-        710
+        699,
+        711
       ],
       "summary": "从 Agent 历史与运行状态汇总终端所需统计字段。",
       "tags": [
@@ -30149,8 +30112,8 @@
       "name": "print_goal_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        713,
-        743
+        714,
+        744
       ],
       "summary": "展示当前持久目标的状态、进度和阻塞信息。",
       "tags": [
@@ -30167,8 +30130,8 @@
       "name": "_goal_store_path",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        746,
-        748
+        747,
+        749
       ],
       "summary": "解析当前 profile 和工作区对应的 CLI 目标存储文件。",
       "tags": [
@@ -30185,8 +30148,8 @@
       "name": "_load_goal_state",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        751,
-        760
+        752,
+        761
       ],
       "summary": "从目标存储读取并恢复可用的 GoalState。",
       "tags": [
@@ -30203,8 +30166,8 @@
       "name": "_save_goal_state",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        763,
-        776
+        764,
+        777
       ],
       "summary": "将 CLI 目标状态保存到其工作区关联的存储位置。",
       "tags": [
@@ -30221,8 +30184,8 @@
       "name": "_restore_cli_goal",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        779,
-        784
+        780,
+        785
       ],
       "summary": "为 CLI Agent 恢复先前保存的持久目标。",
       "tags": [
@@ -30239,8 +30202,8 @@
       "name": "handle_goal_command",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        787,
-        873
+        788,
+        874
       ],
       "summary": "处理交互式目标创建、查看、暂停、继续和清除命令。",
       "tags": [
@@ -30257,10 +30220,10 @@
       "name": "cmd_goal",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        876,
-        985
+        877,
+        1006
       ],
-      "summary": "执行非交互 goal 子命令并输出目标状态。",
+      "summary": "对命名 SessionLog 与旧工作区目标文件复用同一动作和输出策略；命名目标从自己的日志投影读取，修改 append/flush 后关闭日志，未提供 ID 时保持旧文件兼容。",
       "tags": [
         "工具函数",
         "cli",
@@ -30275,8 +30238,8 @@
       "name": "_workspace_from_args",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        988,
-        991
+        1009,
+        1012
       ],
       "summary": "从 CLI 参数和配置解析当前工作目录。",
       "tags": [
@@ -30293,10 +30256,10 @@
       "name": "parse_args",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        994,
-        1215
+        1015,
+        1246
       ],
-      "summary": "定义并解析启动参数和 setup、config、doctor、安装、goal 等子命令。",
+      "summary": "解析 CLI 配置、任务和子命令，支持 --session-id 与 --resume 指向同一逻辑会话；goal 子命令继承相同 ID 选择及原动作参数。",
       "tags": [
         "工具函数",
         "cli",
@@ -30311,8 +30274,8 @@
       "name": "cmd_setup",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1218,
-        1222
+        1249,
+        1253
       ],
       "summary": "确保用户配置存在并启动首次设置向导。",
       "tags": [
@@ -30329,8 +30292,8 @@
       "name": "cmd_config",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1225,
-        1313
+        1256,
+        1344
       ],
       "summary": "执行配置查看、get/set 与编辑操作，对敏感值进行掩码并维护 YAML 文件。",
       "tags": [
@@ -30347,8 +30310,8 @@
       "name": "build_cli_env_context",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1316,
-        1329
+        1347,
+        1360
       ],
       "summary": "探测终端宿主和工具运行时能力，构造共享 EnvContext。",
       "tags": [
@@ -30365,8 +30328,8 @@
       "name": "_resolve_obsidian_cli",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1332,
-        1336
+        1363,
+        1367
       ],
       "summary": "从配置和环境确定可用的 Obsidian CLI。",
       "tags": [
@@ -30383,8 +30346,8 @@
       "name": "_doctor_check",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1339,
-        1342
+        1370,
+        1373
       ],
       "summary": "创建带名称、状态与说明的 doctor 检查结果。",
       "tags": [
@@ -30401,8 +30364,8 @@
       "name": "_doctor_status_prefix",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1345,
-        1351
+        1376,
+        1382
       ],
       "summary": "将健康检查状态映射为终端前缀。",
       "tags": [
@@ -30419,8 +30382,8 @@
       "name": "_doctor_line",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1354,
-        1355
+        1385,
+        1386
       ],
       "summary": "把单项诊断结果格式化为可阅读的终端行。",
       "tags": [
@@ -30437,8 +30400,8 @@
       "name": "_doctor_obsidian_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1358,
-        1411
+        1389,
+        1442
       ],
       "summary": "汇总 Obsidian 配置及 CLI 可用性诊断。",
       "tags": [
@@ -30455,8 +30418,8 @@
       "name": "_doctor_obsidian_status_line",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1414,
-        1415
+        1445,
+        1446
       ],
       "summary": "生成 Obsidian 状态的终端摘要。",
       "tags": [
@@ -30473,8 +30436,8 @@
       "name": "_doctor_check_obsidian",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1418,
-        1419
+        1449,
+        1450
       ],
       "summary": "执行 Obsidian 能力检查并返回标准 doctor 结果。",
       "tags": [
@@ -30491,8 +30454,8 @@
       "name": "_doctor_config_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1422,
-        1431
+        1453,
+        1462
       ],
       "summary": "读取并校验主配置，生成模型及配置可用性诊断。",
       "tags": [
@@ -30509,8 +30472,8 @@
       "name": "_probe_llm_api",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1434,
-        1448
+        1465,
+        1479
       ],
       "summary": "对配置的模型接口执行有界请求，验证认证和响应是否可用。",
       "tags": [
@@ -30527,8 +30490,8 @@
       "name": "_doctor_api_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1451,
-        1483
+        1482,
+        1514
       ],
       "summary": "将模型 API 探测结果转换成成功或失败诊断。",
       "tags": [
@@ -30545,8 +30508,8 @@
       "name": "_doctor_sandbox_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1486,
-        1502
+        1517,
+        1533
       ],
       "summary": "检查 Python 沙箱环境及运行时依赖准备情况。",
       "tags": [
@@ -30563,8 +30526,8 @@
       "name": "_doctor_mcp_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1505,
-        1510
+        1536,
+        1541
       ],
       "summary": "检查 MCP 配置、服务器及工具加载状态。",
       "tags": [
@@ -30581,8 +30544,8 @@
       "name": "cmd_doctor",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1513,
-        1549
+        1544,
+        1580
       ],
       "summary": "组合配置、API、MCP、沙箱和浏览器检查并输出诊断报告。",
       "tags": [
@@ -30599,8 +30562,8 @@
       "name": "_default_browsers_path",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1552,
-        1554
+        1583,
+        1585
       ],
       "summary": "解析当前 profile 下默认 Playwright 浏览器缓存路径。",
       "tags": [
@@ -30617,8 +30580,8 @@
       "name": "_playwright_env",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1557,
-        1563
+        1588,
+        1594
       ],
       "summary": "为 Playwright 安装和诊断构造浏览器缓存环境变量。",
       "tags": [
@@ -30635,8 +30598,8 @@
       "name": "_cli_node_execution_env",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1566,
-        1575
+        1597,
+        1606
       ],
       "summary": "组合托管 Node 可执行路径及环境供 CLI 安装命令使用。",
       "tags": [
@@ -30653,8 +30616,8 @@
       "name": "_doctor_browser_status",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1578,
-        1622
+        1609,
+        1653
       ],
       "summary": "检测 Playwright 浏览器安装与可执行路径状态。",
       "tags": [
@@ -30671,8 +30634,8 @@
       "name": "_doctor_check_browser",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1625,
-        1626
+        1656,
+        1657
       ],
       "summary": "将浏览器检测结果包装为标准 doctor 检查项。",
       "tags": [
@@ -30689,8 +30652,8 @@
       "name": "cmd_install_browser",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1629,
-        1669
+        1660,
+        1700
       ],
       "summary": "安装所需 Playwright 浏览器并报告安装结果。",
       "tags": [
@@ -30707,8 +30670,8 @@
       "name": "cmd_install_node",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1672,
-        1692
+        1703,
+        1723
       ],
       "summary": "安装当前平台的托管 Node runtime，供 Skill 和浏览器工具使用。",
       "tags": [
@@ -30725,8 +30688,8 @@
       "name": "_ensure_user_mcp_config",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1695,
-        1708
+        1726,
+        1739
       ],
       "summary": "初始化或定位当前用户 profile 的 MCP 配置文件。",
       "tags": [
@@ -30743,8 +30706,8 @@
       "name": "_enable_playwright_in_mcp",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1711,
-        1746
+        1742,
+        1777
       ],
       "summary": "更新 MCP 配置以启用 Playwright 服务。",
       "tags": [
@@ -30761,8 +30724,8 @@
       "name": "_quiet_cleanup",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1749,
-        1767
+        1780,
+        1798
       ],
       "summary": "执行退出清理并抑制不应覆盖主运行结果的清理异常。",
       "tags": [
@@ -30779,8 +30742,8 @@
       "name": "_run_session_turn",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1770,
-        1776
+        1801,
+        1807
       ],
       "summary": "通过 AgentSession 消费并渲染单轮事件，同时记录用量与 trace。",
       "tags": [
@@ -30797,10 +30760,10 @@
       "name": "run_agent",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        1779,
-        2624
+        1810,
+        2681
       ],
-      "summary": "经 AgentSession.open 装配 CLI 会话并处理单次任务与交互轮次；目录匹配只更新发现信息，slash 显式选择交给 SkillRuntime。复用目标续跑、MCP 对账、稳定 cwd 和生命周期清理。",
+      "summary": "创建或恢复逻辑 SessionLog，以同一 ID 启动 AgentSession、运行选项和 trace；共享预备先严格验证 Skill 再修复中断调用。命名目标只使用本日志，新建未命名会话保留旧目标文件镜像，所有退出与启动失败路径都关闭 CLI 拥有的日志和客户端。",
       "tags": [
         "cli",
         "entry-point",
@@ -30815,8 +30778,8 @@
       "name": "main",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        2627,
-        2730
+        2684,
+        2789
       ],
       "summary": "分派 CLI 管理子命令，解析工作区与代码会话模式后启动 Agent，不再预创建隐式 output 目录。",
       "tags": [
@@ -31323,7 +31286,7 @@
       "type": "file",
       "name": "loop.py",
       "filePath": "box_agent/kernel/loop.py",
-      "summary": "经服务端口驱动模型、上下文、计划和工具步骤。先冻结 PreparedTools，再由 Context 预算和投影请求资料；Kernel 持久化真实历史及请求关联，在日志提交后调用通用确认回调，并在有效响应后调用消费回调。保留 Hook 与工具提交边界，完整输入超预算及异常重复流均走有界恢复。",
+      "summary": "经服务端口推进模型与工具，Context 消费同一 PreparedTools 并投影普通请求资料；独立 CompactEnginePort 决定压缩。Kernel 提供 before_summary 持久化前缀与 compaction/start，提交返回 surface 并 flush 后才更新内存历史；请求提交、有效响应回调及有界恢复保持原边界。",
       "tags": [
         "kernel",
         "对话控制",
@@ -31337,8 +31300,8 @@
       "name": "_resolve_provider_stale_seconds",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        131,
-        150
+        130,
+        149
       ],
       "summary": "调用共享解析器，按环境变量、配置和默认值确定模型静默超时。",
       "tags": [
@@ -31354,8 +31317,8 @@
       "name": "_stream_with_activity",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        153,
-        170
+        152,
+        169
       ],
       "summary": "为模型流绑定 kernel 心跳间隔与静默超时控制。",
       "tags": [
@@ -31371,8 +31334,8 @@
       "name": "final_summary_wrapup_text",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        251,
-        264
+        250,
+        263
       ],
       "summary": "生成工具调用预算耗尽后的最终总结提示，要求交付已完成结果。",
       "tags": [
@@ -31388,8 +31351,8 @@
       "name": "empty_final_answer_retry_text",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        267,
-        273
+        266,
+        272
       ],
       "summary": "生成空最终回答的重试提示，使模型补充用户可见答复。",
       "tags": [
@@ -31405,8 +31368,8 @@
       "name": "_message_text",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        281,
-        290
+        280,
+        289
       ],
       "summary": "从消息内容块提取文本，用于计划和上下文判断。",
       "tags": [
@@ -31422,8 +31385,8 @@
       "name": "_latest_user_text",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        293,
-        297
+        292,
+        296
       ],
       "summary": "从历史消息逆序寻找最近一条用户文本。",
       "tags": [
@@ -31439,8 +31402,8 @@
       "name": "_should_emit_plan_start",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        300,
-        309
+        299,
+        308
       ],
       "summary": "根据执行选项及最近请求判断是否触发计划开始事件。",
       "tags": [
@@ -31456,8 +31419,8 @@
       "name": "_plan_approval_is_approved",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        312,
-        326
+        311,
+        325
       ],
       "summary": "规范识别计划审批载荷中的批准状态。",
       "tags": [
@@ -31473,8 +31436,8 @@
       "name": "_plan_approval_payload",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        329,
-        342
+        328,
+        341
       ],
       "summary": "生成包含审批请求 ID、计划 ID 与状态的结构化计划审批载荷。",
       "tags": [
@@ -31490,8 +31453,8 @@
       "name": "_attach_plan_approval_payload",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        345,
-        381
+        344,
+        380
       ],
       "summary": "将计划审批载荷合并到工具原始输出，保留现有工具数据并规范化审批字段。",
       "tags": [
@@ -31507,8 +31470,8 @@
       "name": "_plan_start_payload",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        384,
-        413
+        383,
+        412
       ],
       "summary": "构建计划开始事件，携带用户请求及需要审批的计划状态。",
       "tags": [
@@ -31524,8 +31487,8 @@
       "name": "_auto_match_memory_for_latest_prompt",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        418,
-        485
+        417,
+        484
       ],
       "summary": "为最近用户请求检索相关记忆并注入上下文，避免无关检索和重复匹配。",
       "tags": [
@@ -31541,8 +31504,8 @@
       "name": "_signed_web_image_url_map",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        498,
-        540
+        497,
+        539
       ],
       "summary": "从网页提取工具结果收集带签名图片 URL 与安全展示 URL 的对应关系。",
       "tags": [
@@ -31558,8 +31521,8 @@
       "name": "_restore_signed_web_image_urls",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        542,
-        559
+        541,
+        558
       ],
       "summary": "将回答中的简化图片地址恢复为原始可访问签名 URL。",
       "tags": [
@@ -31575,10 +31538,10 @@
       "name": "_run_agent_loop_impl",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        604,
-        2632
+        603,
+        2640
       ],
-      "summary": "推进模型和工具步骤，先冻结 PreparedTools 再预算历史及请求投影；真实调用、回复和请求关联经 Store 提交，日志成功后调用通用 on_committed，有效响应后调用 on_response。超预算仅有界压缩重试，异常重复流最多恢复一次，不重放工具或 Step Hook。",
+      "summary": "先冻结 PreparedTools，再由 Context 处理完整请求输入；独立 CompactEngine 接收 CompactionInput 与 Kernel 的 before_summary 回调。Kernel 先持久化摘要前缀与 start，再提交返回 surface 和 flush，最后替换内存；请求交付和有效响应确认、有界压缩重试及重复流恢复保持。",
       "tags": [
         "kernel",
         "对话控制",
@@ -31592,8 +31555,8 @@
       "name": "run_agent_loop",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        2702,
-        2761
+        2710,
+        2769
       ],
       "summary": "通过已组装的 AgentLoopKernel 执行循环并保留公共异步迭代接口。",
       "tags": [
@@ -31609,8 +31572,8 @@
       "name": "_LoopRuntimeDefaults",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        116,
-        125
+        115,
+        124
       ],
       "summary": "保存 kernel 心跳间隔、提供商静默阈值等默认运行参数。",
       "tags": [
@@ -31626,8 +31589,8 @@
       "name": "_SignedWebImageUrlStreamRewriter",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        561,
-        601
+        560,
+        600
       ],
       "summary": "跨流式文本片段缓存可能被截断的图片地址，并恢复签名 URL。",
       "tags": [
@@ -31643,8 +31606,8 @@
       "name": "AgentLoopKernel",
       "filePath": "box_agent/kernel/loop.py",
       "lineRange": [
-        2652,
-        2699
+        2660,
+        2707
       ],
       "summary": "以外层装配的 KernelServices 配置稳定循环，拒绝在运行参数中重复传入 hooks、plugins 等能力实现；兼容旧服务束时补齐工具引擎，并在退出时关闭事件流及本轮工具引擎。",
       "tags": [
@@ -34213,7 +34176,7 @@
       "type": "file",
       "name": "composition.py",
       "filePath": "box_agent/composition.py",
-      "summary": "在外层为每个 Run 注册、冻结和注入 HookBus，并为最终借用的 Skill 与 Store 绑定运行级 Context。managed 路径保留既有模型、工具和连接器能力身份；额外 Provider 由独立 RUN 宿主拥有。关闭先排空总线，再清理 Provider，即使总线完成关闭后报告迟到持久化错误也继续清理并保留错误。",
+      "summary": "为每 Run 注册冻结 HookBus，并绑定最终借用的 Skill、Store、Context 与 CompactEngine；managed 保留模型、工具及连接器身份，显式压缩器即使布尔值为假也不被替换。额外 Provider 仍由独立 RUN 宿主拥有，关闭先排空总线再清理 Provider并传播迟到持久化错误。",
       "tags": [
         "composition",
         "hooks",
@@ -34227,10 +34190,10 @@
       "name": "_default_capabilities",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        44,
-        76
+        45,
+        78
       ],
-      "summary": "收集借用能力并创建本 Run HookBus；缺失 SkillEngine 时从内置 Get/List 的同一 Loader 创建 Runtime，Store 绑定留到最终能力替换完成后。",
+      "summary": "收集借用模型、工具、Skill、Context 和 Compact 能力并创建本 Run HookBus；缺失 SkillEngine 时解析共同 Loader，Store 归属在最终能力替换后绑定。",
       "tags": [
         "function",
         "composition",
@@ -34246,8 +34209,8 @@
       "name": "_kernel_run_arguments",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        79,
-        86
+        81,
+        88
       ],
       "summary": "过滤已由 KernelServices 拥有的能力和 plugins 参数，只向纯内核转交运行控制参数。",
       "tags": [
@@ -34265,8 +34228,8 @@
       "name": "compose_default_kernel_services",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        121,
-        145
+        123,
+        147
       ],
       "summary": "同步构造默认服务与本 Run HookBus，注册冻结旧 Hook并将真实历史绑定到 Context；拒绝异步静态插件，保留借用工具的默认执行器。",
       "tags": [
@@ -34284,8 +34247,8 @@
       "name": "_validate_managed_services",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        148,
-        201
+        150,
+        203
       ],
       "summary": "按对象身份核对受管服务与有效运行能力及 Hook 列表，拒绝互相矛盾的旧参数覆盖。",
       "tags": [
@@ -34303,8 +34266,8 @@
       "name": "_add_cleanup_note",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        204,
-        213
+        206,
+        215
       ],
       "summary": "实现 `add-cleanup-note` 对应的模块职责；服务于组合默认插件、KernelServices 与 AgentLoopKernel，并统一处理插件清理失败。",
       "tags": [
@@ -34322,8 +34285,8 @@
       "name": "_combined_cleanup_error",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        216,
-        248
+        218,
+        250
       ],
       "summary": "展开插件清理失败并保留原始取消对象，把普通错误挂为原因或注释，兼容 Python 3.10。",
       "tags": [
@@ -34341,8 +34304,8 @@
       "name": "_cleanup_plugin_run",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        251,
-        269
+        253,
+        271
       ],
       "summary": "依次尝试释放当前激活与关闭宿主，收集各阶段失败并保留取消的因果关系。",
       "tags": [
@@ -34360,8 +34323,8 @@
       "name": "_attach_cleanup_error",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        272,
-        281
+        274,
+        283
       ],
       "summary": "实现 `attach-cleanup-error` 对应的模块职责；服务于组合默认插件、KernelServices 与 AgentLoopKernel，并统一处理插件清理失败。",
       "tags": [
@@ -34379,10 +34342,10 @@
       "name": "run_agent_loop_with_default_services",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        349,
-        448
+        351,
+        459
       ],
-      "summary": "验证 managed 能力一致性，绑定最终 Skill/Store/Context 并将同一历史交给 Context，再注册冻结本 Run Hook。其余借用服务保留身份，额外 Provider 使用独立 RUN 宿主；关闭后先排空总线再清理 Provider。",
+      "summary": "核对 managed 能力身份并绑定最终 Skill/Store/Context/Compact；冲突压缩器明确拒绝，存在但布尔值为假的实例仍保留。其余借用服务和 connector 身份保持，额外 Provider 由私有 RUN 宿主清理，关闭先排空 HookBus。",
       "tags": [
         "function",
         "composition",
@@ -34486,7 +34449,7 @@
       "type": "file",
       "name": "ports.py",
       "filePath": "box_agent/kernel/ports.py",
-      "summary": "声明 Kernel 借用的模型、权限、记忆、Store、工具和 Hook 端口，以及 SkillEngine、ContextEngine 和 PreparedContext 合同。Skill 保存来源和读取事实，Context 提供请求投影及可选提交、响应回调，KernelServices 仅持有不可变引用。",
+      "summary": "声明 Kernel 借用的模型、权限、记忆、Store、工具、Hook 与 Skill/Context 端口；新增独立 CompactEnginePort 只返回压缩结果，不能自行提交日志或替换 live history。ContextEnginePort 仍使用 configure_run、bind_history 和 prepare_request，KernelServices 保存各能力的不可变引用。",
       "tags": [
         "kernel",
         "protocol",
@@ -34500,8 +34463,8 @@
       "name": "SummaryLLMPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        21,
-        34
+        23,
+        36
       ],
       "summary": "封装 `SummaryLLMPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34519,8 +34482,8 @@
       "name": "LLMPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        38,
-        57
+        40,
+        59
       ],
       "summary": "封装 `LLMPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34538,8 +34501,8 @@
       "name": "PermissionGatewayPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        61,
-        64
+        63,
+        66
       ],
       "summary": "封装 `PermissionGatewayPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34557,8 +34520,8 @@
       "name": "MemoryLookupPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        68,
-        76
+        70,
+        78
       ],
       "summary": "封装 `MemoryLookupPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34576,8 +34539,8 @@
       "name": "MemoryExtractionPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        80,
-        89
+        82,
+        91
       ],
       "summary": "封装 `MemoryExtractionPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34595,8 +34558,8 @@
       "name": "MemoryPromotionPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        93,
-        111
+        95,
+        113
       ],
       "summary": "封装 `MemoryPromotionPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34614,8 +34577,8 @@
       "name": "SessionStorePort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        115,
-        145
+        117,
+        147
       ],
       "summary": "封装 `SessionStorePort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34633,8 +34596,8 @@
       "name": "HookBusPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        149,
-        201
+        151,
+        203
       ],
       "summary": "保留旧生命周期与工具 fire_* 调用签名，供兼容入口借用 Hook 能力。",
       "tags": [
@@ -34652,8 +34615,8 @@
       "name": "ToolCatalogPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        216,
-        233
+        218,
+        235
       ],
       "summary": "封装 `ToolCatalogPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34671,8 +34634,8 @@
       "name": "ToolExposureResultPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        237,
-        241
+        239,
+        243
       ],
       "summary": "封装 `ToolExposureResultPort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34690,8 +34653,8 @@
       "name": "ToolExposurePort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        245,
-        255
+        247,
+        257
       ],
       "summary": "封装 `ToolExposurePort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34709,8 +34672,8 @@
       "name": "ToolResultStorePort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        259,
-        284
+        261,
+        286
       ],
       "summary": "封装 `ToolResultStorePort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34728,8 +34691,8 @@
       "name": "ToolResultBudgetOutcomePort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        288,
-        294
+        290,
+        296
       ],
       "summary": "封装 `ToolResultBudgetOutcomePort` 契约与状态，用于声明内核依赖的 LLM、权限、记忆、会话、Hook、工具暴露与结果存储端口协议。",
       "tags": [
@@ -34747,8 +34710,8 @@
       "name": "ToolEnginePort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        298,
-        315
+        300,
+        317
       ],
       "summary": "定义每轮工具准备、运行配置、预算指引、异步调用事件及关闭接口，执行器借用会话资源。",
       "tags": [
@@ -34766,10 +34729,10 @@
       "name": "KernelServices",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        395,
-        413
+        408,
+        427
       ],
-      "summary": "把本轮已解析的模型、工具、Store、Hook 及可选 Skill/Context 能力保存为不可变引用包，不移交引用对象的资源所有权。",
+      "summary": "以不可变引用包保存本轮解析的模型、工具、Store、Hook、Skill、Context 和可选 CompactEngine；各能力对象的资源所有权保持外部归属。",
       "tags": [
         "class",
         "kernel",
@@ -34972,7 +34935,7 @@
       "type": "file",
       "name": "defaults.py",
       "filePath": "box_agent/plugins/defaults.py",
-      "summary": "把调用方拥有的能力包装为默认描述符，并为缺失的 Context 创建 RUN 实例。最终装配验证 Get/List Loader 与 SkillEngine 来源身份、Skill 持久化与 SessionStore 身份，再绑定 Context；Hook 和其他借用资源不移交所有权。",
+      "summary": "包装调用方借用能力并在缺失时创建 RUN 级 Context 与 CompactEngine；默认判断使用 None，保留布尔值为假的外部压缩器。最终装配仍校验 Skill 与 Loader/Store 身份后绑定 Context，Hook 和其他借用资源不移交所有权。",
       "tags": [
         "plugins",
         "composition",
@@ -34986,8 +34949,8 @@
       "name": "_captured_instance_descriptor",
       "filePath": "box_agent/plugins/defaults.py",
       "lineRange": [
-        88,
-        102
+        90,
+        104
       ],
       "summary": "为调用方拥有的能力创建捕获同一实例的 RUN 描述符，disposer=None 保留原资源所有权。",
       "tags": [
@@ -35005,10 +34968,10 @@
       "name": "default_plugin_descriptors",
       "filePath": "box_agent/plugins/defaults.py",
       "lineRange": [
-        105,
-        172
+        107,
+        184
       ],
-      "summary": "按固定顺序包装借用能力，包括可选 Skill 和 Context 端口；Context 缺失时创建 RUN 作用域默认描述符，总线仍兼容旧 HookBus 与新 HookDispatch 两个端口。",
+      "summary": "按固定顺序包装借用能力，支持 Skill、Context 和 Compact 端口；只在 Context 或 Compact 为 None 时创建对应 RUN 默认描述符，保留 falsey 实例和 Hook 双端口兼容。",
       "tags": [
         "function",
         "plugins",
@@ -35024,8 +34987,8 @@
       "name": "create_default_plugin_host",
       "filePath": "box_agent/plugins/defaults.py",
       "lineRange": [
-        175,
-        216
+        187,
+        230
       ],
       "summary": "将借用能力与额外静态插件组成当前 Run 私有宿主，拒绝非 RUN 作用域扩展。",
       "tags": [
@@ -35043,10 +35006,10 @@
       "name": "kernel_services_from_registry",
       "filePath": "box_agent/plugins/defaults.py",
       "lineRange": [
-        234,
-        259
+        248,
+        274
       ],
-      "summary": "从冻结注册表读取最终能力，先验证 Skill 来源与 Store 归属，再配置 Context，形成不可变 KernelServices。",
+      "summary": "从冻结注册表读取能力，先验证 Skill 来源与 Store 归属并配置 Context，再把可选 CompactEngine 与其他引用放入 KernelServices。",
       "tags": [
         "function",
         "plugins",
@@ -35062,10 +35025,10 @@
       "name": "compose_default_services",
       "filePath": "box_agent/plugins/defaults.py",
       "lineRange": [
-        262,
-        304
+        277,
+        325
       ],
-      "summary": "验证借用 Skill 与目录、Store 的一致性，缺失时创建运行级 DefaultContextEngine 并绑定最终能力；其余服务保持对象身份，返回不可变引用包。",
+      "summary": "校验借用 Skill 与最终 Loader/Store 并配置 Context；仅在缺失时创建 DefaultContextEngine 或 DefaultCompactEngine，保留 falsey 外部压缩器和其余对象身份。",
       "tags": [
         "function",
         "plugins",
@@ -35436,7 +35399,7 @@
       "type": "file",
       "name": "session_context.py",
       "filePath": "box_agent/session_context.py",
-      "summary": "用显式数据对象分离配置、会话选项、宿主借用能力与本轮输入，诊断输出避免暴露 Config。HostBindings 允许宿主提供 Skill 访问和目录过滤回调，供共享能力组装接入策略。",
+      "summary": "用显式对象分离配置、会话选项、宿主借用能力与当前输入，诊断避免暴露 Config。resume_session_log 选择共享恢复准备顺序，HostBindings 的 Skill 访问与目录过滤器继续把策略交给能力装配。",
       "tags": [
         "data-model",
         "host-bindings",
@@ -35451,9 +35414,9 @@
       "filePath": "box_agent/session_context.py",
       "lineRange": [
         17,
-        34
+        35
       ],
-      "summary": "保存 profile、会话 cwd、utility、权限、工作区布局和原始构造状态等标准化选项，不再定义独立产物根或产物模式。",
+      "summary": "保存 profile、cwd、utility、权限、布局和标准化构造选项；resume_session_log 开启先验证 Skill 后修复日志的共享恢复顺序，不引入另一套会话存储。",
       "tags": [
         "data-model",
         "host-bindings",
@@ -35468,8 +35431,8 @@
       "name": "HostBindings",
       "filePath": "box_agent/session_context.py",
       "lineRange": [
-        38,
-        66
+        39,
+        67
       ],
       "summary": "声明宿主借用的模型、工具、记忆、Hook、SessionLog、异步任务与组装回调，并提供可选 Skill 访问和目录过滤函数，供共享会话预备阶段使用。",
       "tags": [
@@ -35486,8 +35449,8 @@
       "name": "SessionContext",
       "filePath": "box_agent/session_context.py",
       "lineRange": [
-        70,
-        86
+        71,
+        87
       ],
       "summary": "绑定 Config、SessionOptions、HostBindings 与唯一会话键，解析工作区并发送不会改变模型行为的诊断事件。",
       "tags": [
@@ -35504,8 +35467,8 @@
       "name": "RunContext",
       "filePath": "box_agent/session_context.py",
       "lineRange": [
-        90,
-        94
+        91,
+        95
       ],
       "summary": "把当前会话、Agent、有效运行选项和唯一轮次 ID 绑定为 run scope 工厂输入。",
       "tags": [
@@ -36691,7 +36654,7 @@
       "type": "document",
       "name": "AGENT_SESSION.md",
       "filePath": "docs/AGENT_SESSION.md",
-      "summary": "说明 AgentSession.open 的配置驱动装配、插件生命周期、cwd 和宿主边界。Agent 持有唯一 SkillRuntime，读取恢复不在宿主重复执行；保留失败 Run 回滚、再激活门控与先清理 Run 再释放 Session 的顺序。",
+      "summary": "说明 AgentSession 装配、插件生命周期、稳定 cwd 与宿主边界，并记录唯一 SkillRuntime 和严格／部分恢复顺序。新增 CLI 逻辑 Session ID、目标与 trace 归属、日志关闭责任和必需 surface/reset 的兼容迁移要求；清除消息不删除非消息事实或审计历史。",
       "tags": [
         "文档",
         "架构",
@@ -37596,8 +37559,8 @@
       "name": "_register_legacy_hooks",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        89,
-        96
+        91,
+        98
       ],
       "summary": "按原列表顺序把旧 Hook 适配成声明，由装配层绑定 legacy 来源和当前 Run 归属。",
       "complexity": "simple",
@@ -37613,8 +37576,8 @@
       "name": "register_run_hooks",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        99,
-        118
+        101,
+        120
       ],
       "summary": "先注册旧 Hook，再从 activation 的真实 contribution 取得 HookProvider 声明并绑定描述符归属，全部成功后冻结总线；失败先关闭总线。",
       "complexity": "simple",
@@ -37630,8 +37593,8 @@
       "name": "_cleanup_hook_run",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        287,
-        316
+        289,
+        318
       ],
       "summary": "先排空 HookBus；若总线已关闭但报告迟到持久化错误，仍释放拥有的 Provider 并合并错误。私有宿主取消后继续清理剩余实例，以任务返回值保留原异常对象。",
       "complexity": "simple",
@@ -37647,8 +37610,8 @@
       "name": "_wait_for_hook_cleanup",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        319,
-        340
+        321,
+        342
       ],
       "summary": "通过 shield 等待受保护清理任务；managed 路径延后传播重复取消，确保 Hook 与 Provider 清理完成后 Session 才能释放依赖。",
       "complexity": "simple",
@@ -37664,8 +37627,8 @@
       "name": "_cleanup_task_finished",
       "filePath": "box_agent/composition.py",
       "lineRange": [
-        343,
-        346
+        345,
+        348
       ],
       "summary": "释放已完成清理任务的全局保留引用，并消费未取消任务异常。",
       "complexity": "simple",
@@ -38081,8 +38044,8 @@
       "name": "HookDispatchPort",
       "filePath": "box_agent/kernel/ports.py",
       "lineRange": [
-        205,
-        212
+        207,
+        214
       ],
       "summary": "向内核与工具引擎提供 observe、before_tool 和 after_tool 的结构化协议，返回只读决策结果并保留旧 HookBusPort。",
       "complexity": "simple",
@@ -38252,8 +38215,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        275,
-        288
+        249,
+        262
       ],
       "summary": "根据规范图片块的宽高估算输入 token，并在缺少有效尺寸时使用默认值，将结果限制在最小 512 token 与配置上限之间。"
     },
@@ -38271,8 +38234,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        291,
-        304
+        265,
+        278
       ],
       "summary": "序列化预算正文时移除 input_image 的 data 字段，并保留估算图片 token 的标记，避免把 base64 字节作为文本计费。"
     },
@@ -38290,8 +38253,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        307,
-        316
+        281,
+        290
       ],
       "summary": "汇总列表正文中所有规范 input_image 块的像素 token 估算；非列表正文不产生图片成本。"
     },
@@ -38309,8 +38272,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        820,
-        825
+        798,
+        803
       ],
       "summary": "仅将以当前或旧版摘要标记开头的 user 文本识别为合成摘要占位消息。"
     },
@@ -38328,8 +38291,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        843,
-        847
+        821,
+        825
       ],
       "summary": "把当前提供的工具定义归一为名称映射，结合最新真实响应的 usage 与完整请求本地估算计算安全输入 token 量。"
     },
@@ -38347,8 +38310,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        850,
-        859
+        828,
+        837
       ],
       "summary": "从安全输入上限扣除当前消息、实际工具定义和固定 1024 token 信封余量，将剩余额度换算为最多 50000 字符的引用预算。output_tokens 参数只保留调用兼容性，不再次预留模型输出。"
     },
@@ -38364,8 +38327,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        319,
-        327
+        321,
+        329
       ],
       "summary": "约定请求副本、历史投影、资料关联、完整输入估算和阻塞原因，Kernel 消费这些通用字段而不解析 Skill 领域状态。"
     },
@@ -38381,8 +38344,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        331,
-        359
+        333,
+        361
       ],
       "summary": "约定会话来源解析、显式选择、读取与恢复事实，以及不可变快照和交付记录；不持有请求消息或预算，外层装配验证与内置 Skill 工具的来源身份一致。"
     },
@@ -38398,8 +38361,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        363,
-        391
+        365,
+        393
       ],
       "summary": "约定每 Run 的历史绑定、临时资料预留、工具读取和完整 PreparedTools 请求投影；可选 project_history 与提交、响应回调让 Kernel 保持通用，旧 Context 可使用恒等历史投影。"
     },
@@ -38432,8 +38395,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        58,
-        70
+        60,
+        72
       ],
       "summary": "从内置 GetSkillTool 与 ListSkillsTool 解析同一 Loader；只检查已绑定对象，不扫描目录，混用两个来源时明确拒绝。"
     },
@@ -38449,8 +38412,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        73,
-        85
+        75,
+        87
       ],
       "summary": "校验最终工具目录与 SkillEngine 的 Loader 对象身份；拒绝把调用方已有的会话读取事实静默转到其他来源，自定义工具保留自己的绑定合同。"
     },
@@ -38466,8 +38429,8 @@
       ],
       "complexity": "simple",
       "lineRange": [
-        219,
-        231
+        233,
+        245
       ],
       "summary": "为内置 SkillRuntime 绑定最终 SessionStore；若已有持久化归属与最终 Store 不同则拒绝，避免静态插件替换后分裂会话日志。"
     },
@@ -38484,9 +38447,9 @@
       "complexity": "simple",
       "lineRange": [
         125,
-        137
+        143
       ],
-      "summary": "从最终会话 Loader 或内置 Skill 工具解析来源并创建会话 Runtime；utility 不恢复工具能力，只有 ACP profile 允许恢复可用的旧记录子集。"
+      "summary": "从会话 Loader 或内置读取工具绑定 Runtime；需要恢复日志时先 restore_records 校验 Skill，再调用 prepare_resume 修复中断消息。CLI 保持严格规则，只有 ACP profile 允许当前可用子集。"
     },
     {
       "id": "file:box_agent/skill_context.py",
@@ -39045,6 +39008,169 @@
       ],
       "complexity": "moderate",
       "summary": "用两张职责与流程图说明 Tool Engine 和 Skill Engine 如何协作：工具冻结目标后执行，Skill 按来源和版本提供方法资料，Context 决定主请求中的位置与预算，Kernel 提交真实消息。明确目录摘要和 child 方法包仍由各自入口组装。"
+    },
+    {
+      "id": "file:box_agent/kernel/compact_engine.py",
+      "type": "file",
+      "name": "compact_engine.py",
+      "filePath": "box_agent/kernel/compact_engine.py",
+      "summary": "提供可替换压缩能力的默认实现，将 CompactionInput 转交既有 _maybe_summarize，保留摘要、确定性回退、预算和近期完整工具消息组规则。默认 Kernel 路径通过 before_summary 负责开始日志，返回结果的持久提交及内存历史替换仍由 Kernel 完成。",
+      "tags": [
+        "kernel",
+        "compaction",
+        "capability-adapter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "type": "class",
+      "name": "DefaultCompactEngine",
+      "filePath": "box_agent/kernel/compact_engine.py",
+      "summary": "把冻结输入载体中的 history 元组转为列表，并把模型、使用量、工具状态、精确 schema 预算、强制标记和 before_summary 回调原样转交 _maybe_summarize。该适配器不直接持有或提交 Session Log，也不替代负责请求投影的 ContextEnginePort。",
+      "tags": [
+        "class",
+        "kernel",
+        "compaction",
+        "capability-adapter"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        8,
+        22
+      ]
+    },
+    {
+      "id": "file:box_agent/kernel/context_types.py",
+      "type": "file",
+      "name": "context_types.py",
+      "filePath": "box_agent/kernel/context_types.py",
+      "summary": "定义可替换压缩器的输入及结果载体，分开实际工具运行状态与精确提供的 schema 估算，并通过 before_summary 暴露摘要前的持久化边界。CompactionOutcome 携带保护消息数和超限状态，同时保留历史三元组解包契约。",
+      "tags": [
+        "kernel",
+        "compaction",
+        "data-contract",
+        "compatibility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:box_agent/kernel/context_types.py:CompactionInput",
+      "type": "class",
+      "name": "CompactionInput",
+      "filePath": "box_agent/kernel/context_types.py",
+      "summary": "冻结一次压缩决策的输入载体，包含历史元组、安全输入上限、模型、使用量、摘要开关及 before_summary 回调；tools 用于恢复可信工具状态，estimate_tools 用于估算实际提供的 schema 成本。载体不含 Session Log 提交接口，摘要或确定性回退开始前应调用回调。",
+      "tags": [
+        "class",
+        "kernel",
+        "compaction",
+        "input-contract"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        13,
+        35
+      ]
+    },
+    {
+      "id": "class:box_agent/kernel/context_types.py:CompactionOutcome",
+      "type": "class",
+      "name": "CompactionOutcome",
+      "filePath": "box_agent/kernel/context_types.py",
+      "summary": "保存压缩后的消息、前后估算、模式、摘要调用及错误信息和受保护消息数，并将 still_over_limit 归一为是否 blocked，拒绝显式传入的矛盾值。继续支持解包为 messages、False、estimated_before，保证后续请求仍重新检查预算。",
+      "tags": [
+        "class",
+        "kernel",
+        "compaction",
+        "result-contract",
+        "compatibility"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        39,
+        71
+      ]
+    },
+    {
+      "id": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "type": "class",
+      "name": "CompactEnginePort",
+      "filePath": "box_agent/kernel/ports.py",
+      "tags": [
+        "会话",
+        "持久化",
+        "契约"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        397,
+        404
+      ],
+      "summary": "约定 compact_if_needed 接收 CompactionInput 并返回 CompactionOutcome；摘要或确定性兜底前必须调用 before_summary 并传播失败，持久和内存 surface 的提交仍由 Kernel 负责。"
+    },
+    {
+      "id": "class:box_agent/session_log.py:SessionOpenResult",
+      "type": "class",
+      "name": "SessionOpenResult",
+      "filePath": "box_agent/session_log.py",
+      "tags": [
+        "会话",
+        "持久化",
+        "契约"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        74,
+        78
+      ],
+      "summary": "返回已打开的 SessionLog 及 resumed 标志，使调用方决定是否执行共享恢复准备并承担日志关闭责任。"
+    },
+    {
+      "id": "function:box_agent/session_log.py:default_session_root",
+      "type": "function",
+      "name": "default_session_root",
+      "filePath": "box_agent/session_log.py",
+      "tags": [
+        "会话",
+        "持久化",
+        "契约"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        98,
+        104
+      ],
+      "summary": "通过现有 state_path 获取逻辑 Sessions 目录，遵循 BOX_AGENT_HOME profile 并保持历史默认路径。"
+    },
+    {
+      "id": "file:box_agent/session_projection.py",
+      "type": "file",
+      "name": "session_projection.py",
+      "filePath": "box_agent/session_projection.py",
+      "tags": [
+        "会话",
+        "持久化",
+        "投影"
+      ],
+      "complexity": "moderate",
+      "summary": "定义已提交 Session Log 前缀的公开投影快照；构造时深拷贝消息和嵌套状态，每次读取集合再返回防御性副本，保留旧 list/dict 调用形状。投影保存完整会话事实，与单次 provider 请求的 Context 处理分离。"
+    },
+    {
+      "id": "class:box_agent/session_projection.py:SessionProjection",
+      "type": "class",
+      "name": "SessionProjection",
+      "filePath": "box_agent/session_projection.py",
+      "tags": [
+        "会话",
+        "持久化",
+        "契约"
+      ],
+      "complexity": "simple",
+      "lineRange": [
+        18,
+        64
+      ],
+      "summary": "保存已提交日志前缀的隔离快照；输入和每次访问的 Message、list/dict 及嵌套状态均深拷贝，修改恢复后的运行状态不能回写投影本身，公开集合形状兼容旧调用方。"
     }
   ],
   "edges": [
@@ -40559,20 +40685,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "file:box_agent/kernel/context_engine.py",
-      "target": "class:box_agent/kernel/context_engine.py:CompactionOutcome",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:box_agent/kernel/context_engine.py",
-      "target": "class:box_agent/kernel/context_engine.py:CompactionOutcome",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:box_agent/kernel/context_engine.py",
@@ -54971,20 +55083,6 @@
     {
       "source": "file:box_agent/session_log.py",
       "target": "class:box_agent/session_log.py:SessionLogWorkspaceMismatch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:box_agent/session_log.py",
-      "target": "class:box_agent/session_log.py:SessionProjection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1.0
-    },
-    {
-      "source": "file:box_agent/session_log.py",
-      "target": "class:box_agent/session_log.py:SessionProjection",
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
@@ -77029,13 +77127,6 @@
       "weight": 0.8
     },
     {
-      "source": "function:box_agent/kernel/context_engine.py:_maybe_summarize",
-      "target": "class:box_agent/kernel/context_engine.py:CompactionOutcome",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "function:box_agent/kernel/context_engine.py:_message_chars",
       "target": "function:box_agent/kernel/context_engine.py:_budget_content_json",
       "type": "calls",
@@ -77108,13 +77199,6 @@
     {
       "source": "function:box_agent/kernel/loop.py:_run_agent_loop_impl",
       "target": "function:box_agent/kernel/context_engine.py:_fallback_context_estimate",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:box_agent/kernel/loop.py:_run_agent_loop_impl",
-      "target": "function:box_agent/kernel/context_engine.py:_maybe_summarize",
       "type": "calls",
       "direction": "forward",
       "weight": 0.8
@@ -77323,6 +77407,412 @@
       "weight": 0.8
     },
     {
+      "source": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "target": "function:box_agent/kernel/context_engine.py:_maybe_summarize",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "target": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "target": "class:box_agent/kernel/context_types.py:CompactionInput",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "target": "class:box_agent/kernel/context_types.py:CompactionOutcome",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "class:box_agent/kernel/ports.py:KernelServices",
+      "target": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "class:box_agent/session_log.py:SessionLog",
+      "target": "class:box_agent/session_log.py:SessionOpenResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:box_agent/session_log.py:SessionLog",
+      "target": "class:box_agent/session_projection.py:SessionProjection",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "document:docs/AGENT_SESSION.md",
+      "target": "file:box_agent/cli.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/AGENT_SESSION.md",
+      "target": "file:box_agent/session_log.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/AGENT_SESSION.md",
+      "target": "file:box_agent/session_projection.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION.md",
+      "target": "file:box_agent/composition.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION.md",
+      "target": "file:box_agent/kernel/compact_engine.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION.md",
+      "target": "file:box_agent/kernel/context_types.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION.md",
+      "target": "file:box_agent/kernel/loop.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION.md",
+      "target": "file:box_agent/kernel/ports.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION_CN.md",
+      "target": "file:box_agent/composition.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION_CN.md",
+      "target": "file:box_agent/kernel/compact_engine.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION_CN.md",
+      "target": "file:box_agent/kernel/context_types.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION_CN.md",
+      "target": "file:box_agent/kernel/loop.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/CONTEXT_COMPRESSION_CN.md",
+      "target": "file:box_agent/kernel/ports.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:box_agent/cli.py",
+      "target": "file:box_agent/session_log.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/kernel/compact_engine.py",
+      "target": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:box_agent/kernel/compact_engine.py",
+      "target": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/kernel/compact_engine.py",
+      "target": "file:box_agent/kernel/context_engine.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/kernel/compact_engine.py",
+      "target": "file:box_agent/kernel/context_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/kernel/context_engine.py",
+      "target": "class:box_agent/kernel/context_types.py:CompactionOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/kernel/context_engine.py",
+      "target": "file:box_agent/kernel/context_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/kernel/context_types.py",
+      "target": "class:box_agent/kernel/context_types.py:CompactionInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:box_agent/kernel/context_types.py",
+      "target": "class:box_agent/kernel/context_types.py:CompactionOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:box_agent/kernel/context_types.py",
+      "target": "class:box_agent/kernel/context_types.py:CompactionInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/kernel/context_types.py",
+      "target": "class:box_agent/kernel/context_types.py:CompactionOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/kernel/context_types.py",
+      "target": "file:box_agent/schema/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/kernel/context_types.py",
+      "target": "file:box_agent/tools/base.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/kernel/ports.py",
+      "target": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/kernel/ports.py",
+      "target": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/kernel/ports.py",
+      "target": "file:box_agent/kernel/context_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/session_log.py",
+      "target": "class:box_agent/session_log.py:SessionOpenResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/session_log.py",
+      "target": "function:box_agent/session_log.py:default_session_root",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/session_log.py",
+      "target": "class:box_agent/session_log.py:SessionOpenResult",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/session_log.py",
+      "target": "class:box_agent/session_projection.py:SessionProjection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/session_log.py",
+      "target": "function:box_agent/session_log.py:default_session_root",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/session_log.py",
+      "target": "file:box_agent/session_projection.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:box_agent/session_projection.py",
+      "target": "class:box_agent/session_projection.py:SessionProjection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:box_agent/session_projection.py",
+      "target": "class:box_agent/session_projection.py:SessionProjection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:box_agent/session_projection.py",
+      "target": "file:box_agent/schema/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:box_agent/cli.py:cmd_goal",
+      "target": "class:box_agent/session_log.py:SessionLog",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/cli.py:cmd_goal",
+      "target": "function:box_agent/agent.py:goal_state_from_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/cli.py:cmd_goal",
+      "target": "function:box_agent/session_log.py:default_session_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/cli.py:run_agent",
+      "target": "class:box_agent/session_log.py:SessionLog",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/cli.py:run_agent",
+      "target": "function:box_agent/session_log.py:default_session_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/kernel/context_engine.py:_maybe_summarize",
+      "target": "class:box_agent/kernel/context_types.py:CompactionOutcome",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/kernel/loop.py:_run_agent_loop_impl",
+      "target": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/kernel/loop.py:_run_agent_loop_impl",
+      "target": "class:box_agent/kernel/context_types.py:CompactionInput",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/kernel/loop.py:_run_agent_loop_impl",
+      "target": "class:box_agent/kernel/ports.py:CompactEnginePort",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "function:box_agent/plugins/defaults.py:compose_default_services",
+      "target": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:box_agent/plugins/defaults.py:default_plugin_descriptors",
+      "target": "class:box_agent/kernel/compact_engine.py:DefaultCompactEngine",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "function:box_agent/session_assembly.py:_bind_skill_runtime",
+      "target": "class:box_agent/session_log.py:SessionLog",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "function:box_agent/session_log.py:default_session_root",
+      "target": "function:box_agent/user_paths.py:state_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
       "source": "class:box_agent/agent.py:Agent",
       "target": "function:box_agent/plugins/defaults.py:_bind_skill_store",
       "type": "calls",
@@ -77341,7 +77831,7 @@
     {
       "id": "layer:core-agent-runtime",
       "name": "核心 Agent 与 Kernel 运行层",
-      "description": "承载 AgentSession、会话能力装配、Agent 运行入口、稳定 Kernel 循环与端口、唯一工具消息提交及 SessionLog，使 CLI 与 ACP 在稳定 cwd 下复用配置、恢复、取消和生命周期。Agent 持有会话 SkillRuntime，Context 通过通用端口投影完整请求；Kernel 提交真实历史与请求关联后调用确认回调。Composition 绑定最终 Skill、Store 与运行级 Context，并为每 Run 冻结 HookBus；managed 保留模型、工具和连接器能力身份，关闭先排空总线再清理拥有的 Provider，迟到持久化错误保留且不跳过已可释放资源。",
+      "description": "承载 AgentSession、能力装配、Agent 运行入口、稳定 Kernel 与端口、工具消息提交及唯一 SessionLog。CLI 使用统一逻辑 Session ID，日志投影对消息和嵌套状态提供防御性副本；清除历史先提交必需 reset，保留非消息事实与审计事件。Agent 持有 SkillRuntime，请求 Context 保持原输入合同，CompactEngine 只返回压缩决策，Kernel 持久化摘要前缀与新 surface 并 flush 后才改内存。Composition 绑定最终借用能力并为每 Run 冻结 HookBus，保留包括 falsey 压缩器在内的实例身份；关闭仍先排空总线再清理拥有的 Provider并传播迟到持久化错误。",
       "nodeIds": [
         "file:box_agent/__init__.py",
         "file:box_agent/agent.py",
@@ -77394,7 +77884,10 @@
         "file:box_agent/kernel/tool_messages.py",
         "file:box_agent/session_context.py",
         "file:box_agent/hook_bus.py",
-        "file:box_agent/kernel/hook_types.py"
+        "file:box_agent/kernel/hook_types.py",
+        "file:box_agent/kernel/compact_engine.py",
+        "file:box_agent/kernel/context_types.py",
+        "file:box_agent/session_projection.py"
       ]
     },
     {
@@ -77847,13 +78340,14 @@
     {
       "order": 2,
       "title": "CLI 装配入口",
-      "description": "命令行入口负责配置、诊断、目标管理和交互式执行，Pydantic 配置模型把 LLM、工具、MCP 与宿主设置转成共享类型。user_paths 统一自有状态位置；显式 BOX_AGENT_HOME 要求专用绝对目录，并约束配置和状态覆盖路径，根目录切换本身不授予文件权限。工具装配再把配置转成以同一会话 cwd 解析路径的能力，为每套工具分配独立 scratch；隔离 profile 样例展示了如何另行关闭背景能力。 CLI 目录匹配只更新名称、简介等发现信息，slash 显式选择进入 SkillRuntime，关键词命中不再预载正文。",
+      "description": "命令行入口负责配置、诊断、目标管理和交互式执行，Pydantic 配置模型把 LLM、工具、MCP 与宿主设置转成共享类型。user_paths 统一自有状态位置；显式 BOX_AGENT_HOME 要求专用绝对目录，并约束配置和状态覆盖路径，根目录切换本身不授予文件权限。工具装配再把配置转成以同一会话 cwd 解析路径的能力，为每套工具分配独立 scratch；隔离 profile 样例展示了如何另行关闭背景能力。 CLI 目录匹配只更新名称、简介等发现信息，slash 显式选择进入 SkillRuntime，关键词命中不再预载正文。 CLI 创建或恢复 SessionLog，--session-id/--resume 的逻辑 ID 同时用于 Agent、运行选项、trace 和命名目标；新建未命名会话继续兼容旧工作区目标文件。",
       "nodeIds": [
         "file:box_agent/cli.py",
         "file:box_agent/config.py",
         "file:box_agent/user_paths.py",
         "file:box_agent/tools/setup.py",
-        "config:box_agent/config/isolated-profile-example.yaml"
+        "config:box_agent/config/isolated-profile-example.yaml",
+        "file:box_agent/session_log.py"
       ],
       "languageLesson": "Pydantic 模型把外部配置转换成经过校验的类型化对象，让 CLI 装配阶段尽早暴露缺失字段和非法组合。"
     },
@@ -77872,7 +78366,7 @@
     {
       "order": 4,
       "title": "共享运行入口",
-      "description": "两个宿主经 AgentSession.open 进入受管会话，同步 create 与 AgentService 入口继续兼容。session_assembly 按插件顺序准备模型、记忆、工具、提示和 Hook，保留 utility 门控、稳定 cwd、宿主 Skill 过滤与连接器许可。Agent 持有唯一会话 SkillRuntime，Session 只传递引用；每轮创建 Context 并在最终装配后验证 Loader/Store 绑定。managed 路径保留借用模型、工具与连接器对象身份，事件流结束后等待本 Run HookBus 和拥有的 Provider 清理完成，再释放 Session 资源。",
+      "description": "两个宿主经 AgentSession.open 进入受管会话，同步 create 与 AgentService 入口继续兼容。session_assembly 按插件顺序准备模型、记忆、工具、提示和 Hook，保留 utility 门控、稳定 cwd、宿主 Skill 过滤与连接器许可。Agent 持有唯一会话 SkillRuntime，Session 只传递引用；每轮创建 Context 并在最终装配后验证 Loader/Store 绑定。managed 路径保留借用模型、工具与连接器对象身份，事件流结束后等待本 Run HookBus 和拥有的 Provider 清理完成，再释放 Session 资源。 共享恢复准备以 resume_session_log 控制，先校验 Skill 记录再修复中断调用；CLI 严格恢复，ACP 原有可用子集策略保持。CLI 拥有并在失败启动和最终退出时关闭自己的日志。",
       "nodeIds": [
         "file:box_agent/agent_session.py",
         "file:box_agent/session_context.py",
@@ -77884,32 +78378,35 @@
     {
       "order": 5,
       "title": "Kernel 执行内核",
-      "description": "Kernel ports 区分 ToolEngine、SkillEngine、ContextEngine 和 PreparedContext。主循环先取得同一份 PreparedTools，再请求 Context 核算完整输入和普通资料投影；工具目标及权限仍归 Tool Engine。Kernel 持久化真实调用、回复及请求关联，日志成功后调用通用 on_committed，并在非空且无过期、截断标记的响应后调用 on_response。压缩重试不重放工具或 Step Hook；stream_controller 对连接中断和异常重复流分别提供每轮最多一次的恢复。Hook 的匹配与决策仍由外层总线负责。",
+      "description": "Kernel 的请求 ContextEnginePort 保持 configure_run、bind_history、prepare_request 合同，继续消费同一 PreparedTools。独立 CompactEnginePort 接收 CompactionInput 并决定是否压缩；默认适配器委托原 _maybe_summarize，保留实际工具状态、精确 schema 估算、force 和摘要输入上限。摘要或确定性兜底前执行 Kernel 的 before_summary；Kernel 提交前缀、compaction/start 和返回 surface并 flush 后才更新内存。请求提交与有效响应回调、单次预算重试、连接中断和重复流的有界恢复及 Hook 分工保持。",
       "nodeIds": [
         "file:box_agent/kernel/ports.py",
         "file:box_agent/kernel/loop.py",
         "file:box_agent/kernel/tool_messages.py",
-        "file:box_agent/kernel/stream_controller.py"
+        "file:box_agent/kernel/stream_controller.py",
+        "file:box_agent/kernel/compact_engine.py",
+        "file:box_agent/kernel/context_types.py"
       ],
       "languageLesson": "Python Protocol 提供结构化子类型：实现方不必继承共同基类，只要满足端口方法签名即可被 Kernel 接受。"
     },
     {
       "order": 6,
       "title": "会话与连续执行",
-      "description": "上一站的活跃会话与运行状态不会成为第二套持久化来源：SessionLog 以追加式 JSONL 保存可重放的会话事实，并负责工作区校验和中断修复。显式降级恢复只有在会话 ID 和 cwd 验证通过后，才备份原始日志并建立新日志，不执行历史工具。turn_continuation 处理承诺继续却提前结束的回合，与模型连接中断后的恢复各自保持有界。产物事件以 cwd 相对路径关联实际文件，roadmap 校验和任务注册把执行结果关联回可追踪的交付内容。 宿主代读资料使用 SessionLog 内容寻址快照保留本次正文，路径与 UTF-8 哈希需验证；快照先持久化，请求关联随后提交。Skill 读取记录保留来源和版本，但不代表正文仍存在于下一请求。",
+      "description": "SessionLog 是唯一持久会话来源，记录真实消息、目标、计划、Todo、Skill 与审计事件；open_or_create 区分不存在的会话与损坏目录，校验 cwd 并在恢复失败时释放写锁。SessionProjection 构造与访问时深拷贝消息和嵌套状态，保留旧集合形状；请求 Context 不改这个完整投影。Agent 清除历史先 append/flush 必需 surface/reset，再清内存，两个 surface reducer 同时响应 reset且不忘记非消息事实。旧读者不能忽略 reset，回滚需保留兼容 reader。Skill 请求快照、连续执行及产物验收仍沿既有证据链。",
       "nodeIds": [
         "file:box_agent/session_log.py",
         "file:box_agent/turn_continuation.py",
         "file:box_agent/roadmap_artifacts.py",
         "file:box_agent/artifacts.py",
-        "file:box_agent/task_registry.py"
+        "file:box_agent/task_registry.py",
+        "file:box_agent/session_projection.py"
       ],
       "languageLesson": "追加式 JSONL 适合会话事件日志：每行独立解析，写入失败的影响局部化，并可通过投影重建当前状态。"
     },
     {
       "order": 7,
       "title": "插件能力所有权",
-      "description": "插件描述符定义作用域与依赖，PluginHost 负责发现、排序、激活、实例缓存和清理，类型化注册表冻结各轮 KernelServices。PluginRuntime 与 PluginSession 管理 process/session/run 生命周期，在激活锁外准备会话能力，再为每轮绑定运行插件；内置初始化器按固定顺序调用共享装配能力，区分借用与自建资源，并在关闭时等待初始化后按所有权清理。失败 Run 激活的中断回滚由 PluginHost 按 session_key 保留，涵盖运行时 Port 校验失败；会话关闭先重试 Run 再释放 Session 依赖，清理未完成时禁止该会话再次激活，其他会话和 Process 资源保持独立。HookProviderPort 的有序 HookSpec 按插件身份登记到每 Run 的总线；额外 RUN 插件使用仅拥有新 Provider 的私有扩展宿主，先排空总线再清理 Provider，重复取消会触发清理重试，借用能力仍由既有所有者释放。 默认装配可创建 RUN 级 Context，但 Skill 读取事实归 Agent 会话；替换最终工具目录或 Store 时须配套同来源、同持久化绑定。总线关闭后出现迟到日志持久化错误仍继续 Provider 清理，错误向调用方传播。",
+      "description": "插件描述符定义作用域与依赖，PluginHost 负责发现、排序、激活、实例缓存和清理，类型化注册表冻结各轮 KernelServices。PluginRuntime 与 PluginSession 管理 process/session/run 生命周期，在激活锁外准备会话能力，再为每轮绑定运行插件；内置初始化器按固定顺序调用共享装配能力，区分借用与自建资源，并在关闭时等待初始化后按所有权清理。失败 Run 激活的中断回滚由 PluginHost 按 session_key 保留，涵盖运行时 Port 校验失败；会话关闭先重试 Run 再释放 Session 依赖，清理未完成时禁止该会话再次激活，其他会话和 Process 资源保持独立。HookProviderPort 的有序 HookSpec 按插件身份登记到每 Run 的总线；额外 RUN 插件使用仅拥有新 Provider 的私有扩展宿主，先排空总线再清理 Provider，重复取消会触发清理重试，借用能力仍由既有所有者释放。 默认装配可创建 RUN 级 Context，但 Skill 读取事实归 Agent 会话；替换最终工具目录或 Store 时须配套同来源、同持久化绑定。总线关闭后出现迟到日志持久化错误仍继续 Provider 清理，错误向调用方传播。 CompactEngine 同样通过可选单实例端口注册，缺失时才创建 RUN 默认值；普通和 managed 路径都保留调用方提供的 falsey 实例，不转移借用资源所有权。",
       "nodeIds": [
         "file:box_agent/plugins/descriptors.py",
         "file:box_agent/plugins/host.py",
@@ -77958,7 +78455,7 @@
     {
       "order": 11,
       "title": "记忆与上下文",
-      "description": "长期记忆负责存储、检索、自动匹配、提取维护与晋升；资源账本保留读取完整性和恢复证据。DefaultContextEngine 面向下一次完整请求核算历史、PreparedTools schema、自动记忆、Skill 资料及临时图片，并保持工具定义与目标绑定。SkillReferenceContext 从 Runtime 取得不可变快照，基于最终可见文本核验同源、同版和完整范围；显式选择投影到当前 user 副本，真实读取留在 tool 消息，超预算可分页或阻塞。压缩后重新绑定历史，已读事实不能替代正文。",
+      "description": "长期记忆负责存储、检索、自动匹配、提取维护与晋升；资源账本保留读取完整性和恢复证据。DefaultContextEngine 面向下一次完整请求核算历史、PreparedTools schema、自动记忆、Skill 资料及临时图片，并保持工具定义与目标绑定。SkillReferenceContext 从 Runtime 取得不可变快照，基于最终可见文本核验同源、同版和完整范围；显式选择投影到当前 user 副本，真实读取留在 tool 消息，超预算可分页或阻塞。压缩后重新绑定历史，已读事实不能替代正文。 压缩策略通过独立 CompactEngine 返回结果；CompactionOutcome 的旧三元组解包形式及模块再导出仍可用，still_over_limit 必须与 blocked 模式一致。",
       "nodeIds": [
         "file:box_agent/memory.py",
         "file:box_agent/memory_maintainer.py",

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -25,8 +25,8 @@
       "GitHub Actions"
     ],
     "description": "一个具备 Jupyter 沙箱、数据分析、MCP 工具、ACP 协议、多模型提供商支持和独立运行时打包能力的 AI Agent 框架。注意：该项目包含超过 100 个源文件；如需更快的分析，可考虑将范围限定到某个子目录。",
-    "analyzedAt": "2026-09-10T21:15:38.894Z",
-    "gitCommitHash": "d715ff42905edaa44541efcfc4797564bcb56024"
+    "analyzedAt": "2026-09-10T21:44:12.391Z",
+    "gitCommitHash": "f501eebf61a6934c1fceee713f207db39b73354c"
   },
   "nodes": [
     {
@@ -30761,9 +30761,9 @@
       "filePath": "box_agent/cli.py",
       "lineRange": [
         1810,
-        2681
+        2683
       ],
-      "summary": "创建或恢复逻辑 SessionLog，以同一 ID 启动 AgentSession、运行选项和 trace；共享预备先严格验证 Skill 再修复中断调用。命名目标只使用本日志，新建未命名会话保留旧目标文件镜像，所有退出与启动失败路径都关闭 CLI 拥有的日志和客户端。",
+      "summary": "创建或恢复逻辑 SessionLog，以同一 ID 启动 AgentSession、运行选项和 trace；共享预备先严格验证 Skill 再修复中断调用。命名目标只使用本日志，新建未命名会话保留旧目标文件镜像，所有退出与启动失败路径都关闭 CLI 拥有的日志和客户端。新增 session_id 只能按关键字传入，原有全部位置参数顺序保持不变。",
       "tags": [
         "cli",
         "entry-point",
@@ -30778,8 +30778,8 @@
       "name": "main",
       "filePath": "box_agent/cli.py",
       "lineRange": [
-        2684,
-        2789
+        2686,
+        2791
       ],
       "summary": "分派 CLI 管理子命令，解析工作区与代码会话模式后启动 Agent，不再预创建隐式 output 目录。",
       "tags": [
@@ -35416,7 +35416,7 @@
         17,
         35
       ],
-      "summary": "保存 profile、cwd、utility、权限、布局和标准化构造选项；resume_session_log 开启先验证 Skill 后修复日志的共享恢复顺序，不引入另一套会话存储。",
+      "summary": "保存 profile、cwd、utility、权限、布局和标准化构造选项；resume_session_log 开启先验证 Skill 后修复日志的共享恢复顺序，不引入另一套会话存储。resume_session_log 是 keyword-only 字段，原 profile 及后续位置参数顺序保持不变。",
       "tags": [
         "data-model",
         "host-bindings",

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-09-10T21:15:38.894Z",
-  "gitCommitHash": "d715ff42905edaa44541efcfc4797564bcb56024",
+  "lastAnalyzedAt": "2026-09-10T21:44:12.391Z",
+  "gitCommitHash": "f501eebf61a6934c1fceee713f207db39b73354c",
   "version": "1.0.0",
   "analyzedFiles": 425
 }

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-09-10T20:59:08.389Z",
-  "gitCommitHash": "b7b884768974bb5ca5103a1740349eef9e3e7c0f",
+  "lastAnalyzedAt": "2026-09-10T21:15:38.894Z",
+  "gitCommitHash": "d715ff42905edaa44541efcfc4797564bcb56024",
   "version": "1.0.0",
-  "analyzedFiles": 422
+  "analyzedFiles": 425
 }

--- a/box_agent/agent.py
+++ b/box_agent/agent.py
@@ -465,6 +465,7 @@ class Agent:
         enable_builtin_tools: bool = True,
         plugins: tuple[Any, ...] = (),
         skill_runtime: SkillRuntime | None = None,
+        session_id: str = "",
     ):
         self.llm = llm_client
         self.tools = {
@@ -605,6 +606,7 @@ class Agent:
         self.session_log = session_log
         self._pending_skill_restore: list[dict[str, Any]] = []
         self._skill_persistence_pending = False
+        self.session_id = session_id.strip()
         if self.session_log is not None:
             projection = self.session_log.replay()
             self.messages.extend(projection.messages)
@@ -939,6 +941,11 @@ class Agent:
         Returns the number of removed messages.
         """
         removed = max(0, len(self.messages) - 1)
+        if self.session_log is not None:
+            # Commit the reset before changing live history. Use the existing
+            # Store append/flush contract; custom stores need no new method.
+            self.session_log.append("surface/reset", {"reason": "agent.clear_history"})
+            self.session_log.flush()
         del self.messages[1:]
         self.context_resource_ledger.rotate_epoch()
         return removed
@@ -961,6 +968,7 @@ class Agent:
             memory_manager=getattr(self._memory_extractor, "_mgr", None),
             memory_extractor=self._memory_extractor,
             inject_queue=self.inject_queue,
+            session_id=self.session_id,
             max_tool_calls=self.tool_limits.general.max_tool_calls,
             max_delegated_tool_calls=(
                 self.tool_limits.general.max_delegated_tool_calls

--- a/box_agent/agent_runtime.py
+++ b/box_agent/agent_runtime.py
@@ -98,6 +98,7 @@ def build_agent(
     session_log: Any = _UNSET,
     enable_builtin_tools: bool | object = _UNSET,
     skill_runtime: Any = _UNSET,
+    session_id: str | None = None,
     agent_factory: AgentFactory = Agent,
 ) -> Agent:
     """Construct an Agent while keeping adapter-specific state outside it.
@@ -141,6 +142,8 @@ def build_agent(
         kwargs["enable_builtin_tools"] = enable_builtin_tools
     if skill_runtime is not _UNSET:
         kwargs["skill_runtime"] = skill_runtime
+    if session_id is not None:
+        kwargs["session_id"] = session_id
     return agent_factory(**kwargs)
 
 

--- a/box_agent/agent_session.py
+++ b/box_agent/agent_session.py
@@ -110,6 +110,7 @@ class AgentSession:
         hooks: list[Any] | None = None,
         plugins: tuple[Any, ...] = (),
         session_log: SessionLog | None = None,
+        session_id: str | None = None,
         skill_runtime: Any = _UNSET,
         utility: bool = False,
         allowed_connector_ids_provider: Callable[[], frozenset[str]] | None = None,
@@ -126,6 +127,8 @@ class AgentSession:
         capabilities = {}
         if skill_runtime is not _UNSET:
             capabilities["skill_runtime"] = skill_runtime
+        if session_id is not None:
+            capabilities["session_id"] = session_id
         agent = AgentService(agent_factory=agent_factory).create_agent(
             llm_client=llm_client,
             system_prompt=system_prompt,

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -1811,13 +1811,14 @@ async def run_agent(
     workspace_dir: Path,
     task: str | None = None,
     initial_goal: str | None = None,
-    session_id: str | None = None,
     sandbox_mode: bool = True,
     verify_api: bool = True,
     json_summary: bool = False,
     deep_think: bool = False,
     force_plan_start: bool = False,
     goal_autopilot_enabled: bool = True,
+    *,
+    session_id: str | None = None,
 ) -> int:
     """Run Agent in interactive or non-interactive mode.
 
@@ -1831,6 +1832,7 @@ async def run_agent(
         deep_think: If True, enable thinking mode for the run
         force_plan_start: If True, require the next turn to publish a plan first
         goal_autopilot_enabled: If True, continue active goals in --task mode within configured budgets
+        session_id: Optional logical session ID, supplied by keyword
     """
     session_start = datetime.now()
 

--- a/box_agent/cli.py
+++ b/box_agent/cli.py
@@ -106,6 +106,7 @@ from box_agent.project_context import (
     compose_prompt_segments,
 )
 from box_agent.workspace_registry import WorkspaceRegistry, WorkspaceRegistryError
+from box_agent.session_log import SessionLog, default_session_root
 
 from box_agent.user_paths import state_path
 
@@ -880,109 +881,129 @@ def cmd_goal(
     evidence: list[str] | None = None,
     progress: list[str] | None = None,
     json_output: bool = False,
+    session_id: str | None = None,
 ) -> int:
-    """Scriptable CLI goal management without starting the agent runtime."""
-    action = (action or "status").strip().lower()
-    text_value = " ".join(text or []).strip()
-    evidence_items = [item.strip() for item in (evidence or []) if item.strip()]
-    progress_items = [item.strip() for item in (progress or []) if item.strip()]
-    goal = _load_goal_state(workspace_dir)
-    now = datetime.now().isoformat()
-
-    def emit(ok: bool = True, error: str | None = None) -> int:
-        if json_output:
-            payload = {"ok": ok, "goal": goal_payload(goal)}
-            if error:
-                payload["error"] = error
-            _json_print(payload)
-        else:
-            if error:
-                print(f"{Colors.RED}❌ {error}{Colors.RESET}")
-            elif goal is None:
-                print(f"{Colors.DIM}No goal for workspace: {workspace_dir}{Colors.RESET}")
+    """Scriptable CLI goal management with one action policy for both stores."""
+    logical_session_id = (session_id or "").strip()
+    opened = (SessionLog.open_or_create(
+        default_session_root(), session_id=logical_session_id,
+        cwd=workspace_dir, origin="cli",
+    ) if logical_session_id else None)
+    log = opened.log if opened is not None else None
+    try:
+        def save_goal(value):
+            if log is not None:
+                log.append("goal/change", {"goal": goal_payload(value)})
+                log.flush()
             else:
-                temp_agent = Agent.__new__(Agent)
-                temp_agent.goal = goal
-                print_goal_status(temp_agent)
-        return 0 if ok else 1
+                _save_goal_state(workspace_dir, value)
 
-    if action in ("status", "get"):
+        action = (action or "status").strip().lower()
+        text_value = " ".join(text or []).strip()
+        evidence_items = [item.strip() for item in (evidence or []) if item.strip()]
+        progress_items = [item.strip() for item in (progress or []) if item.strip()]
+        goal = goal_state_from_payload(log.replay().goal) if log is not None else _load_goal_state(workspace_dir)
+        now = datetime.now().isoformat()
+
+        def emit(ok: bool = True, error: str | None = None) -> int:
+            if json_output:
+                payload = {"ok": ok, "goal": goal_payload(goal)}
+                if opened is not None:
+                    payload.update(sessionId=logical_session_id, resumed=opened.resumed)
+                if error:
+                    payload["error"] = error
+                _json_print(payload)
+            else:
+                if error:
+                    print(f"{Colors.RED}❌ {error}{Colors.RESET}")
+                elif goal is None:
+                    print(f"{Colors.DIM}No goal for workspace: {workspace_dir}{Colors.RESET}")
+                else:
+                    temp_agent = Agent.__new__(Agent)
+                    temp_agent.goal = goal
+                    print_goal_status(temp_agent)
+            return 0 if ok else 1
+
+        if action in ("status", "get"):
+            return emit()
+
+        if action == "set":
+            if not text_value:
+                return emit(False, "Goal objective is required.")
+            goal = GoalState(
+                objective=text_value,
+                status="active",
+                created_at=now,
+                updated_at=now,
+                evidence=evidence_items,
+                progress=progress_items,
+            )
+            save_goal(goal)
+            return emit()
+
+        if action == "clear":
+            goal = None
+            save_goal(None)
+            return emit()
+
+        if goal is None:
+            return emit(False, "No goal is set for this workspace.")
+
+        if action == "pause":
+            goal.status = "paused"
+            goal.updated_at = now
+        elif action == "resume":
+            goal.status = "active"
+            goal.blocked_reason = None
+            goal.updated_at = now
+        elif action == "complete":
+            goal.status = "complete"
+            goal.blocked_reason = None
+            if text_value:
+                evidence_items.append(text_value)
+            if not evidence_items:
+                evidence_items.append("Completed via `box-agent goal complete`.")
+            for item in evidence_items:
+                if item not in goal.evidence:
+                    goal.evidence.append(item)
+            for item in progress_items:
+                if item not in goal.progress:
+                    goal.progress.append(item)
+            goal.completed_by = "cli"
+            goal.updated_at = now
+        elif action == "progress":
+            if text_value:
+                progress_items.append(text_value)
+            if not progress_items:
+                return emit(False, "Progress text is required.")
+            for item in progress_items:
+                if item not in goal.progress:
+                    goal.progress.append(item)
+            for item in evidence_items:
+                if item not in goal.evidence:
+                    goal.evidence.append(item)
+            goal.updated_at = now
+        elif action == "block":
+            reason = text_value
+            if not reason:
+                return emit(False, "Blocked reason is required.")
+            goal.status = "blocked"
+            goal.blocked_reason = reason
+            for item in evidence_items:
+                if item not in goal.evidence:
+                    goal.evidence.append(item)
+            for item in progress_items:
+                if item not in goal.progress:
+                    goal.progress.append(item)
+            goal.updated_at = now
+        else:
+            return emit(False, f"Unknown goal action: {action}")
+
+        save_goal(goal)
         return emit()
-
-    if action == "set":
-        if not text_value:
-            return emit(False, "Goal objective is required.")
-        goal = GoalState(
-            objective=text_value,
-            status="active",
-            created_at=now,
-            updated_at=now,
-            evidence=evidence_items,
-            progress=progress_items,
-        )
-        _save_goal_state(workspace_dir, goal)
-        return emit()
-
-    if action == "clear":
-        goal = None
-        _save_goal_state(workspace_dir, None)
-        return emit()
-
-    if goal is None:
-        return emit(False, "No goal is set for this workspace.")
-
-    if action == "pause":
-        goal.status = "paused"
-        goal.updated_at = now
-    elif action == "resume":
-        goal.status = "active"
-        goal.blocked_reason = None
-        goal.updated_at = now
-    elif action == "complete":
-        goal.status = "complete"
-        goal.blocked_reason = None
-        if text_value:
-            evidence_items.append(text_value)
-        if not evidence_items:
-            evidence_items.append("Completed via `box-agent goal complete`.")
-        for item in evidence_items:
-            if item not in goal.evidence:
-                goal.evidence.append(item)
-        for item in progress_items:
-            if item not in goal.progress:
-                goal.progress.append(item)
-        goal.completed_by = "cli"
-        goal.updated_at = now
-    elif action == "progress":
-        if text_value:
-            progress_items.append(text_value)
-        if not progress_items:
-            return emit(False, "Progress text is required.")
-        for item in progress_items:
-            if item not in goal.progress:
-                goal.progress.append(item)
-        for item in evidence_items:
-            if item not in goal.evidence:
-                goal.evidence.append(item)
-        goal.updated_at = now
-    elif action == "block":
-        reason = text_value
-        if not reason:
-            return emit(False, "Blocked reason is required.")
-        goal.status = "blocked"
-        goal.blocked_reason = reason
-        for item in evidence_items:
-            if item not in goal.evidence:
-                goal.evidence.append(item)
-        for item in progress_items:
-            if item not in goal.progress:
-                goal.progress.append(item)
-        goal.updated_at = now
-    else:
-        return emit(False, f"Unknown goal action: {action}")
-
-    _save_goal_state(workspace_dir, goal)
-    return emit()
+    finally:
+        if log is not None:
+            log.close()
 
 
 def _workspace_from_args(args: argparse.Namespace) -> Path:
@@ -1084,6 +1105,11 @@ Examples:
         help="Disable Jupyter sandbox mode (sandbox is enabled by default)",
     )
 
+    parser.add_argument(
+        "--session-id", "--resume", dest="session_id", default=None,
+        help="Resume or create a durable logical Session by ID",
+    )
+
     # Subcommands
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
@@ -1133,6 +1159,11 @@ Examples:
         type=str,
         default=None,
         help="Workspace directory for this goal command",
+    )
+
+    goal_parser.add_argument(
+        "--session-id", "--resume", dest="session_id", default=argparse.SUPPRESS,
+        help="Read or update the canonical SessionLog by ID",
     )
 
     # setup subcommand
@@ -1780,6 +1811,7 @@ async def run_agent(
     workspace_dir: Path,
     task: str | None = None,
     initial_goal: str | None = None,
+    session_id: str | None = None,
     sandbox_mode: bool = True,
     verify_api: bool = True,
     json_summary: bool = False,
@@ -1871,6 +1903,7 @@ async def run_agent(
     provider = LLMProvider.ANTHROPIC if config.llm.provider.lower() == "anthropic" else LLMProvider.OPENAI
 
     owned_clients = []
+    session_log = None
 
     def _new_client(**kwargs):
         client = build_llm_client(**kwargs)
@@ -1986,21 +2019,30 @@ async def run_agent(
         non_interactive = task is not None
         allow_full_access = config.tools.allow_full_access
         cli_env_context = build_cli_env_context()
+        logical_session_id = (session_id or "").strip() or f"cli-{uuid4().hex}"
+        legacy_goal_file = not bool((session_id or "").strip())
+        session_open = SessionLog.open_or_create(
+            default_session_root(), session_id=logical_session_id,
+            cwd=workspace_dir, origin="cli", prepare_resume=False,
+        )
+        session_log = session_open.log
         agent_session = await AgentSession.open(
             config=config, agent_factory=Agent,
             options=SessionOptions(
                 profile="cli", workspace_dir=workspace_dir, sandbox_mode=sandbox_mode,
+                resume_session_log=session_open.resumed,
                 non_interactive=non_interactive,
                 session_mode="code_agent" if code_workspace else None,
                 shell_python_path=resolve_cli_shell_python(),
             ),
             host=HostBindings(
-                llm_client=llm_client,
+                llm_client=llm_client, session_log=session_log,
                 base_tools_factory=initialize_base_tools,
                 workspace_tools_factory=add_workspace_tools,
                 output=print,
             ),
             thinking_enabled=deep_think, env_context=cli_env_context,
+            session_id=logical_session_id,
             force_plan_start=force_plan_start,
         )
         try:
@@ -2026,10 +2068,21 @@ async def run_agent(
             agent = agent_session.agent
 
             agent_session.source_text = bind_user_source_text(agent.tools, "", "")
-            restored_goal = _restore_cli_goal(agent, workspace_dir)
+            print(f"{Colors.DIM}Session: {logical_session_id}{Colors.RESET}")
+            restored_goal = agent.goal
+            if legacy_goal_file and not session_open.resumed:
+                restored_goal = _restore_cli_goal(agent, workspace_dir)
+                if restored_goal is not None:
+                    session_log.append("goal/change", {"goal": goal_payload(agent.goal)})
+                    session_log.flush()
+
+            def _save_cli_goal() -> None:
+                if legacy_goal_file:
+                    _save_goal_state(workspace_dir, agent.goal)
+
             if initial_goal and initial_goal.strip():
                 restored_goal = agent.set_goal(initial_goal)
-                _save_goal_state(workspace_dir, agent.goal)
+                _save_cli_goal()
 
             # Wire CLI permission negotiator (parity with ACP in-band negotiation)
             if grant_store is not None and not non_interactive:
@@ -2098,8 +2151,8 @@ async def run_agent(
                             f"{result.get('error') or 'unknown error'}{Colors.RESET}"
                         )
 
-            # One diagnostic file per CLI invocation; no synthetic ACP identity.
-            trace_session_id = f"cli-{uuid4().hex}"
+            # Diagnostics and kernel runs use the same logical Session identity.
+            trace_session_id = logical_session_id
             try:
                 trace_writer = SessionTraceWriter(session_id=trace_session_id, acp_session_id="")
             except Exception:
@@ -2208,7 +2261,7 @@ async def run_agent(
                             f"\n{Colors.YELLOW}⚠️  Goal autopilot stopped after "
                             f"{autopilot.no_progress_turns} continuation(s) without recorded goal progress.{Colors.RESET}"
                         )
-                    _save_goal_state(workspace_dir, agent.goal)
+                    _save_cli_goal()
                     if agent_session.skill_scratch_dir is not None:
                         try:
                             cleanup_skill_scratch_dir(agent_session.skill_scratch_dir)
@@ -2420,7 +2473,7 @@ async def run_agent(
 
                         elif command == "/goal" or command.startswith("/goal "):
                             handle_goal_command(agent, user_input)
-                            _save_goal_state(workspace_dir, agent.goal)
+                            _save_cli_goal()
                             continue
 
                         elif command == "/memory" or command.startswith("/memory "):
@@ -2575,7 +2628,7 @@ async def run_agent(
                         agent_session.cancelled = False
                         esc_listener_stop.set()
                         esc_thread.join(timeout=0.2)
-                        _save_goal_state(workspace_dir, agent.goal)
+                        _save_cli_goal()
                         if agent_session.skill_scratch_dir is not None:
                             try:
                                 cleanup_skill_scratch_dir(agent_session.skill_scratch_dir)
@@ -2621,7 +2674,11 @@ async def run_agent(
                 await _quiet_cleanup()
     finally:
         from box_agent.session_assembly import close_owned_clients
-        await close_owned_clients(owned_clients)
+        try:
+            await close_owned_clients(owned_clients)
+        finally:
+            if session_log is not None:
+                session_log.close()
 
 
 def main() -> int:
@@ -2683,6 +2740,7 @@ def main() -> int:
             evidence=args.evidence,
             progress=args.progress,
             json_output=args.json,
+            session_id=getattr(args, "session_id", None),
         )
 
     # Ensure user config exists; run setup wizard on first launch
@@ -2718,6 +2776,7 @@ def main() -> int:
                 workspace_dir,
                 task=args.task,
                 initial_goal=args.goal,
+                session_id=getattr(args, "session_id", None),
                 sandbox_mode=not args.no_sandbox,
                 verify_api=not args.no_verify_api,
                 json_summary=args.json,

--- a/box_agent/composition.py
+++ b/box_agent/composition.py
@@ -37,6 +37,7 @@ _SERVICE_OWNED_RUN_ARGUMENTS = frozenset(
         "kernel_services",
         "skill_engine",
         "context_engine",
+        "compact_engine",
     }
 )
 
@@ -73,6 +74,7 @@ def _default_capabilities(run_arguments: Mapping[str, Any]) -> dict[str, Any]:
         "tool_result_store": run_arguments.get("tool_result_storage"),
         "skill_engine": skill_engine,
         "context_engine": run_arguments.get("context_engine"),
+        "compact_engine": run_arguments.get("compact_engine"),
     }
 
 
@@ -364,13 +366,22 @@ async def run_agent_loop_with_default_services(
             supplied = getattr(managed_services, name)
             if supplied is not None and supplied is not capabilities[name]:
                 raise ValueError(f"kernel_services contradict effective run capabilities: {name}")
+        supplied_compact = managed_services.compact_engine
+        requested_compact = capabilities["compact_engine"]
+        if (supplied_compact is not None and requested_compact is not None
+                and supplied_compact is not requested_compact):
+            raise ValueError("kernel_services contradict effective run capabilities: compact_engine")
+        capabilities["compact_engine"] = (
+            supplied_compact if supplied_compact is not None else requested_compact
+        )
         bound = compose_default_services(**capabilities)
         managed_services = replace(
             managed_services, skill_engine=bound.skill_engine,
-            context_engine=bound.context_engine,
+            context_engine=bound.context_engine, compact_engine=bound.compact_engine,
         )
         capabilities["skill_engine"] = bound.skill_engine
         capabilities["context_engine"] = bound.context_engine
+        capabilities["compact_engine"] = bound.compact_engine
     bus = capabilities["hook_bus"]
     plugins = tuple(run_arguments.get("plugins") or ())
     host: PluginHost | None = None

--- a/box_agent/kernel/compact_engine.py
+++ b/box_agent/kernel/compact_engine.py
@@ -1,0 +1,22 @@
+"""Replaceable compaction capability over the existing compression algorithm."""
+from __future__ import annotations
+
+from .context_engine import _maybe_summarize
+from .context_types import CompactionInput, CompactionOutcome
+
+
+class DefaultCompactEngine:
+    """Preserve current summary, fallback, budgets and retained tool groups."""
+
+    async def compact_if_needed(self, inputs: CompactionInput) -> CompactionOutcome:
+        return await _maybe_summarize(
+            inputs.llm, list(inputs.history), inputs.token_limit,
+            inputs.api_total_tokens, inputs.skip_check, inputs.session_id,
+            turn_id=inputs.turn_id, title=inputs.title,
+            api_prompt_tokens=inputs.api_prompt_tokens, tools=inputs.tools,
+            summary_llm=inputs.summary_llm,
+            allow_llm_summary=inputs.allow_llm_summary,
+            before_summary=inputs.before_summary,
+            force=inputs.force, estimate_tools=inputs.estimate_tools,
+            summary_input_token_limit=inputs.summary_input_token_limit,
+        )

--- a/box_agent/kernel/context_engine.py
+++ b/box_agent/kernel/context_engine.py
@@ -6,13 +6,13 @@ import json
 import logging
 import math
 import re
-from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Callable, Final
 
 from ..llm.capabilities import image_input_support
 from ..schema import LLMResponse, Message
 from ..session_log import SessionLog
 from ..tools.base import Tool, ToolResult
+from .context_types import CompactionOutcome
 
 
 _log = logging.getLogger("box_agent.core")
@@ -110,32 +110,6 @@ _SUMMARY_REQUEST = (
 )
 
 
-@dataclass(frozen=True)
-class CompactionOutcome:
-    """Observable result of one context-compaction decision.
-
-    Iteration preserves the historical ``(messages, skip_next, estimate)``
-    return contract for callers that have not migrated yet.  ``skip_next`` is
-    intentionally always false: every subsequent request must be rechecked.
-    """
-
-    messages: list[Message] | None
-    estimated_before: int
-    estimated_after: int
-    mode: str = "none"
-    summary_calls: int = 0
-    error: str | None = None
-    error_type: str | None = None
-    trigger_source: str = "none"
-
-    @property
-    def blocked(self) -> bool:
-        return self.mode == "blocked"
-
-    def __iter__(self):
-        yield self.messages
-        yield False
-        yield self.estimated_before
 
 
 def _summary_message_text(msg: Message) -> str:
@@ -660,6 +634,7 @@ async def _maybe_summarize(
     force: bool = False,
     estimate_tools: dict[str, Any] | None = None,
     summary_input_token_limit: int | None = None,
+    before_summary: Callable[[int], None] | None = None,
 ) -> CompactionOutcome:
     """Compact once when the complete next request exceeds its safe limit."""
     if skip_check:
@@ -708,7 +683,9 @@ async def _maybe_summarize(
         if index > 0 and index not in retained_indices
     ]
 
-    if session_log is not None and session_turn is not None and session_step is not None:
+    if before_summary is not None:
+        before_summary(estimated)
+    elif session_log is not None and session_turn is not None and session_step is not None:
         session_log.append_unlogged_messages(
             messages[1:],
             turn=session_turn,
@@ -814,6 +791,7 @@ async def _maybe_summarize(
         error=error,
         error_type=None if error_type == "none" else error_type,
         trigger_source=trigger_source,
+        protected_messages=len(retained_messages),
     )
 
 

--- a/box_agent/kernel/context_types.py
+++ b/box_agent/kernel/context_types.py
@@ -1,0 +1,71 @@
+"""Inputs and outcomes for replaceable compaction, separate from request Context."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from ..schema import Message
+from ..tools.base import Tool
+
+
+@dataclass(frozen=True, slots=True)
+class CompactionInput:
+    """Resolved run inputs; an engine commits no SessionLog state itself.
+
+    token_limit is the safe input threshold. tools restores runtime state;
+    estimate_tools is the exact offered schema set used for cost estimation.
+    Call before_summary before any model summary or deterministic fallback.
+    """
+    history: tuple[Message, ...]
+    token_limit: int
+    llm: Any
+    summary_llm: Any | None = None
+    tools: dict[str, Tool] | None = None
+    api_total_tokens: int = 0
+    api_prompt_tokens: int | None = None
+    skip_check: bool = False
+    allow_llm_summary: bool = True
+    session_id: str = ""
+    turn_id: str = ""
+    title: str = ""
+    before_summary: Callable[[int], None] | None = None
+    force: bool = False
+    estimate_tools: dict[str, Any] | None = None
+    summary_input_token_limit: int | None = None
+
+
+@dataclass(frozen=True)
+class CompactionOutcome:
+    """Observable result of one context-compaction decision.
+
+    Iteration preserves the historical ``(messages, skip_next, estimate)``
+    return contract for callers that have not migrated yet.  ``skip_next`` is
+    intentionally always false: every subsequent request must be rechecked.
+    """
+
+    messages: list[Message] | None
+    estimated_before: int
+    estimated_after: int
+    mode: str = "none"
+    summary_calls: int = 0
+    error: str | None = None
+    error_type: str | None = None
+    trigger_source: str = "none"
+    protected_messages: int = 0
+    still_over_limit: bool | None = None
+
+    def __post_init__(self) -> None:
+        blocked = self.mode == "blocked"
+        if self.still_over_limit is not None and self.still_over_limit != blocked:
+            raise ValueError("still_over_limit must match the blocked compaction mode")
+        object.__setattr__(self, "still_over_limit", blocked)
+
+    @property
+    def blocked(self) -> bool:
+        return self.mode == "blocked"
+
+    def __iter__(self):
+        yield self.messages
+        yield False
+        yield self.estimated_before

--- a/box_agent/kernel/loop.py
+++ b/box_agent/kernel/loop.py
@@ -57,7 +57,6 @@ from .context_engine import (
     REQUEST_INPUT_HEADROOM_TOKENS,
     _fallback_context_estimate,
     _is_compaction_metadata,
-    _maybe_summarize,
     _validate_transient_followup_result,
 )
 from .ports import KernelServices
@@ -720,6 +719,11 @@ async def _run_agent_loop_impl(
     tools = _services.tool_catalog
     tool_exposure_manager = _services.tool_exposure
     tool_result_storage = _services.tool_result_store
+    compact_engine = _services.compact_engine
+    if compact_engine is None:
+        from .compact_engine import DefaultCompactEngine
+
+        compact_engine = DefaultCompactEngine()
     context_engine = _services.context_engine
     if context_engine is not None:
         context_engine.bind_history(messages)
@@ -1017,26 +1021,30 @@ async def _run_agent_loop_impl(
         # Older custom contexts retain the identity projection.
         project_history = getattr(context_engine, "project_history", None)
         effective_messages = project_history(messages) if callable(project_history) else messages
-        result = await _maybe_summarize(
-            llm,
-            effective_messages,
-            history_token_limit,
-            api_total_tokens,
-            False,
-            session_id=session_id,
-            turn_id=turn_id,
-            title=title,
-            api_prompt_tokens=api_prompt_tokens,
-            tools=tools,
+        from .context_types import CompactionInput
+
+        def before_summary(estimated: int) -> None:
+            if session_log is not None and session_turn is not None:
+                session_log.append_unlogged_messages(
+                    effective_messages[1:], turn=session_turn, step=step + 1,
+                )
+                session_log.append("compaction/start", {
+                    "turn": session_turn, "step": step + 1,
+                    "estimatedBefore": estimated, "tokenLimit": history_token_limit,
+                })
+                session_log.flush()
+
+        result = await compact_engine.compact_if_needed(CompactionInput(
+            history=tuple(effective_messages), token_limit=history_token_limit,
+            llm=llm, api_total_tokens=api_total_tokens,
+            session_id=session_id, turn_id=turn_id, title=title,
+            api_prompt_tokens=api_prompt_tokens, tools=tools,
             summary_llm=summary_llm,
             allow_llm_summary=summary_failure_cooldown_steps == 0,
-            session_log=session_log,
-            session_turn=session_turn,
-            session_step=step + 1,
-            force=force,
-            estimate_tools=estimate_tools,
+            before_summary=before_summary,
+            force=force, estimate_tools=estimate_tools,
             summary_input_token_limit=token_limit if force else None,
-        )
+        ))
         if result.mode == "fallback" and result.summary_calls > 0 and result.error:
             summary_failure_cooldown_steps = (
                 max_steps

--- a/box_agent/kernel/ports.py
+++ b/box_agent/kernel/ports.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from ..tools.engine.call_contracts import ToolExecutionOptions, ToolRunContext, ToolStepControl, ToolStepSummary
     from ..tools.engine.contracts import PreparedTools
 
+from .context_types import CompactionInput, CompactionOutcome
+
 
 @runtime_checkable
 class SummaryLLMPort(Protocol):
@@ -391,6 +393,17 @@ class ContextEnginePort(Protocol):
                         transient_tokens: int = 0) -> PreparedContextPort: ...
 
 
+@runtime_checkable
+class CompactEnginePort(Protocol):
+    """Decide compaction without applying the durable or live surface.
+
+    Call inputs.before_summary before summary execution; propagate its errors.
+    The Kernel commits the result before replacing live history.
+    """
+
+    async def compact_if_needed(self, inputs: "CompactionInput") -> "CompactionOutcome": ...
+
+
 @dataclass(frozen=True, slots=True)
 class KernelServices:
     """Resolved per-run capabilities consumed directly by the kernel."""
@@ -411,9 +424,11 @@ class KernelServices:
     hook_context: HookContext | None = None
     skill_engine: SkillEnginePort | None = None
     context_engine: ContextEnginePort | None = None
+    compact_engine: CompactEnginePort | None = None
 
 
 __all__ = [
+    "CompactEnginePort",
     "PreparedContextPort",
     "ContextEnginePort",
     "SkillEnginePort",

--- a/box_agent/plugins/defaults.py
+++ b/box_agent/plugins/defaults.py
@@ -19,6 +19,7 @@ from ..kernel.ports import (
     ToolEnginePort,
     SkillEnginePort,
     ContextEnginePort,
+    CompactEnginePort,
     ToolExposurePort,
     ToolResultStorePort,
 )
@@ -51,6 +52,7 @@ DEFAULT_CAPABILITY_SCHEMA = CapabilitySchema(
         CapabilityBinding(ToolEnginePort, CapabilityPolicy.OPTIONAL_SINGLE),
         CapabilityBinding(SkillEnginePort, CapabilityPolicy.OPTIONAL_SINGLE),
         CapabilityBinding(ContextEnginePort, CapabilityPolicy.OPTIONAL_SINGLE),
+        CapabilityBinding(CompactEnginePort, CapabilityPolicy.OPTIONAL_SINGLE),
     )
 )
 
@@ -118,6 +120,7 @@ def default_plugin_descriptors(
     tool_engine: ToolEnginePort | None = None,
     skill_engine: SkillEnginePort | None = None,
     context_engine: ContextEnginePort | None = None,
+    compact_engine: CompactEnginePort | None = None,
 ) -> tuple[PluginDescriptor, ...]:
     """Return deterministic descriptors for the supplied runtime instances."""
 
@@ -151,6 +154,7 @@ def default_plugin_descriptors(
         ("default.tool-engine", ToolEnginePort, tool_engine, True),
         ("default.skill-engine", SkillEnginePort, skill_engine, True),
         ("default.context-engine", ContextEnginePort, context_engine, True),
+        ("default.compact-engine", CompactEnginePort, compact_engine, True),
     )
     descriptors = tuple(
         replace(
@@ -167,6 +171,14 @@ def default_plugin_descriptors(
         descriptors += (PluginDescriptor(
             plugin_id="default.context-engine", version="1.0.0",
             capabilities=(ContextEnginePort,), factory=lambda: DefaultContextEngine(),
+            scope=PluginScope.RUN,
+        ),)
+    if compact_engine is None:
+        from ..kernel.compact_engine import DefaultCompactEngine
+
+        descriptors += (PluginDescriptor(
+            plugin_id="default.compact-engine", version="1.0.0",
+            capabilities=(CompactEnginePort,), factory=DefaultCompactEngine,
             scope=PluginScope.RUN,
         ),)
     return descriptors
@@ -189,6 +201,7 @@ def create_default_plugin_host(
     plugins: tuple[PluginDescriptor, ...] = (),
     skill_engine: SkillEnginePort | None = None,
     context_engine: ContextEnginePort | None = None,
+    compact_engine: CompactEnginePort | None = None,
 ) -> PluginHost:
     """Create a fresh static host for one outer agent-loop run."""
 
@@ -211,6 +224,7 @@ def create_default_plugin_host(
             tool_engine=tool_engine,
             skill_engine=skill_engine,
             context_engine=context_engine,
+            compact_engine=compact_engine,
         ) + tuple(plugins),
         schema=DEFAULT_CAPABILITY_SCHEMA,
     )
@@ -256,6 +270,7 @@ def kernel_services_from_registry(registry: ActivatedRegistry) -> KernelServices
         tool_engine=registry.get(ToolEnginePort),
         skill_engine=registry.get(SkillEnginePort),
         context_engine=context_engine,
+        compact_engine=registry.get(CompactEnginePort),
     )
 
 
@@ -275,6 +290,7 @@ def compose_default_services(
     tool_engine: ToolEnginePort | None = None,
     skill_engine: SkillEnginePort | None = None,
     context_engine: ContextEnginePort | None = None,
+    compact_engine: CompactEnginePort | None = None,
 ) -> KernelServices:
     """Resolve a run-local Context over borrowed services without discovery or I/O."""
 
@@ -285,6 +301,10 @@ def compose_default_services(
 
         context_engine = DefaultContextEngine()
     context_engine.configure_run(skill_engine=skill_engine, session_store=session_store)
+    if compact_engine is None:
+        from ..kernel.compact_engine import DefaultCompactEngine
+
+        compact_engine = DefaultCompactEngine()
     return KernelServices(
         llm=llm,
         summary_llm=summary_llm,
@@ -301,6 +321,7 @@ def compose_default_services(
         tool_engine=tool_engine,
         skill_engine=skill_engine,
         context_engine=context_engine,
+        compact_engine=compact_engine,
     )
 
 

--- a/box_agent/session_assembly.py
+++ b/box_agent/session_assembly.py
@@ -130,11 +130,17 @@ def _bind_skill_runtime(resources: SessionResources) -> None:
     loader = None if options.utility else resources.skill_loader
     if loader is None and not options.utility:
         loader = AgentService.resolve_skill_loader(resources.tools)
-    if loader is not None or options.profile == "acp":
-        resources.state.setdefault("skill_runtime", SkillRuntime(
+    if loader is not None or options.profile == "acp" or options.resume_session_log:
+        runtime = resources.state.setdefault("skill_runtime", SkillRuntime(
             loader, session_log=resources.context.host.session_log,
             allow_partial_restore=options.profile == "acp",
         ))
+        if options.resume_session_log:
+            session_log = resources.context.host.session_log
+            if session_log is None:
+                raise ValueError("resume_session_log requires a borrowed SessionLog")
+            runtime.restore_records(session_log.replay().skills)
+            session_log.prepare_resume()
 
 
 async def prepare_tools(resources: SessionResources) -> None:

--- a/box_agent/session_context.py
+++ b/box_agent/session_context.py
@@ -20,7 +20,7 @@ class SessionOptions:
     workspace_dir: str | Path | None = None
     token_limit: int | None = None
     utility: bool = False
-    resume_session_log: bool = False
+    resume_session_log: bool = field(default=False, kw_only=True)
     profile: str = "python"
     sandbox_mode: bool = False
     non_interactive: bool = True

--- a/box_agent/session_context.py
+++ b/box_agent/session_context.py
@@ -20,6 +20,7 @@ class SessionOptions:
     workspace_dir: str | Path | None = None
     token_limit: int | None = None
     utility: bool = False
+    resume_session_log: bool = False
     profile: str = "python"
     sandbox_mode: bool = False
     non_interactive: bool = True

--- a/box_agent/session_log.py
+++ b/box_agent/session_log.py
@@ -18,6 +18,7 @@ from typing import Any, BinaryIO
 from uuid import uuid4
 
 from .schema import Message
+from .session_projection import SessionProjection
 
 
 _log = logging.getLogger(__name__)
@@ -67,17 +68,6 @@ class SessionLogInUseError(RuntimeError):
 
 class SessionLogWorkspaceMismatch(ValueError):
     """The requested cwd does not own this immutable Session."""
-
-
-@dataclass(frozen=True, slots=True)
-class SessionProjection:
-    """Values reconstructed from one committed Session Log prefix."""
-
-    messages: list[Message]
-    goal: dict[str, Any] | None
-    plan: dict[str, Any] | None
-    todos: list[dict[str, Any]]
-    skills: list[dict[str, Any]]
 
 
 @dataclass(frozen=True, slots=True)

--- a/box_agent/session_log.py
+++ b/box_agent/session_log.py
@@ -40,6 +40,7 @@ KNOWN_EVENT_TYPES = frozenset(
         "request/header",
         "request/context",
         "session/end-seed",
+        "surface/reset",
         "goal/change",
         "plan/write",
         "todo/write",
@@ -79,6 +80,14 @@ class SessionProjection:
     skills: list[dict[str, Any]]
 
 
+@dataclass(frozen=True, slots=True)
+class SessionOpenResult:
+    """Result of opening or creating one logical Session."""
+
+    log: "SessionLog"
+    resumed: bool
+
+
 def _encode_record(record: dict[str, Any]) -> bytes:
     return (
         json.dumps(
@@ -94,6 +103,15 @@ def _encode_record(record: dict[str, Any]) -> bytes:
 def _session_dir(root: Path, session_id: str) -> Path:
     key = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
     return root / key
+
+
+def default_session_root() -> Path:
+    """Return the shared on-disk root for logical Agent Sessions."""
+    # Keep session storage inside the configured Box-Agent profile when one is
+    # active (BOX_AGENT_HOME), while preserving the historical default path.
+    from .user_paths import state_path
+
+    return state_path("sessions")
 
 
 def _normalize_cwd(cwd: str | Path) -> str:
@@ -210,6 +228,43 @@ class SessionLog:
                 "session cwd does not match the immutable workspace "
                 f"(stored={stored_cwd!r}, requested={requested_cwd!r})"
             )
+
+    @classmethod
+    def open_or_create(
+        cls,
+        root: str | Path,
+        *,
+        session_id: str,
+        cwd: str | Path,
+        origin: str | None = None,
+        prepare_resume: bool = True,
+    ) -> SessionOpenResult:
+        """Open an existing Session or create it, with one recovery policy."""
+
+        try:
+            log = cls.open(root, session_id=session_id, cwd=cwd)
+        except FileNotFoundError:
+            directory = _session_dir(Path(root), session_id)
+            if directory.exists():
+                # A directory without a canonical session file is not a new
+                # session; surface the corruption instead of overwriting it.
+                raise SessionLogCorrupted(
+                    f"session directory exists without {directory / 'session.jsonl'}"
+                )
+            log = cls.create(
+                root,
+                session_id=session_id,
+                cwd=cwd,
+                origin=origin,
+            )
+            return SessionOpenResult(log=log, resumed=False)
+        if prepare_resume:
+            try:
+                log.prepare_resume()
+            except BaseException:
+                log.close()
+                raise
+        return SessionOpenResult(log=log, resumed=True)
 
     @classmethod
     def create(
@@ -638,6 +693,9 @@ class SessionLog:
     def _surface_nodes(self) -> list[tuple[int, Message]]:
         surface: list[tuple[int, Message]] = []
         for event in self._events:
+            if event["type"] == "surface/reset":
+                surface.clear()
+                continue
             if event["type"] not in {
                 "user/message",
                 "assistant/message",
@@ -734,6 +792,13 @@ class SessionLog:
             )
         return appended
 
+    def reset_surface(self, *, reason: str) -> dict[str, Any]:
+        """Persist a logical conversation reset without deleting audit history."""
+
+        event = self.append("surface/reset", {"reason": reason})
+        self.flush()
+        return event
+
     def replay(self) -> SessionProjection:
         surface: list[tuple[int, Message]] = []
         goal: dict[str, Any] | None = None
@@ -743,6 +808,9 @@ class SessionLog:
         for event in self._events:
             event_type = event.get("type")
             data = event["data"]
+            if event_type == "surface/reset":
+                surface.clear()
+                continue
             if event_type == "goal/change":
                 value = data.get("goal")
                 goal = deepcopy(value) if isinstance(value, dict) else None

--- a/box_agent/session_projection.py
+++ b/box_agent/session_projection.py
@@ -1,0 +1,67 @@
+"""Public Session projection types.
+
+The projection is the complete state reconstructed from a committed Session
+Log. It is separate from provider context: a Context Engine may select,
+summarize, or trim this state for one request without mutating it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from copy import deepcopy
+from typing import Any, Sequence
+
+from .schema import Message
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class SessionProjection:
+    """An isolated snapshot of one committed Session Log prefix.
+
+    Public collections keep the historical list/dict shapes for consumers
+    restoring mutable runtime state. Each access returns a defensive copy so
+    mutating a restored Message or nested state cannot change this snapshot.
+    """
+
+    _messages: tuple[Message, ...]
+    _goal: dict[str, Any] | None
+    _plan: dict[str, Any] | None
+    _todos: tuple[dict[str, Any], ...]
+    _skills: tuple[dict[str, Any], ...]
+
+    def __init__(
+        self,
+        messages: Sequence[Message],
+        goal: dict[str, Any] | None,
+        plan: dict[str, Any] | None,
+        todos: Sequence[dict[str, Any]],
+        skills: Sequence[dict[str, Any]],
+    ) -> None:
+        object.__setattr__(self, "_messages", deepcopy(tuple(messages)))
+        object.__setattr__(self, "_goal", deepcopy(goal))
+        object.__setattr__(self, "_plan", deepcopy(plan))
+        object.__setattr__(self, "_todos", deepcopy(tuple(todos)))
+        object.__setattr__(self, "_skills", deepcopy(tuple(skills)))
+
+    @property
+    def messages(self) -> list[Message]:
+        return deepcopy(list(self._messages))
+
+    @property
+    def goal(self) -> dict[str, Any] | None:
+        return deepcopy(self._goal)
+
+    @property
+    def plan(self) -> dict[str, Any] | None:
+        return deepcopy(self._plan)
+
+    @property
+    def todos(self) -> list[dict[str, Any]]:
+        return deepcopy(list(self._todos))
+
+    @property
+    def skills(self) -> list[dict[str, Any]]:
+        return deepcopy(list(self._skills))
+
+
+__all__ = ["SessionProjection"]

--- a/docs/AGENT_SESSION.md
+++ b/docs/AGENT_SESSION.md
@@ -173,6 +173,40 @@ One managed session serves task mode, interactive turns and goal continuations.
 `/clear` and `/clear_all` reuse that session. The CLI closes its session and every
 model client it created, including probe/reconfiguration clients, on exit.
 
+### Durable CLI sessions
+
+CLI invocations create a SessionLog and print its logical ID. Pass
+`--session-id <id>` or `--resume <id>` to reopen it in the same workspace. The
+Agent, run options and diagnostic trace share that ID. A workspace mismatch is
+rejected, and a failed opening releases the log writer lock. The CLI closes its
+borrowed log after managed session cleanup, including failed startup paths.
+
+```bash
+box-agent --session-id report-work --task "Inspect the report inputs"
+box-agent --resume report-work --task "Continue from the saved history"
+box-agent goal status --session-id report-work
+box-agent goal progress "Inputs checked" --session-id report-work
+```
+
+`SessionLog.open_or_create(..., prepare_resume=False)` lets shared session
+preparation validate current Skill sources before repairing interrupted calls.
+`SessionOptions.resume_session_log` enables this ordering. CLI restores strictly;
+ACP retains its existing partial restoration policy for optional Skill state.
+
+Named sessions use their log's goal even when it is empty; an unrelated workspace
+goal never overwrites it. For compatibility, fresh unnamed CLI sessions can seed
+and mirror the legacy workspace goal file. The goal command without a session ID
+retains that legacy target, while the named form shares the existing complete
+action and output policy with SessionLog persistence.
+
+Clearing history commits a required `surface/reset` event before clearing live
+messages. It retains goal/plan/todo/Skill facts and the append-only audit trail.
+Reset affects both surface reducers so later appends and compression cannot
+revive cleared messages. Older readers that do not understand this event reject
+the log; recovery-enabled hosts may archive it and start a replacement. Before
+rolling back a runtime that has written resets, retain a reader with reset
+support. Marking reset ignorable would incorrectly restore cleared history.
+
 Skill names and descriptions may enter the system catalog. Context assembles
 main-Agent Skill bodies into ordinary request material, or a reading tool returns
 them as tool content. Restore validation precedes SessionLog resume repair, and

--- a/docs/CONTEXT_COMPRESSION.md
+++ b/docs/CONTEXT_COMPRESSION.md
@@ -127,6 +127,23 @@ Unsupported blocks and persistence failures remain unchanged. Since IDs are mark
 
 ## Context-limit compaction
 
+### Capability and commit boundary
+
+The Kernel supplies a `CompactionInput` to `CompactEnginePort`. The default
+engine delegates to the existing compression algorithm; it does not replace
+the request Context interface or introduce a second Skill loading policy.
+Inputs distinguish the tool catalog used for runtime-state recovery from the
+exact offered schemas used for estimation, and retain forced recovery and the
+summary-request input limit.
+
+Context projects effective history before compaction. The engine calls the
+Kernel's `before_summary` callback before a summary attempt or deterministic
+fallback. The Kernel commits the returned surface and flushes it before changing
+live messages; request delivery/response callbacks and the one-retry input-budget
+rule are unchanged. Static and managed composition preserve supplied compactors,
+including falsey instances. `CompactionOutcome` retains legacy tuple iteration;
+its limit flag must agree with its existing blocked mode.
+
 ### Threshold
 
 The trigger is derived from the model's input budget:

--- a/docs/CONTEXT_COMPRESSION_CN.md
+++ b/docs/CONTEXT_COMPRESSION_CN.md
@@ -98,6 +98,18 @@ Preview (head + tail, up to 2.0KB):
 
 ## 上下文限制压缩
 
+### 能力与提交边界
+
+Kernel 通过 `CompactionInput` 调用 `CompactEnginePort`。默认引擎沿用现有压缩算法，
+不替换请求 Context 接口，也不增加第二套 Skill 加载策略。输入分别保留用于恢复运行状态的
+工具目录、用于估算的本次实际提供 schema、强制恢复标志及摘要请求输入上限。
+
+Context 先投影有效历史。压缩引擎必须在摘要调用或确定性兜底前调用 Kernel 提供的
+`before_summary`；Kernel 提交并 flush 返回的 surface 后才更新内存历史。请求交付及响应
+确认回调、最多一次压缩重试的规则保持不变。普通及 managed 装配均保留调用方提供的压缩器，
+包括布尔值为假的实例。`CompactionOutcome` 保留原 tuple 解包方式，超限标志必须与已有
+blocked 模式一致。
+
 ### 触发阈值
 
 ```text

--- a/tests/test_agent_session_persistence.py
+++ b/tests/test_agent_session_persistence.py
@@ -748,3 +748,26 @@ log.close()
     assert replayed["skills"] == expected.skills
     assert replayed["messages"] == [[message.role, message.content] for message in expected.messages]
     assert log.path.read_bytes() == before
+
+
+@pytest.mark.parametrize("failure", ["append", "flush"])
+def test_clear_history_keeps_live_messages_when_reset_commit_fails(tmp_path, monkeypatch, failure):
+    from box_agent.agent import Agent
+    from box_agent.schema import Message
+
+    log = SessionLog.create(tmp_path / "sessions", session_id="reset-failure", cwd=tmp_path)
+    agent = Agent(llm_client=object(), system_prompt="system", tools=[], session_log=log,
+                  workspace_dir=str(tmp_path), deferred_mcp_loading_enabled=False)
+    agent.messages.append(Message(role="user", content="keep this history"))
+    original = [message.model_copy(deep=True) for message in agent.messages]
+
+    def fail(*args, **kwargs):
+        log._failed = True
+        raise OSError("reset write failed")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(log, failure, fail)
+        with pytest.raises(OSError, match="reset write failed"):
+            agent.clear_history()
+    assert agent.messages == original
+    log.close()

--- a/tests/test_agent_session_persistence.py
+++ b/tests/test_agent_session_persistence.py
@@ -109,6 +109,38 @@ async def test_agent_persists_request_before_provider_and_restores_messages(tmp_
     restored.close()
 
 
+def test_agent_clear_history_persists_surface_reset(tmp_path):
+    sessions = tmp_path / "sessions"
+    log = SessionLog.create(sessions, session_id="clear-session", cwd=tmp_path)
+    agent = Agent(
+        llm_client=_CheckpointInspectingLLM(log.path),
+        system_prompt="system",
+        tools=[],
+        workspace_dir=str(tmp_path),
+        deferred_mcp_loading_enabled=False,
+        session_log=log,
+    )
+    agent.add_user_message("remove me")
+    assert agent.clear_history() == 1
+    log.append(
+        "user/message",
+        Message(role="user", content="keep me").model_dump(mode="json"),
+        surface_op="append",
+    )
+    log.flush()
+    log.close()
+
+    restored_log = SessionLog.open(
+        sessions,
+        session_id="clear-session",
+        cwd=tmp_path,
+    )
+    assert [message.content for message in restored_log.replay().messages] == [
+        "keep me"
+    ]
+    restored_log.close()
+
+
 class _ToolCallingLLM:
     model = "test-model"
     max_output_tokens = 1024

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -12,6 +12,7 @@ import yaml
 import box_agent.cli as cli
 from box_agent.config import ToolLimitsConfig
 from box_agent.workspace_registry import WorkspaceRegistry
+from box_agent.session_log import SessionLog
 
 
 def _write_config(path: Path, api_key: str = "sk-test-key") -> None:
@@ -690,3 +691,28 @@ def test_cmd_goal_persists_workspace_goal(tmp_path: Path, monkeypatch, capsys) -
     assert stored is not None
     assert stored.status == "complete"
     assert stored.evidence == ["uv run pytest tests/ -q passed"]
+
+
+def test_cmd_goal_can_persist_goal_in_session_log(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    assert cli.cmd_goal(
+        workspace,
+        action="set",
+        text=["Ship", "session", "goal"],
+        session_id="cli-goal-session",
+        json_output=True,
+    ) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["goal"]["objective"] == "Ship session goal"
+    assert result["resumed"] is False
+
+    restored = SessionLog.open(
+        tmp_path / "home" / ".box-agent" / "sessions",
+        session_id="cli-goal-session",
+        cwd=workspace,
+    )
+    assert restored.replay().goal["objective"] == "Ship session goal"
+    restored.close()

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -23,6 +23,7 @@ from box_agent.tools.setup import add_workspace_tools
 from box_agent.tools.skill_tool import GetSkillTool
 from box_agent.workspace_registry import WorkspaceRegistry
 from tests.architecture_imports import forbidden_adapter_layer_imports
+from box_agent.session_log import SessionLog
 
 
 def _make_executable(path: Path) -> None:
@@ -230,6 +231,88 @@ class _CaptureStreamLLM:
         self.system_prompts.append(messages[0].content)
         yield StreamEvent(type="text", delta="done.")
         yield StreamEvent(type="finish", finish_reason="stop")
+
+
+def test_cli_resumes_messages_from_session_log(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("api_key: test\n", encoding="utf-8")
+    system_prompt_path = tmp_path / "system_prompt.md"
+    system_prompt_path.write_text("base system", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(
+            max_steps=2,
+            workspace_dir=str(workspace),
+            enable_memory=False,
+            enable_memory_extraction=False,
+            memory_maintainer_enabled=False,
+            memory_promotion_proposal_enabled=False,
+            system_prompt_path=str(system_prompt_path),
+        ),
+        tools=ToolsConfig(
+            enable_file_tools=False,
+            enable_bash=False,
+            enable_todo=False,
+            enable_plan=False,
+            enable_sub_agent=False,
+            enable_mcp=False,
+            enable_skills=False,
+            allow_full_access=True,
+        ),
+    )
+
+    async def fake_initialize_base_tools(*args, **kwargs):
+        return [], None, None, None
+
+    monkeypatch.setattr(
+        cli.Config,
+        "get_default_config_path",
+        staticmethod(lambda: config_path),
+    )
+    monkeypatch.setattr(cli.Config, "from_yaml", staticmethod(lambda _path: config))
+    monkeypatch.setattr(
+        cli.Config,
+        "find_config_file",
+        staticmethod(
+            lambda name: Path(name) if name == str(system_prompt_path) else None
+        ),
+    )
+    monkeypatch.setattr(cli, "LLMClient", _CaptureStreamLLM)
+    monkeypatch.setattr(cli, "initialize_base_tools", fake_initialize_base_tools)
+    monkeypatch.setattr(cli, "add_workspace_tools", lambda *args, **kwargs: None)
+    _CaptureStreamLLM.instances.clear()
+
+    for prompt in ("first request", "second request"):
+        assert (
+            asyncio.run(
+                cli.run_agent(
+                    workspace,
+                    task=prompt,
+                    session_id="cli-resume",
+                    sandbox_mode=False,
+                    verify_api=False,
+                    goal_autopilot_enabled=False,
+                )
+            )
+            == 0
+        )
+
+    restored = SessionLog.open(
+        tmp_path / "home" / ".box-agent" / "sessions",
+        session_id="cli-resume",
+        cwd=workspace,
+    )
+    assert [
+        (message.role, message.content) for message in restored.replay().messages
+    ] == [
+        ("user", "first request"),
+        ("assistant", "done."),
+        ("user", "second request"),
+        ("assistant", "done."),
+    ]
+    restored.close()
 
 
 class _PreloadedSkillThenGetSkillLLM(_CaptureStreamLLM):

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -7,6 +7,8 @@ import asyncio
 import json
 from pathlib import Path
 
+import pytest
+
 import box_agent.cli as cli
 import box_agent.composition as composition_module
 import box_agent.runtime as runtime_module
@@ -24,6 +26,13 @@ from box_agent.tools.skill_tool import GetSkillTool
 from box_agent.workspace_registry import WorkspaceRegistry
 from tests.architecture_imports import forbidden_adapter_layer_imports
 from box_agent.session_log import SessionLog
+
+
+@pytest.fixture(autouse=True)
+def isolated_cli_session_home(tmp_path, monkeypatch):
+    """Persistent CLI test sessions must never use the developer's profile."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("BOX_AGENT_HOME", raising=False)
 
 
 def _make_executable(path: Path) -> None:
@@ -1103,3 +1112,62 @@ def test_cli_source_image_optout_reaches_real_pptx_scaffold(tmp_path, monkeypatc
     )
     assert manifests[0]["generation_forbidden"] is True
     assert all(item["decision"] == "skip" for item in manifests[0]["image_plan"])
+
+
+def _configure_persistent_cli_test(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("api_key: test\n")
+    config = Config(
+        llm=LLMConfig(api_key="test-key"),
+        agent=AgentConfig(workspace_dir=str(workspace), enable_memory=False, max_steps=1),
+        tools=ToolsConfig(enable_mcp=False, enable_skills=False),
+    )
+    async def base(*args, **kwargs):
+        return [], None, None, None
+    monkeypatch.setattr(cli.Config, "get_default_config_path", staticmethod(lambda: config_path))
+    monkeypatch.setattr(cli.Config, "from_yaml", staticmethod(lambda _path: config))
+    monkeypatch.setattr(cli, "LLMClient", _CaptureStreamLLM)
+    monkeypatch.setattr(cli, "initialize_base_tools", base)
+    monkeypatch.setattr(cli, "add_workspace_tools", lambda *args, **kwargs: None)
+    return workspace
+
+
+def test_cli_failed_skill_restore_preserves_log_and_releases_writer_lock(tmp_path, monkeypatch):
+    from box_agent.skill_dependencies import SkillDependencyError
+
+    workspace = _configure_persistent_cli_test(tmp_path, monkeypatch)
+    root = cli.default_session_root()
+    log = SessionLog.create(root, session_id="missing-skill", cwd=workspace)
+    log.append("skill/change", {"skills": [{"name": "missing", "sha256": "old", "loadOrder": 1}]})
+    log.flush()
+    path = log.path
+    log.close()
+    before = path.read_bytes()
+    with pytest.raises(SkillDependencyError, match="No Skill source"):
+        asyncio.run(cli.run_agent(workspace, task="continue", session_id="missing-skill",
+                                  verify_api=False, sandbox_mode=False, goal_autopilot_enabled=False))
+    reopened = SessionLog.open(root, session_id="missing-skill", cwd=workspace)
+    reopened.close()
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("persisted_goal", [None, "canonical goal"])
+def test_resumed_cli_uses_log_goal_and_leaves_workspace_goal_unchanged(tmp_path, monkeypatch, persisted_goal):
+    workspace = _configure_persistent_cli_test(tmp_path, monkeypatch)
+    assert cli.cmd_goal(workspace, "set", ["workspace goal"]) == 0
+    root = cli.default_session_root()
+    if persisted_goal is not None:
+        assert cli.cmd_goal(workspace, "set", [persisted_goal], session_id="goal-session") == 0
+    else:
+        SessionLog.create(root, session_id="goal-session", cwd=workspace).close()
+    for prompt in ("first", "second"):
+        assert asyncio.run(cli.run_agent(workspace, task=prompt, session_id="goal-session",
+                                         verify_api=False, sandbox_mode=False, goal_autopilot_enabled=False)) == 0
+    reopened = SessionLog.open(root, session_id="goal-session", cwd=workspace)
+    try:
+        goal = reopened.replay().goal
+        assert (goal["objective"] if goal else None) == persisted_goal
+        assert cli._load_goal_state(workspace).objective == "workspace goal"
+    finally:
+        reopened.close()

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -1133,6 +1133,34 @@ def _configure_persistent_cli_test(tmp_path, monkeypatch):
     return workspace
 
 
+@pytest.mark.parametrize("all_legacy_arguments", [False, True])
+def test_legacy_cli_positional_arguments_keep_api_verification_disabled(
+    tmp_path, monkeypatch, all_legacy_arguments,
+):
+    workspace = _configure_persistent_cli_test(tmp_path, monkeypatch)
+    probes = []
+
+    async def record_probe(client):
+        probes.append(client)
+
+    monkeypatch.setattr(cli, "_probe_llm_api", record_probe)
+    arguments = [workspace, "task", None, False, False]
+    options = {"session_id": "positional-contract"}
+    if all_legacy_arguments:
+        arguments.extend([False, False, False, False])
+    else:
+        options["goal_autopilot_enabled"] = False
+    assert asyncio.run(cli.run_agent(*arguments, **options)) == 0
+    assert probes == []
+    restored = SessionLog.open(
+        cli.default_session_root(), session_id="positional-contract", cwd=workspace,
+    )
+    try:
+        assert restored.replay().messages[-1].content == "done."
+    finally:
+        restored.close()
+
+
 def test_cli_failed_skill_restore_preserves_log_and_releases_writer_lock(tmp_path, monkeypatch):
     from box_agent.skill_dependencies import SkillDependencyError
 

--- a/tests/test_context_engine_contract.py
+++ b/tests/test_context_engine_contract.py
@@ -1,0 +1,104 @@
+"""Compaction injection and projection contracts alongside canonical Context."""
+from dataclasses import replace
+
+import pytest
+
+from box_agent.agent import Agent
+from box_agent.kernel.compact_engine import DefaultCompactEngine
+from box_agent.kernel.context_types import CompactionInput, CompactionOutcome
+from box_agent.kernel.ports import CompactEnginePort
+from box_agent.schema import Message
+from box_agent.session_projection import SessionProjection
+from tests.test_managed_kernel_services import DeterministicLLM, managed_services
+
+
+def test_compaction_outcome_exposes_limit_fields_without_breaking_legacy_tuple():
+    outcome = CompactionOutcome(None, 100, 120, mode="blocked", protected_messages=2,
+                                still_over_limit=True)
+    assert outcome.blocked and outcome.still_over_limit
+    assert outcome.protected_messages == 2
+    assert tuple(outcome) == (None, False, 100)
+    assert CompactionOutcome(None, 100, 100, mode="blocked").still_over_limit
+    with pytest.raises(ValueError, match="must match"):
+        CompactionOutcome(None, 100, 100, mode="none", still_over_limit=True)
+
+
+def test_session_projection_returns_defensive_copies():
+    messages = [Message(role="user", content="original")]
+    goal = {"status": "active"}
+    projection = SessionProjection(messages=messages, goal=goal,
+                                   plan={"steps": ["one"]}, todos=[{"title": "one"}],
+                                   skills=[{"name": "demo"}])
+    messages[0].content = "changed before access"
+    goal["status"] = "changed before access"
+    projection.messages[0].content = "changed"
+    projection.goal["status"] = "changed"
+    projection.plan["steps"].append("changed")
+    projection.todos[0]["title"] = "changed"
+    projection.skills[0]["name"] = "changed"
+    assert projection.messages[0].content == "original"
+    assert projection.goal == {"status": "active"}
+    assert projection.plan == {"steps": ["one"]}
+    assert projection.todos == [{"title": "one"}]
+    assert projection.skills == [{"name": "demo"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("managed", [False, True])
+async def test_kernel_uses_the_provided_compact_engine_without_replacing_falsey_instances(tmp_path, monkeypatch, managed):
+    class Compact:
+        def __init__(self):
+            self.inputs = []
+
+        def __bool__(self):
+            return False
+
+        async def compact_if_needed(self, inputs):
+            self.inputs.append(inputs)
+            return CompactionOutcome(None, 0, 0)
+
+    compact = Compact()
+    llm = DeterministicLLM()
+    agent = Agent(llm_client=llm, system_prompt="system", tools=[], workspace_dir=tmp_path)
+    agent.add_user_message("use the supplied compaction policy")
+    options = None
+    if managed:
+        services = managed_services(
+            llm=llm, tools=agent.tools, tool_exposure=agent.mcp_tool_exposure,
+            tool_result_store=agent.tool_result_storage, compact_engine=compact,
+        )
+        options = replace(agent.default_run_options(), kernel_services=services)
+    else:
+        import box_agent.plugins.defaults as defaults
+        original = defaults.default_plugin_descriptors
+
+        def descriptors(**kwargs):
+            return tuple(
+                replace(descriptor, factory=lambda: compact)
+                if descriptor.capabilities == (CompactEnginePort,) else descriptor
+                for descriptor in original(**kwargs)
+            )
+        monkeypatch.setattr(defaults, "default_plugin_descriptors", descriptors)
+    _ = [event async for event in agent.run_events(options=options)]
+    assert compact.inputs
+    assert all(isinstance(inputs, CompactionInput) for inputs in compact.inputs)
+    assert all(inputs.llm is llm and inputs.tools is agent.tools for inputs in compact.inputs)
+    assert "use the supplied compaction policy" in str(compact.inputs[0].history)
+
+
+@pytest.mark.asyncio
+async def test_compact_engine_propagates_commit_failure_before_requesting_a_summary():
+    class Provider:
+        async def generate(self, **kwargs):
+            pytest.fail("summary requested before its durable start committed")
+
+    def failed_commit(estimated):
+        raise OSError("compaction start failed")
+
+    inputs = CompactionInput(
+        history=(Message(role="system", content="BASE"), Message(role="user", content="request")),
+        token_limit=10000, llm=Provider(), force=True, before_summary=failed_commit,
+        estimate_tools={}, summary_input_token_limit=10000,
+    )
+    with pytest.raises(OSError, match="compaction start failed"):
+        await DefaultCompactEngine().compact_if_needed(inputs)

--- a/tests/test_plugin_host.py
+++ b/tests/test_plugin_host.py
@@ -458,7 +458,7 @@ def test_default_capability_schema_covers_kernel_services_in_field_order() -> No
 
     from box_agent.kernel.ports import ToolEnginePort, HookDispatchPort
     from box_agent.plugins.hooks import HookProviderPort
-    from box_agent.kernel.ports import ContextEnginePort, SkillEnginePort
+    from box_agent.kernel.ports import ContextEnginePort, SkillEnginePort, CompactEnginePort
 
     ports_by_field = {
         "llm": LLMPort,
@@ -476,6 +476,7 @@ def test_default_capability_schema_covers_kernel_services_in_field_order() -> No
         "hook_dispatch": HookDispatchPort,
         "skill_engine": SkillEnginePort,
         "context_engine": ContextEnginePort,
+        "compact_engine": CompactEnginePort,
     }
     # Provider 是多实现贡献，调用身份是值对象，二者不按服务字段一一映射。
     assert {binding.port_type for binding in bindings} == set(ports_by_field.values()) | {HookProviderPort}
@@ -548,7 +549,11 @@ def test_default_descriptors_are_deterministic_and_preserve_exact_instances() ->
     assert isinstance(by_port[ContextEnginePort], DefaultContextEngine)
     context_descriptor = next(item for item in first if item.capabilities == (ContextEnginePort,))
     assert inspect.signature(context_descriptor.factory).parameters == {}
-    assert len(first) == 7
+    from box_agent.kernel.compact_engine import DefaultCompactEngine
+    from box_agent.kernel.ports import CompactEnginePort
+
+    assert isinstance(by_port[CompactEnginePort], DefaultCompactEngine)
+    assert len(first) == 8
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_adapter_assembly.py
+++ b/tests/test_session_adapter_assembly.py
@@ -148,6 +148,8 @@ async def test_managed_session_keeps_connector_skill_grants_for_parent_and_child
 async def test_cli_shared_prompt_controls_model_and_session_closes(tmp_path, monkeypatch):
     import sys
 
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("BOX_AGENT_HOME", raising=False)
     # Python 3.10 has exc_info(), but not exception().
     monkeypatch.delattr(sys, "exception", raising=False)
     import box_agent.cli as cli

--- a/tests/test_session_adapter_assembly.py
+++ b/tests/test_session_adapter_assembly.py
@@ -7,6 +7,28 @@ from box_agent.config import Config, AgentConfig, LLMConfig, ToolsConfig
 from tests.test_acp import DummyConn, DoneLLM
 
 @pytest.mark.asyncio
+async def test_legacy_positional_session_profile_starts_without_log_restore(tmp_path):
+    from box_agent.agent_session import AgentSession
+    from box_agent.session_context import HostBindings, SessionOptions
+
+    options = SessionOptions(tmp_path, None, True, "python")
+    assert options.profile == "python"
+    assert options.resume_session_log is False
+    session = await AgentSession.open(
+        config=Config(llm=LLMConfig(api_key="test"), agent=AgentConfig(enable_memory=False),
+                      tools=ToolsConfig(enable_mcp=False, enable_skills=False)),
+        options=options,
+        host=HostBindings(llm_client=DoneLLM(), tools=[], system_prompt="system"),
+    )
+    try:
+        assert session.plugin_session is not None
+        assert session.plugin_session.resources.context.options.profile == "python"
+        assert session.agent.session_log is None
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
 async def test_acp_uses_shared_preparation_and_managed_session(tmp_path, monkeypatch):
     config = Config(llm=LLMConfig(api_key="test"), agent=AgentConfig(workspace_dir=str(tmp_path), enable_memory=False), tools=ToolsConfig(enable_mcp=False, enable_skills=False, enable_file_tools=False, enable_bash=False, enable_sub_agent=False))
     calls = []

--- a/tests/test_session_log.py
+++ b/tests/test_session_log.py
@@ -800,3 +800,21 @@ def test_replay_restores_latest_box_agent_domain_state(tmp_path):
         {"name": "pdfs", "sha256": "abc", "loadOrder": 1}
     ]
     restored.close()
+
+
+def test_open_or_create_releases_writer_lock_when_resume_repair_fails(tmp_path, monkeypatch):
+    log = SessionLog.create(tmp_path / "sessions", session_id="failed-resume", cwd=tmp_path)
+    path = log.path
+    log.close()
+    before = path.read_bytes()
+
+    def failed_prepare(self):
+        raise RuntimeError("resume repair failed")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(SessionLog, "prepare_resume", failed_prepare)
+        with pytest.raises(RuntimeError, match="resume repair failed"):
+            SessionLog.open_or_create(tmp_path / "sessions", session_id="failed-resume", cwd=tmp_path)
+    reopened = SessionLog.open(tmp_path / "sessions", session_id="failed-resume", cwd=tmp_path)
+    reopened.close()
+    assert path.read_bytes() == before

--- a/tests/test_session_log.py
+++ b/tests/test_session_log.py
@@ -818,3 +818,27 @@ def test_open_or_create_releases_writer_lock_when_resume_repair_fails(tmp_path, 
     reopened = SessionLog.open(tmp_path / "sessions", session_id="failed-resume", cwd=tmp_path)
     reopened.close()
     assert path.read_bytes() == before
+
+
+def test_reset_then_append_and_compact_preserves_only_the_new_surface_after_reopen(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="reset-compact", cwd=tmp_path)
+    log.append("goal/change", {"goal": {"objective": "retained goal", "status": "active"}})
+    log.append("skill/change", {"skills": [{"name": "method", "sha256": "old", "loadOrder": 1}]})
+    log.append_unlogged_messages([Message(role="user", content="cleared history")], turn=1, step=1)
+    log.reset_surface(reason="clear")
+    log.append_unlogged_messages([
+        Message(role="user", content="new request"),
+        Message(role="assistant", content="new answer"),
+    ], turn=2, step=1)
+    log.replace_surface([Message(role="user", content="new summary")], turn=2, step=2)
+    log.close()
+    reopened = SessionLog.open(tmp_path, session_id="reset-compact", cwd=tmp_path)
+    try:
+        projection = reopened.replay()
+        assert [message.content for message in projection.messages] == ["new summary"]
+        assert projection.goal["objective"] == "retained goal"
+        assert projection.skills[0]["name"] == "method"
+        assert any(event["type"] == "surface/reset" for event in reopened.events)
+        assert any(event.get("data", {}).get("content") == "cleared history" for event in reopened.events)
+    finally:
+        reopened.close()

--- a/tests/test_session_log.py
+++ b/tests/test_session_log.py
@@ -32,6 +32,27 @@ def test_session_log_rejects_second_writer_until_owner_closes(tmp_path):
     successor.close()
 
 
+def test_open_or_create_reports_new_then_resumed_session(tmp_path):
+    first = SessionLog.open_or_create(
+        tmp_path,
+        session_id="open-or-create",
+        cwd=tmp_path,
+        origin="cli",
+    )
+    assert first.resumed is False
+    first.log.close()
+
+    second = SessionLog.open_or_create(
+        tmp_path,
+        session_id="open-or-create",
+        cwd=tmp_path,
+        origin="acp",
+    )
+    assert second.resumed is True
+    assert second.log.header["origin"] == "cli"
+    second.log.close()
+
+
 def test_session_log_writer_ownership_is_released_when_process_exits(tmp_path):
     created = SessionLog.create(
         tmp_path,
@@ -371,6 +392,33 @@ def test_surface_replacement_restores_compacted_context_without_deleting_history
     assert [event["type"] for event in restored.events] == [
         "user/message",
         "assistant/message",
+        "user/message",
+    ]
+    restored.close()
+
+
+def test_surface_reset_clears_replayed_surface_without_deleting_audit_history(tmp_path):
+    log = SessionLog.create(tmp_path, session_id="reset", cwd=tmp_path)
+    log.append(
+        "user/message",
+        Message(role="user", content="before reset").model_dump(mode="json"),
+        surface_op="append",
+    )
+    log.reset_surface(reason="cli_clear")
+    log.append(
+        "user/message",
+        Message(role="user", content="after reset").model_dump(mode="json"),
+        surface_op="append",
+    )
+    log.close()
+
+    restored = SessionLog.open(tmp_path, session_id="reset", cwd=tmp_path)
+    assert restored.replay().messages == [
+        Message(role="user", content="after reset")
+    ]
+    assert [event["type"] for event in restored.events] == [
+        "user/message",
+        "surface/reset",
         "user/message",
     ]
     restored.close()


### PR DESCRIPTION
## Task

Add durable CLI SessionLog recovery and an independently replaceable compaction capability while retaining PR117's canonical Skill/Context interface.

CLI invocations create a logical session and print its ID; `--session-id` / `--resume` reopen it in the same workspace. The Agent, run options and diagnostic trace share that identity. Named sessions use their log's goal, while legacy unnamed CLI goal-file behavior remains an explicit compatibility path. The goal command uses one action policy with either persistence target.

Shared preparation validates strict CLI Skill restoration before repairing interrupted calls. Owned logs close after Session cleanup, including failed startup. Clearing history commits a required surface/reset event before changing live messages and preserves non-message facts and audit history. SessionProjection returns defensive snapshots while the existing tolerant reducers remain authoritative.

CompactEnginePort receives explicit inputs, including the final offered schemas, force flag and summary input limit. Its default delegates to the existing algorithm. Kernel owns compaction/start, surface commit and flush-before-live-update; request delivery/response callbacks and Hook processing are preserved. Managed and legacy composition retain supplied compactor identities, including falsey instances.

Out of scope: a second build_context interface, automatic full Skill reinjection, a copied compression algorithm, new plugin discovery, real-model evaluation or installed-host deployment.

## Proof

Current Head: 0a6e06f65c415acd076bdb5be218dc1cf0929efd.
Source baseline: f501eebf61a6934c1fceee713f207db39b73354c.
Target main: e22179fad58d38dcbea1f3f8f852e2089539ac2a.

- `bash general_review/ci/preflight.sh` at 7074edf79fcff87bfb42b2d717f713371fa3cac4 — **4629 passed, 19 skipped, 1 deselected, 3 warnings**, 439.61 seconds; locked dependency sync, compilation and sdist/wheel builds succeeded. That full run preceded the final public positional-API compatibility fixes, whose focused and Python 3.10 evidence is listed below.
- Regressions prove writer-lock release on failed repair/restoration, unchanged live messages on failed reset, named log goals surviving two CLI starts, reset→append→compact→reopen without resurrecting cleared messages, defensive snapshots, supplied compactor identity and persistence failure before summary calls.
- A real source ACP subprocess probe at d715ff42, with network connections blocked, passed initialize, managed utility session creation, stdout JSON isolation and graceful SIGTERM (exit 0). This is source-process validation, not installed-host proof.
- The official graph at f501eebf contains **425 files, 2296 nodes, 5509 edges and 659 imports**. Strict schema, 64 changed-symbol ranges and all 425 source hashes pass; all node IDs, edges, layers and tour remain intact. Existing 86 orphan warnings remain.
- `uv run --no-sync pytest tests/test_cli_runtime.py tests/test_cli_config.py tests/test_session_adapter_assembly.py tests/test_agent_session.py tests/test_managed_kernel_services.py tests/test_acp.py tests/test_context_engine_contract.py tests/test_session_log.py -q --tb=short` — **313 passed** after the final positional-API fixes. Three public startup regressions also passed on Python 3.10; the original CLI probe now skips API verification correctly. Compileall, sdist and wheel builds succeeded on f501eebf.
- The new session_id argument and resume_session_log field are keyword-only, preserving every existing positional argument. Exact-Head remote checks and final independent confirmation are required before merge.


- After adopting the final Skill Store and ranking fixes, `uv run --no-sync pytest tests/test_context_engine_contract.py tests/test_cli_runtime.py tests/test_agent_session_persistence.py tests/test_skill_review_regressions.py tests/test_skill_filter.py -q --tb=short` — **136 passed** at source 8e0506a5; executable source bytes remain identical after final rebasing.

Runtime validation stops at source and Python distributions. No standalone install, OfficeV3 restart or live external-model task was performed.

## Risk

- surface/reset is a required event. Older readers reject it; recovery-enabled hosts may archive and replace that log. Rollback must retain reset-reader support. Marking this event ignorable would incorrectly restore cleared history.
- Named sessions never import or overwrite the legacy workspace goal file. Fresh unnamed sessions retain the existing bootstrap/mirror behavior for compatibility; their logical SessionLog remains the recovery source when reopened by ID.
- CLI remains strict for unavailable historical Skill sources; ACP retains the preceding partial-restore policy. Restoration and compaction do not replay old tools or claim obsolete body visibility.
- Custom compactors must call before_summary before summary/fallback work and return a coherent outcome without applying the live or durable surface themselves. Inconsistent blocked/limit flags are rejected; legacy tuple iteration remains supported.
- Context budgets still distinguish runtime tool state from the actually offered schemas. This PR preserves input headroom and the single bounded compaction retry instead of reusing the older incompatible policy.
- Packaged hosts and rollback readers require coordinated validation before deployment; this PR does not modify other repositories.
