### PR TITLE
auto-update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ contracts.
 | Topic | English | 中文 |
 | --- | --- | --- |
 | Context compaction and summarization | [Context Compression](CONTEXT_COMPRESSION.md) | [上下文压缩](CONTEXT_COMPRESSION_CN.md) |
+| Managed session and plugin lifecycle | [Agent Session](AGENT_SESSION.md) | Same document |
 | Workflow ownership and third-party Skill recovery | [Workflow Ownership](WORKFLOW_OWNERSHIP.md) | Same document |
 | Flat sub-agent request and derived policy | [Sub-agent Delegation](SUB_AGENT_DELEGATION.md) | [子 Agent 委派](SUB_AGENT_DELEGATION_CN.md) |
 | Persistent memory integration | [Memory Integration](MEMORY_INTEGRATION.md) | Same document |


### PR DESCRIPTION
Automated follow-up for original PR #120: https://github.com/Raccoon-Office/Box-Agent/pull/120

Fixed merged baseline: `3f70b0a2bad78414c0f2016dc510128df8591e21`.

- Dependency stage: `FAILED`; recovery succeeded. The updater found `pydantic-core` constrained to `2.46.5` by `pydantic==2.13.5`, so no dependency commit was retained or pushed.
- Documentation stage: `UPDATED_AND_PUSHED`; added documentation-index navigation.
- Verified auto-update commit: `6da038e619664be1e8ff1543dbca434dd3010038` (`doc(auto-update)`), one direct child of the fixed baseline; local and remote branch heads match.