### PR TITLE
auto-update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ contracts.
 | Topic | English | 中文 |
 | --- | --- | --- |
 | Context compaction and summarization | [Context Compression](CONTEXT_COMPRESSION.md) | [上下文压缩](CONTEXT_COMPRESSION_CN.md) |
+| Managed session and plugin lifecycle | [Agent Session](AGENT_SESSION.md) | Same document |
 | Workflow ownership and third-party Skill recovery | [Workflow Ownership](WORKFLOW_OWNERSHIP.md) | Same document |
 | Flat sub-agent request and derived policy | [Sub-agent Delegation](SUB_AGENT_DELEGATION.md) | [子 Agent 委派](SUB_AGENT_DELEGATION_CN.md) |
 | Persistent memory integration | [Memory Integration](MEMORY_INTEGRATION.md) | Same document |

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -74,13 +74,15 @@ branch history, also check
 Release, provider API, and ACP compatibility have their own sources under
 [long-lived release and compatibility history](#long-lived-release-and-compatibility-history).
 
-## Pending material changes
+## Pending and recently merged material changes
 
 ### 2026-09-10 — managed session assembly and plugin lifecycle
 
-- **Change:** `refactor(session): manage capability assembly through scoped plugins`
-  on `codex/kernel-plugin-refactor`. This extends [PR #114](https://github.com/Raccoon-Office/Box-Agent/pull/114),
-  merged as `7c85e82`; see [Agent Session](../AGENT_SESSION.md).
+- **Change:** [PR #120](https://github.com/Raccoon-Office/Box-Agent/pull/120),
+  `refactor(session): manage capability assembly through scoped plugins`, merged as
+  `3f70b0a2bad78414c0f2016dc510128df8591e21`. This extends
+  [PR #114](https://github.com/Raccoon-Office/Box-Agent/pull/114), merged as
+  `7c85e82`; see [Agent Session](../AGENT_SESSION.md).
 - **Durable effect:** `AgentSession.open` prepares models, memory, tools/Skills/MCP,
   prompts and hooks through shared session initializers. ACP shares an application
   PluginRuntime; CLI owns a private runtime by default. Each run receives fresh


### PR DESCRIPTION
Original PR: #120 https://github.com/Raccoon-Office/Box-Agent/pull/120
Fixed post-merge baseline: 3f70b0a2bad78414c0f2016dc510128df8591e21

Dependency stage: FAILED. Latest stable numpy 2.5.3 requires Python >=3.12, incompatible with declared Python >=3.10. Recovery succeeded: five tracked changes restored to baseline; no dependency commit/push retained.

Documentation stage: UPDATED_AND_PUSHED. Commit c6f0fd76d040a0c1032a86ab3e7a4769a1fd977e (doc(auto-update)) updates docs/README.md and docs/changes/README.md. Markdown-link and diff checks passed; orchestrator verified parent, subject, clean worktree, and remote SHA.